### PR TITLE
fix: improve _extract_json robustness and fix call_judgment truncation

### DIFF
--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -31,16 +31,13 @@ def _log_error(fn: str, agent_name: str, stage: str, e: Exception, raw: str) -> 
 
 
 def _extract_json(text: str) -> str:
-    """Extract JSON object from text, handling markdown code blocks."""
-    # Try to find JSON in code blocks first
-    match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
-    if match:
-        return match.group(1)
-    # Try raw JSON
-    match = re.search(r"\{.*\}", text, re.DOTALL)
+    """Extract JSON object from text, stripping markdown code fences if present."""
+    stripped = re.sub(r"^```(?:json)?\s*", "", text.strip())
+    stripped = re.sub(r"\s*```$", "", stripped)
+    match = re.search(r"\{.*\}", stripped, re.DOTALL)
     if match:
         return match.group(0)
-    return text
+    return stripped
 
 
 def call(
@@ -97,7 +94,7 @@ def call_judgment(
     try:
         message = _client.messages.create(
             model=agent.model,
-            max_tokens=64,
+            max_tokens=256,
             messages=[{"role": "user", "content": prompt}],
         )
         raw = message.content[0].text

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -1,5 +1,4 @@
 import json
-import re
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from collections.abc import Iterator
@@ -31,13 +30,24 @@ def _log_error(fn: str, agent_name: str, stage: str, e: Exception, raw: str) -> 
 
 
 def _extract_json(text: str) -> str:
-    """Extract JSON object from text, stripping markdown code fences if present."""
-    stripped = re.sub(r"^```(?:json)?\s*", "", text.strip())
-    stripped = re.sub(r"\s*```$", "", stripped)
-    match = re.search(r"\{.*\}", stripped, re.DOTALL)
-    if match:
-        return match.group(0)
-    return stripped
+    """Extract the first complete JSON object from text.
+
+    Handles markdown code fences, multiple JSON blocks, and self-correction
+    patterns where the LLM emits extra text or a second JSON block.
+    Uses bracket counting to find the first complete { ... } span.
+    """
+    start = text.find("{")
+    if start == -1:
+        return text
+    depth = 0
+    for i, ch in enumerate(text[start:], start):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return text[start:]  # truncated JSON fallback
 
 
 def call(
@@ -94,7 +104,7 @@ def call_judgment(
     try:
         message = _client.messages.create(
             model=agent.model,
-            max_tokens=256,
+            max_tokens=512,
             messages=[{"role": "user", "content": prompt}],
         )
         raw = message.content[0].text

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -296,7 +296,7 @@ def build_judgment_prompt(
         for e in recent:
             lines.append(f"  [{e.speech_id}] {e.agent}: {e.text}")
     lines.append(f"""
-Decide your next action. Respond with ONLY valid JSON, no other text:
+Decide your next action. Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
 {{
   "decision": "challenge" | "speak" | "silent",
   "reply_to": <speech_id to challenge, or null>
@@ -304,7 +304,8 @@ Decide your next action. Respond with ONLY valid JSON, no other text:
 - "challenge": directly counter a specific speech (set reply_to to its speech_id)
 - "speak": add a new statement unprompted
 - "silent": nothing to add right now
-Use {lang}.""")
+- The JSON must contain exactly these two fields and nothing else.
+Use {lang} only for internal reasoning if needed, but keep the JSON minimal.""")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary

### 問題

`call_judgment` で2種類のパースエラーが発生していた。

1. **`JSONDecodeError('Expecting value: line 1 column 1 (char 0)')`**
   LLM がコードフェンス付きで返してきたが、旧 `_extract_json` は完全に閉じた ` ``` ``` ` ブロックにしかマッチしなかったため抽出に失敗。

2. **`JSONDecodeError('Extra data: line 5 column 1 (char 46)')`**
   LLM が自己訂正パターンで JSON を2ブロック返してきた。greedy な `\{.*\}` で最初の `{` から最後の `}` まで（余分テキスト込み）をマッチしてしまいパース失敗。

3. **`JSONDecodeError("Expecting ',' delimiter: ...")`**
   LLM が `"statement"` フィールドに長い日本語を付けて返し、`max_tokens=64` を超えてJSONが途中で切断。

### 修正

- **`_extract_json`**: greedy regex を廃止し、括弧カウント方式で最初の完全な `{...}` を抽出。`re` import も削除。
- **`call_judgment` の `max_tokens`**: 64 → 512
- **`build_judgment_prompt`**: 余分なフィールドを出さないよう明示的な制約を追加

## Test plan

- [x] `ruff check .` パス
- [x] `pytest` 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)