### PR TITLE
fix: show Seer speech in blue only after CO

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -80,6 +80,19 @@ LLMの出力は自然文のパースに頼らず、常にPydanticモデルで検
 - 状態は `state/agents/{name}.json` に永続化
 - Pydanticモデルでスキーマを定義
 
+#### claimed_role（公開役職）
+
+`AgentState` に `claimed_role: str | None` フィールドを持つ。
+
+| フィールド | 内容 |
+|---|---|
+| `role` | 真の役職（システム管理。LLMには渡さない） |
+| `claimed_role` | エージェントが公言した役職（CO済みなら設定。未COはNull） |
+
+- `intent.co` がLLM出力に含まれたタイミングでGame Engineが `claimed_role` に保存
+- `claimed_role` は **Public情報** として全エージェントのプロンプトに渡す
+- UIのカラー表示も `claimed_role` を参照（真の役職で色付けしない）
+
 ### 3.3 LLM Client（`src/llm/`）
 
 - `anthropic` SDKのラッパー
@@ -90,7 +103,7 @@ LLMの出力は自然文のパースに頼らず、常にPydanticモデルで検
 
 | 関数 | 用途 | プロンプト | 出力モデル |
 |---|---|---|---|
-| `call()` | 発言生成（OPENING / DISCUSSION） | フル（役職・性格・記憶・当日ログ） | `AgentOutput` |
+| `call()` | 発言生成（OPENING / DISCUSSION） | フル（役職・性格・記憶・当日ログ・他者のCO情報） | `AgentOutput` |
 | `call_judgment()` | 判断（DISCUSSION 並列） | 軽量（役職・性格・memory_summary・直近発言のみ） | `JudgmentOutput` |
 | `call_night_action()` | 夜行動 | 夜フェーズ専用 | `str`（ターゲット名） |
 

--- a/doc/Task.md
+++ b/doc/Task.md
@@ -31,6 +31,8 @@
 
 ## 未着手・検討中
 
+- [ ] 前日以前の投票結果（誰が誰に投票したか）をプロンプトのPublic情報として渡す（現状は当日の発言ログのみ）
+
 - [ ] Extended thinking フラグ（`call()` に `extended_thinking: bool = False` 引数）
 - [ ] prompt cache 活用（キャラ性格mdファイルをシステムプロンプト先頭に固定して cache_control を付与）
 - [ ] 思考ログのデバッグ表示と観戦表示の切り替えUI

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -21,3 +21,4 @@ class AgentState(BaseModel):
     beliefs: dict[str, Belief] = {}
     memory_summary: list[str] = []
     is_alive: bool = True
+    claimed_role: str | None = None  # publicly claimed role via CO; None until CO

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -150,6 +150,10 @@ class GameEngine:
             speech_id=speech_id,
         ))
 
+        if output.intent.co:
+            agent.claimed_role = output.intent.co
+            store.save(agent)
+
         if output.memory_update:
             memory_mod.update_memory(agent, output.memory_update)
 

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -123,6 +123,7 @@ class GameEngine:
             self.day,
             self.lang,
             reply_to_entry=reply_to_entry,
+            all_agents=self.agents,
         )
         self._day_outputs[agent.name] = output
 

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -44,9 +44,10 @@ def call(
     day: int = 1,
     lang: str = "English",
     reply_to_entry: SpeechEntry | None = None,
+    all_agents: list[AgentState] | None = None,
 ) -> AgentOutput:
     """Call LLM for day-phase speech and return structured AgentOutput."""
-    system_prompt = build_system_prompt(agent, today_log, alive_players, dead_players, day, lang, reply_to_entry)
+    system_prompt = build_system_prompt(agent, today_log, alive_players, dead_players, day, lang, reply_to_entry, all_agents)
     try:
         message = _client.messages.create(
             model=agent.model,

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -55,6 +55,7 @@ def build_public_info_prompt(
     alive_players: list[str],
     dead_players: list[str],
     day: int,
+    all_agents: list[AgentState] | None = None,
 ) -> str:
     """Build prompt section with public game information."""
     lines = [
@@ -62,6 +63,14 @@ def build_public_info_prompt(
         f"Alive players: {', '.join(alive_players)}",
         f"Dead players: {', '.join(dead_players) if dead_players else 'none'}",
     ]
+    if all_agents:
+        claims = [
+            f"{a.name} claims {a.claimed_role}"
+            for a in all_agents
+            if a.claimed_role is not None
+        ]
+        if claims:
+            lines.append(f"Known role claims: {', '.join(claims)}")
     if today_log:
         lines.append("\nToday's discussion so far:")
         for entry in today_log:
@@ -132,13 +141,14 @@ def build_system_prompt(
     day: int,
     lang: str = "English",
     reply_to_entry: SpeechEntry | None = None,
+    all_agents: list[AgentState] | None = None,
 ) -> str:
     """Assemble full system prompt for an agent."""
     parts = [
         build_persona_prompt(agent),
         "\n",
         build_role_prompt(agent.role),
-        build_public_info_prompt(today_log, alive_players, dead_players, day),
+        build_public_info_prompt(today_log, alive_players, dead_players, day, all_agents),
         build_personal_info_prompt(agent),
     ]
     if reply_to_entry is not None:

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -7,12 +7,13 @@ from src.agent.state import AgentState
 console = Console()
 
 
-def _get_agent_role(agent_name: str | None, agents: list[AgentState]) -> str | None:
+def _get_claimed_role(agent_name: str | None, agents: list[AgentState]) -> str | None:
+    """Return the role the agent has publicly claimed (CO), or None if no CO."""
     if agent_name is None:
         return None
     for a in agents:
         if a.name == agent_name:
-            return a.role
+            return a.claimed_role
     return None
 
 
@@ -29,7 +30,7 @@ def render_event(
     if not event.is_public and not spectator_mode:
         return None
 
-    role = _get_agent_role(event.agent, agents)
+    claimed_role = _get_claimed_role(event.agent, agents)
     text = Text()
 
     if event.event_type == EventType.PHASE_START:
@@ -42,8 +43,8 @@ def render_event(
             text.append(f"  [THINK] {event.agent}: ", style="dim white")
             text.append(thought_content, style="dim white")
         else:
-            # Regular speech
-            if role == "Seer":
+            # Regular speech — blue only after Seer CO
+            if claimed_role == "Seer":
                 style = "blue"
             else:
                 style = "white"


### PR DESCRIPTION
## Summary

- Seerの発言が、COしていないのに青で表示されるバグを修正
- `renderer.py` が真の役職（`AgentState.role`）を参照していたため、CO前から色が出ていた
- `AgentState` に `claimed_role: str | None` を追加し、`intent.co` が出たタイミングで保存
- `renderer.py` は `claimed_role` を参照するよう変更。COするまでは白で表示される

## Test plan

- [x] 既存テスト 16件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)