### PR TITLE
fix: use Persona.model_validate(config) to load all persona fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,11 +51,7 @@ def initialize_agents() -> list[AgentState]:
         agent = AgentState(
             name=name,
             role=role,
-            persona=Persona(
-                style=config["style"],
-                lie_tendency=config["lie_tendency"],
-                aggression=config["aggression"],
-            ),
+            persona=Persona.model_validate(config),
             beliefs=beliefs,
             memory_summary=[],
             is_alive=True,


### PR DESCRIPTION
## Summary

`initialize_agents()` で `Persona` を生成する際に `style / lie_tendency / aggression` しか読んでいなかったため、`config/agents.json` に追加した `gender / age / speech_style` が `state/agents/*.json` に反映されていなかった。

`Persona.model_validate(config)` に変更することで、Pydanticが既知のフィールドを自動マッピングし、`name` 等の未知のキーは無視される。今後 Persona にフィールドを追加しても `main.py` を変更する必要がない。

## Test plan

- [x] `ruff check .` パス
- [x] `pytest` 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)