### PR TITLE
feat: 7-player mode, knight guard, and werewolf night chat

### DIFF
--- a/config/agents.json
+++ b/config/agents.json
@@ -43,5 +43,23 @@
     "gender": null,
     "age": null,
     "speech_style": "polite"
+  },
+  {
+    "name": "Jonas",
+    "style": "calm, strategic, quietly perceptive",
+    "lie_tendency": 0.45,
+    "aggression": 0.25,
+    "gender": "male",
+    "age": "adult",
+    "speech_style": "gentle"
+  },
+  {
+    "name": "Methode",
+    "style": "elegant, calculating, merciless",
+    "lie_tendency": 0.55,
+    "aggression": 0.5,
+    "gender": "female",
+    "age": "adult",
+    "speech_style": "polite"
   }
 ]

--- a/config/roles.json
+++ b/config/roles.json
@@ -1,1 +1,4 @@
-["Villager", "Villager", "Villager", "Seer", "Werewolf"]
+{
+  "5": ["Villager", "Villager", "Villager", "Seer", "Werewolf"],
+  "7": ["Villager", "Villager", "Villager", "Seer", "Werewolf", "Werewolf", "Knight"]
+}

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -75,6 +75,16 @@ class AgentOutput(BaseModel):
     memory_update: list[str]
 ```
 
+### LLM呼び出し関数と max_tokens 設定
+
+| 関数 | 用途 | max_tokens | 理由 |
+|---|---|---|---|
+| `call()` | 昼フェーズの発言生成（OPENING / DISCUSSION） | 2048 | thought が日本語で長くなりやすい |
+| `call_judgment()` | 昼フェーズの並列判断（challenge / speak / silent） | 1024 | JSON 2フィールドのみだが日本語思考が付随することがある |
+| `call_wolf_chat()` | 夜フェーズの狼チーム会話 | 2048 | thought + speech + vote_candidates。日本語で長くなりやすい |
+| `call_pre_night_action()` | 前夜フェーズの CO 判断（占い師・人狼） | 1024 | thought + decision + reasoning の3フィールド |
+| `call_night_action()` | 夜フェーズの個別行動（襲撃・占い・護衛） | 64 | プレイヤー名1つだけ返す |
+
 ---
 
 ## src/action/ — 構造化アクション処理

--- a/main.py
+++ b/main.py
@@ -5,7 +5,8 @@ Usage:
     uv run main.py                        # Public mode (English)
     uv run main.py --spectator            # Spectator mode
     uv run main.py --lang Japanese        # Japanese output
-    uv run main.py --spectator --lang Japanese
+    uv run main.py --players 7            # 7-player mode (default: 5)
+    uv run main.py --spectator --lang Japanese --players 7
 """
 import argparse
 import json
@@ -30,22 +31,34 @@ from src.logger.writer import LogWriter, archive_state  # noqa: E402
 from src.ui.cli import CLI  # noqa: E402
 
 
-def initialize_agents() -> list[AgentState]:
+def initialize_agents(num_players: int) -> list[AgentState]:
     """Create and persist initial agent states with randomized roles."""
     Path("state/agents").mkdir(parents=True, exist_ok=True)
 
     agent_configs = json.loads(Path("config/agents.json").read_text(encoding="utf-8"))
-    roles = json.loads(Path("config/roles.json").read_text(encoding="utf-8"))
+    roles_config = json.loads(Path("config/roles.json").read_text(encoding="utf-8"))
+
+    key = str(num_players)
+    if key not in roles_config:
+        print(f"Error: no role configuration found for {num_players} players.")
+        print(f"Available: {', '.join(roles_config.keys())} players")
+        sys.exit(1)
+
+    roles = roles_config[key]
+    selected_configs = agent_configs[:num_players]
+    if len(selected_configs) < num_players:
+        print(f"Error: not enough agents in config/agents.json for {num_players} players (found {len(agent_configs)}).")
+        sys.exit(1)
 
     shuffled_roles = roles[:]
     random.shuffle(shuffled_roles)
 
     agents = []
-    for config, role in zip(agent_configs, shuffled_roles):
+    for config, role in zip(selected_configs, shuffled_roles):
         name = config["name"]
         beliefs = {
             other["name"]: Belief()
-            for other in agent_configs
+            for other in selected_configs
             if other["name"] != name
         }
         agent = AgentState(
@@ -74,12 +87,18 @@ def main() -> None:
         default="English",
         help="Language for agent speech and reasoning (e.g. English, Japanese)",
     )
+    parser.add_argument(
+        "--players",
+        type=int,
+        default=5,
+        help="Number of players (e.g. 5 or 7)",
+    )
     args = parser.parse_args()
 
     spectator_mode: bool = args.spectator
     lang: str = args.lang
 
-    agents = initialize_agents()
+    agents = initialize_agents(args.players)
 
     cli = CLI(agents=agents, spectator_mode=spectator_mode)
     cli.show_intro()

--- a/src/action/resolver.py
+++ b/src/action/resolver.py
@@ -12,11 +12,13 @@ def resolve_vote(action: Vote, agents: list[AgentState]) -> str:
 def resolve_inspect(action: Inspect, agents: list[AgentState]) -> tuple[str, str]:
     """
     Resolve a Seer's inspect action.
-    Returns (target_name, true_role).
+    Returns (target_name, result) where result is "Werewolf" or "Not Werewolf".
+    The Seer only learns alignment, not the specific role.
     """
     for agent in agents:
         if agent.name == action.target:
-            return (agent.name, agent.role)
+            result = "Werewolf" if agent.role == "Werewolf" else "Not Werewolf"
+            return (agent.name, result)
     return (action.target, "Unknown")
 
 

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -6,7 +6,6 @@ from src.agent import store, memory as memory_mod
 from src.engine.phase import Phase
 from src.engine.vote import tally_votes
 from src.engine.victory import check_victory
-from src.engine.role import has_night_action
 from src.llm import client as llm_client
 from src.llm.schema import AgentOutput, SpeechEntry
 from src.action.types import Vote, Inspect, Attack
@@ -369,79 +368,76 @@ class GameEngine:
             if score_totals:
                 attack_target = max(score_totals, key=lambda t: score_totals[t])
 
-        # --- ② 各役職の夜行動（狼の個人行動 / 占い師 / 騎士） ---
-        for agent in self._alive_agents():
-            if not has_night_action(agent.role):
-                continue
-
-            if agent.role == "Werewolf":
-                # 狼が2人未満（5人制）またはチャットで合意できなかった場合のフォールバック
-                if attack_target is None:
-                    target_name = llm_client.call_night_action(agent, night_context, alive_names)
-                    attack = Attack(target=target_name)
-                    if validate(attack, agent, alive_names):
-                        attack_target = resolve_attack(attack, self.agents)
-                        self._emit(LogEvent.make(
-                            day=self.day,
-                            phase=Phase.NIGHT.value,
-                            event_type=EventType.NIGHT_ATTACK,
-                            agent=agent.name,
-                            target=attack_target,
-                            content=f"{agent.name} attacks {attack_target}",
-                            is_public=False,
-                        ))
-
-            elif agent.role == "Seer":
+        # --- ② 狼単体フォールバック（チャットで合意できなかった場合） ---
+        if attack_target is None:
+            for agent in self._alive_agents():
+                if agent.role != "Werewolf":
+                    continue
                 target_name = llm_client.call_night_action(agent, night_context, alive_names)
-                inspect = Inspect(target=target_name)
-                if validate(inspect, agent, alive_names):
-                    name, role = resolve_inspect(inspect, self.agents)
-                    if name not in agent.beliefs:
-                        agent.beliefs[name] = Belief()
-                    if role == "Werewolf":
-                        agent.beliefs[name].suspicion = 1.0
-                        agent.beliefs[name].trust = 0.0
-                        agent.beliefs[name].reason.append(f"Day {self.day}: inspected as Werewolf")
-                    else:
-                        agent.beliefs[name].suspicion = 0.0
-                        agent.beliefs[name].trust = 1.0
-                        agent.beliefs[name].reason.append(f"Day {self.day}: inspected as {role}")
-                    store.save(agent)
-                    self._emit(LogEvent.make(
-                        day=self.day,
-                        phase=Phase.NIGHT.value,
-                        event_type=EventType.INSPECTION,
-                        agent=agent.name,
-                        target=name,
-                        content=f"{agent.name} inspects {name}: {role}",
-                        is_public=False,
-                    ))
+                attack = Attack(target=target_name)
+                if validate(attack, agent, alive_names):
+                    attack_target = resolve_attack(attack, self.agents)
+                    break  # 1人決めれば十分
 
-            elif agent.role == "Knight":
-                target_name = llm_client.call_night_action(agent, night_context, alive_names)
-                if target_name in alive_names:
-                    guard_target = target_name
-                    self._emit(LogEvent.make(
-                        day=self.day,
-                        phase=Phase.NIGHT.value,
-                        event_type=EventType.GUARD,
-                        agent=agent.name,
-                        target=guard_target,
-                        content=f"{agent.name} guards {guard_target}",
-                        is_public=False,
-                    ))
-
-        # --- ③ 狼チャットで合意した場合の攻撃ログ（フォールバック経由でない場合） ---
-        if attack_target and len(wolves) >= 2:
+        if attack_target:
             self._emit(LogEvent.make(
                 day=self.day,
                 phase=Phase.NIGHT.value,
                 event_type=EventType.NIGHT_ATTACK,
-                agent=wolves[0].name,
+                agent=wolves[0].name if wolves else None,
                 target=attack_target,
-                content=f"Werewolves agreed to attack {attack_target}",
+                content=f"Werewolves attack {attack_target}",
                 is_public=False,
             ))
+
+        # --- ③ 騎士が護衛先を決定（襲撃より先に実行） ---
+        for agent in self._alive_agents():
+            if agent.role != "Knight":
+                continue
+            target_name = llm_client.call_night_action(agent, night_context, alive_names)
+            candidates = [n for n in alive_names if n != agent.name]
+            if target_name in candidates:
+                guard_target = target_name
+                self._emit(LogEvent.make(
+                    day=self.day,
+                    phase=Phase.NIGHT.value,
+                    event_type=EventType.GUARD,
+                    agent=agent.name,
+                    target=guard_target,
+                    content=f"{agent.name} guards {guard_target}",
+                    is_public=False,
+                ))
+
+        # --- ④ 占い師が占い（自分が襲撃対象の場合はスキップ） ---
+        for agent in self._alive_agents():
+            if agent.role != "Seer":
+                continue
+            if agent.name == attack_target:
+                continue  # 今夜狼に襲われる占い師は占えない
+            target_name = llm_client.call_night_action(agent, night_context, alive_names)
+            inspect = Inspect(target=target_name)
+            if validate(inspect, agent, alive_names):
+                name, result = resolve_inspect(inspect, self.agents)
+                if name not in agent.beliefs:
+                    agent.beliefs[name] = Belief()
+                if result == "Werewolf":
+                    agent.beliefs[name].suspicion = 1.0
+                    agent.beliefs[name].trust = 0.0
+                    agent.beliefs[name].reason.append(f"Day {self.day}: inspected as Werewolf")
+                else:
+                    agent.beliefs[name].suspicion = 0.0
+                    agent.beliefs[name].trust = 1.0
+                    agent.beliefs[name].reason.append(f"Day {self.day}: inspected as Not Werewolf")
+                store.save(agent)
+                self._emit(LogEvent.make(
+                    day=self.day,
+                    phase=Phase.NIGHT.value,
+                    event_type=EventType.INSPECTION,
+                    agent=agent.name,
+                    target=name,
+                    content=f"{agent.name} inspects {name}: {result}",
+                    is_public=False,
+                ))
 
         # --- ④ 護衛と襲撃の照合 → 結果適用 ---
         if attack_target:

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -207,7 +207,7 @@ class GameEngine:
         self._phase_start(Phase.PRE_NIGHT)
 
         for agent in targets:
-            output = llm_client.call_pre_night_action(agent, self._alive_names(), self.lang)
+            output = llm_client.call_pre_night_action(agent, self._alive_names(), self.lang, self.agents)
             agent.intended_co = output.decision == "co"
             memory_mod.update_memory(agent, [f"Pre-game decision: {output.reasoning}"])
 

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -393,8 +393,10 @@ class GameEngine:
         # --- ③ 全役職が行動意思を決定（騎士・占い師） ---
         seer_inspect: tuple[AgentState, Inspect] | None = None  # (seer, inspect_action)
 
+        knight: AgentState | None = None
         for agent in self._alive_agents():
             if agent.role == "Knight":
+                knight = agent
                 target_name = llm_client.call_night_action(agent, night_context, alive_names)
                 candidates = [n for n in alive_names if n != agent.name]
                 if target_name in candidates:
@@ -420,6 +422,7 @@ class GameEngine:
         seer_survived = True
         if attack_target:
             if guard_target == attack_target:
+                # spectator: 護衛成功の詳細
                 self._emit(LogEvent.make(
                     day=self.day,
                     phase=Phase.NIGHT.value,
@@ -428,6 +431,20 @@ class GameEngine:
                     content=f"{attack_target} was protected by the Knight! The attack was blocked.",
                     is_public=False,
                 ))
+                # 村全員: 誰も死ななかった（誰が守ったかは伏せる）
+                self._emit(LogEvent.make(
+                    day=self.day,
+                    phase=Phase.NIGHT.value,
+                    event_type=EventType.GUARD_BLOCK,
+                    content="The village woke up to find everyone safe. The werewolves' attack seems to have failed.",
+                    is_public=True,
+                ))
+                # 騎士: 自分の護衛が成功したことを記憶
+                if knight:
+                    memory_mod.update_memory(
+                        knight,
+                        [f"Day {self.day}: successfully guarded {guard_target} from werewolf attack"],
+                    )
             else:
                 # 占い師が襲撃対象かチェック
                 if seer_inspect and seer_inspect[0].name == attack_target:

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -321,43 +321,81 @@ class GameEngine:
         self._phase_start(Phase.NIGHT)
         self.today_log = []
 
-        # Collect night action context
-        night_context = f"Day {self.day} night. Alive: {', '.join(self._alive_names())}"
+        alive_names = self._alive_names()
+        night_context = f"Day {self.day} night. Alive: {', '.join(alive_names)}"
 
         attack_target: str | None = None
-        inspect_results: list[tuple[str, str, str]] = []  # (seer_name, target, role)
+        guard_target: str | None = None
 
+        # --- ① 狼同士の会話（最大3往復） ---
+        wolves = [a for a in self._alive_agents() if a.role == "Werewolf"]
+        if len(wolves) >= 2:
+            self.phase = Phase.NIGHT_WOLF_CHAT
+            self._phase_start(Phase.NIGHT_WOLF_CHAT)
+            wolf_chat_log: list[SpeechEntry] = []
+            wolf_names = [w.name for w in wolves]
+            last_wolf_outputs = {w.name: None for w in wolves}
+
+            for _round in range(3):
+                for wolf in wolves:
+                    partners = [n for n in wolf_names if n != wolf.name]
+                    output = llm_client.call_wolf_chat(
+                        wolf, partners, alive_names, wolf_chat_log, self.lang
+                    )
+                    last_wolf_outputs[wolf.name] = output
+                    entry = SpeechEntry(
+                        speech_id=self._next_speech_id(),
+                        agent=wolf.name,
+                        text=output.speech,
+                    )
+                    wolf_chat_log.append(entry)
+                    self._emit(LogEvent.make(
+                        day=self.day,
+                        phase=Phase.NIGHT_WOLF_CHAT.value,
+                        event_type=EventType.WOLF_CHAT,
+                        agent=wolf.name,
+                        content=f"[WOLF] {wolf.name}: {output.speech}",
+                        is_public=False,
+                    ))
+
+            # 最後のターンのvote_candidatesを集計して襲撃対象を決定
+            score_totals: dict[str, float] = {}
+            for wolf in wolves:
+                out = last_wolf_outputs[wolf.name]
+                if out and out.vote_candidates:
+                    for vc in out.vote_candidates:
+                        if vc.target in alive_names and vc.target not in wolf_names:
+                            score_totals[vc.target] = score_totals.get(vc.target, 0.0) + vc.score
+            if score_totals:
+                attack_target = max(score_totals, key=lambda t: score_totals[t])
+
+        # --- ② 各役職の夜行動（狼の個人行動 / 占い師 / 騎士） ---
         for agent in self._alive_agents():
             if not has_night_action(agent.role):
                 continue
 
-            target_name = llm_client.call_night_action(
-                agent,
-                night_context,
-                self._alive_names(),
-            )
-
             if agent.role == "Werewolf":
-                attack = Attack(target=target_name)
-                if validate(attack, agent, self._alive_names()):
-                    attack_target = resolve_attack(attack, self.agents)
-                    self._emit(LogEvent.make(
-                        day=self.day,
-                        phase=Phase.NIGHT.value,
-                        event_type=EventType.NIGHT_ATTACK,
-                        agent=agent.name,
-                        target=attack_target,
-                        content=f"{agent.name} attacks {attack_target}",
-                        is_public=False,  # spectator only
-                    ))
+                # 狼が2人未満（5人制）またはチャットで合意できなかった場合のフォールバック
+                if attack_target is None:
+                    target_name = llm_client.call_night_action(agent, night_context, alive_names)
+                    attack = Attack(target=target_name)
+                    if validate(attack, agent, alive_names):
+                        attack_target = resolve_attack(attack, self.agents)
+                        self._emit(LogEvent.make(
+                            day=self.day,
+                            phase=Phase.NIGHT.value,
+                            event_type=EventType.NIGHT_ATTACK,
+                            agent=agent.name,
+                            target=attack_target,
+                            content=f"{agent.name} attacks {attack_target}",
+                            is_public=False,
+                        ))
 
             elif agent.role == "Seer":
+                target_name = llm_client.call_night_action(agent, night_context, alive_names)
                 inspect = Inspect(target=target_name)
-                if validate(inspect, agent, self._alive_names()):
+                if validate(inspect, agent, alive_names):
                     name, role = resolve_inspect(inspect, self.agents)
-                    inspect_results.append((agent.name, name, role))
-
-                    # Update seer's beliefs with inspection result
                     if name not in agent.beliefs:
                         agent.beliefs[name] = Belief()
                     if role == "Werewolf":
@@ -369,7 +407,6 @@ class GameEngine:
                         agent.beliefs[name].trust = 1.0
                         agent.beliefs[name].reason.append(f"Day {self.day}: inspected as {role}")
                     store.save(agent)
-
                     self._emit(LogEvent.make(
                         day=self.day,
                         phase=Phase.NIGHT.value,
@@ -377,15 +414,50 @@ class GameEngine:
                         agent=agent.name,
                         target=name,
                         content=f"{agent.name} inspects {name}: {role}",
-                        is_public=False,  # spectator only
+                        is_public=False,
                     ))
 
-        # Apply attack
-        if attack_target:
-            self._eliminate(attack_target, EventType.NIGHT_ATTACK, Phase.NIGHT.value)
+            elif agent.role == "Knight":
+                target_name = llm_client.call_night_action(agent, night_context, alive_names)
+                if target_name in alive_names:
+                    guard_target = target_name
+                    self._emit(LogEvent.make(
+                        day=self.day,
+                        phase=Phase.NIGHT.value,
+                        event_type=EventType.GUARD,
+                        agent=agent.name,
+                        target=guard_target,
+                        content=f"{agent.name} guards {guard_target}",
+                        is_public=False,
+                    ))
 
-        winner = check_victory(self.agents)
-        return winner
+        # --- ③ 狼チャットで合意した場合の攻撃ログ（フォールバック経由でない場合） ---
+        if attack_target and len(wolves) >= 2:
+            self._emit(LogEvent.make(
+                day=self.day,
+                phase=Phase.NIGHT.value,
+                event_type=EventType.NIGHT_ATTACK,
+                agent=wolves[0].name,
+                target=attack_target,
+                content=f"Werewolves agreed to attack {attack_target}",
+                is_public=False,
+            ))
+
+        # --- ④ 護衛と襲撃の照合 → 結果適用 ---
+        if attack_target:
+            if guard_target == attack_target:
+                self._emit(LogEvent.make(
+                    day=self.day,
+                    phase=Phase.NIGHT.value,
+                    event_type=EventType.GUARD_BLOCK,
+                    target=attack_target,
+                    content=f"{attack_target} was protected by the Knight! The attack was blocked.",
+                    is_public=False,
+                ))
+            else:
+                self._eliminate(attack_target, EventType.NIGHT_ATTACK, Phase.NIGHT.value)
+
+        return check_victory(self.agents)
 
     def _game_over(self, winner: str) -> None:
         self._emit(LogEvent.make(

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -377,7 +377,7 @@ class GameEngine:
                 attack = Attack(target=target_name)
                 if validate(attack, agent, alive_names):
                     attack_target = resolve_attack(attack, self.agents)
-                    break  # 1人決めれば十分
+                    break
 
         if attack_target:
             self._emit(LogEvent.make(
@@ -390,56 +390,34 @@ class GameEngine:
                 is_public=False,
             ))
 
-        # --- ③ 騎士が護衛先を決定（襲撃より先に実行） ---
-        for agent in self._alive_agents():
-            if agent.role != "Knight":
-                continue
-            target_name = llm_client.call_night_action(agent, night_context, alive_names)
-            candidates = [n for n in alive_names if n != agent.name]
-            if target_name in candidates:
-                guard_target = target_name
-                self._emit(LogEvent.make(
-                    day=self.day,
-                    phase=Phase.NIGHT.value,
-                    event_type=EventType.GUARD,
-                    agent=agent.name,
-                    target=guard_target,
-                    content=f"{agent.name} guards {guard_target}",
-                    is_public=False,
-                ))
+        # --- ③ 全役職が行動意思を決定（騎士・占い師） ---
+        seer_inspect: tuple[AgentState, Inspect] | None = None  # (seer, inspect_action)
 
-        # --- ④ 占い師が占い（自分が襲撃対象の場合はスキップ） ---
         for agent in self._alive_agents():
-            if agent.role != "Seer":
-                continue
-            if agent.name == attack_target:
-                continue  # 今夜狼に襲われる占い師は占えない
-            target_name = llm_client.call_night_action(agent, night_context, alive_names)
-            inspect = Inspect(target=target_name)
-            if validate(inspect, agent, alive_names):
-                name, result = resolve_inspect(inspect, self.agents)
-                if name not in agent.beliefs:
-                    agent.beliefs[name] = Belief()
-                if result == "Werewolf":
-                    agent.beliefs[name].suspicion = 1.0
-                    agent.beliefs[name].trust = 0.0
-                    agent.beliefs[name].reason.append(f"Day {self.day}: inspected as Werewolf")
-                else:
-                    agent.beliefs[name].suspicion = 0.0
-                    agent.beliefs[name].trust = 1.0
-                    agent.beliefs[name].reason.append(f"Day {self.day}: inspected as Not Werewolf")
-                store.save(agent)
-                self._emit(LogEvent.make(
-                    day=self.day,
-                    phase=Phase.NIGHT.value,
-                    event_type=EventType.INSPECTION,
-                    agent=agent.name,
-                    target=name,
-                    content=f"{agent.name} inspects {name}: {result}",
-                    is_public=False,
-                ))
+            if agent.role == "Knight":
+                target_name = llm_client.call_night_action(agent, night_context, alive_names)
+                candidates = [n for n in alive_names if n != agent.name]
+                if target_name in candidates:
+                    guard_target = target_name
+                    self._emit(LogEvent.make(
+                        day=self.day,
+                        phase=Phase.NIGHT.value,
+                        event_type=EventType.GUARD,
+                        agent=agent.name,
+                        target=guard_target,
+                        content=f"{agent.name} guards {guard_target}",
+                        is_public=False,
+                    ))
 
-        # --- ④ 護衛と襲撃の照合 → 結果適用 ---
+            elif agent.role == "Seer":
+                target_name = llm_client.call_night_action(agent, night_context, alive_names)
+                inspect = Inspect(target=target_name)
+                if validate(inspect, agent, alive_names):
+                    seer_inspect = (agent, inspect)  # 結果適用は後回し
+
+        # --- ④ 解決フェーズ ---
+        # 騎士の護衛判定 → 狼の襲撃判定 → 占い師の占い判定
+        seer_survived = True
         if attack_target:
             if guard_target == attack_target:
                 self._emit(LogEvent.make(
@@ -451,7 +429,35 @@ class GameEngine:
                     is_public=False,
                 ))
             else:
+                # 占い師が襲撃対象かチェック
+                if seer_inspect and seer_inspect[0].name == attack_target:
+                    seer_survived = False
                 self._eliminate(attack_target, EventType.NIGHT_ATTACK, Phase.NIGHT.value)
+
+        # 占い師が生き残っていれば占い結果を適用
+        if seer_inspect and seer_survived:
+            seer, inspect = seer_inspect
+            name, result = resolve_inspect(inspect, self.agents)
+            if name not in seer.beliefs:
+                seer.beliefs[name] = Belief()
+            if result == "Werewolf":
+                seer.beliefs[name].suspicion = 1.0
+                seer.beliefs[name].trust = 0.0
+                seer.beliefs[name].reason.append(f"Day {self.day}: inspected as Werewolf")
+            else:
+                seer.beliefs[name].suspicion = 0.0
+                seer.beliefs[name].trust = 1.0
+                seer.beliefs[name].reason.append(f"Day {self.day}: inspected as Not Werewolf")
+            store.save(seer)
+            self._emit(LogEvent.make(
+                day=self.day,
+                phase=Phase.NIGHT.value,
+                event_type=EventType.INSPECTION,
+                agent=seer.name,
+                target=name,
+                content=f"{seer.name} inspects {name}: {result}",
+                is_public=False,
+            ))
 
         return check_victory(self.agents)
 

--- a/src/engine/phase.py
+++ b/src/engine/phase.py
@@ -7,4 +7,5 @@ class Phase(Enum):
     DAY_DISCUSSION = "day_discussion"
     DAY_VOTE = "day_vote"
     NIGHT = "night"
+    NIGHT_WOLF_CHAT = "night_wolf_chat"
     GAME_OVER = "game_over"

--- a/src/engine/role.py
+++ b/src/engine/role.py
@@ -1,9 +1,8 @@
-ROLES = ["Villager", "Villager", "Villager", "Werewolf", "Seer"]
-
 ROLE_NIGHT_ACTIONS = {
     "Villager": None,
     "Werewolf": "attack",
     "Seer": "inspect",
+    "Knight": "guard",
 }
 
 

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -69,7 +69,7 @@ def call(
     try:
         message = _client.messages.create(
             model=agent.model,
-            max_tokens=1024,
+            max_tokens=2048,
             system=system_prompt,
             messages=[
                 {

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -179,7 +179,7 @@ def call_wolf_chat(
     try:
         message = _client.messages.create(
             model=agent.model,
-            max_tokens=512,
+            max_tokens=2048,
             messages=[{"role": "user", "content": prompt}],
         )
         raw = message.content[0].text

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -104,7 +104,7 @@ def call_judgment(
     try:
         message = _client.messages.create(
             model=agent.model,
-            max_tokens=512,
+            max_tokens=1024,
             messages=[{"role": "user", "content": prompt}],
         )
         raw = message.content[0].text
@@ -142,9 +142,10 @@ def call_pre_night_action(
     agent: AgentState,
     alive_players: list[str],
     lang: str = "English",
+    all_agents: list[AgentState] | None = None,
 ) -> PreNightOutput:
     """Call LLM for pre-night CO decision and return structured PreNightOutput."""
-    prompt = build_pre_night_prompt(agent, alive_players, lang)
+    prompt = build_pre_night_prompt(agent, alive_players, lang, all_agents)
     raw = ""
     try:
         message = _client.messages.create(

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -6,8 +6,8 @@ from collections.abc import Iterator
 import anthropic
 
 from src.agent.state import AgentState
-from src.llm.prompt import build_system_prompt, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt
-from src.llm.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, SpeechEntry
+from src.llm.prompt import build_system_prompt, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_wolf_chat_prompt
+from src.llm.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, SpeechEntry, WolfChatOutput
 
 _client = anthropic.Anthropic()
 
@@ -163,6 +163,35 @@ def call_pre_night_action(
     except Exception as e:
         _log_error("call_pre_night_action", agent.name, "parse", e, raw)
         return PreNightOutput(thought="...", decision="wait", reasoning="Defaulting to wait.")
+
+
+def call_wolf_chat(
+    agent: AgentState,
+    wolf_partners: list[str],
+    alive_players: list[str],
+    wolf_chat_log: list[SpeechEntry],
+    lang: str = "English",
+) -> WolfChatOutput:
+    """Call LLM for werewolf team night chat and return structured WolfChatOutput."""
+    prompt = build_wolf_chat_prompt(agent, wolf_partners, alive_players, wolf_chat_log, lang)
+    raw = ""
+    try:
+        message = _client.messages.create(
+            model=agent.model,
+            max_tokens=512,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = message.content[0].text
+    except Exception as e:
+        _log_error("call_wolf_chat", agent.name, "api", e, raw)
+        return WolfChatOutput(thought="...", speech="...", vote_candidates=[])
+    try:
+        json_str = _extract_json(raw)
+        data = json.loads(json_str)
+        return WolfChatOutput.model_validate(data)
+    except Exception as e:
+        _log_error("call_wolf_chat", agent.name, "parse", e, raw)
+        return WolfChatOutput(thought="...", speech="...", vote_candidates=[])
 
 
 def call_night_action(

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -233,7 +233,12 @@ def build_system_prompt(
     return "\n".join(parts)
 
 
-def build_pre_night_prompt(agent: AgentState, alive_players: list[str], lang: str = "English") -> str:
+def build_pre_night_prompt(
+    agent: AgentState,
+    alive_players: list[str],
+    lang: str = "English",
+    all_agents: list[AgentState] | None = None,
+) -> str:
     """Build prompt for pre-night CO decision phase (non-Villager roles only).
 
     Seer decides whether to true-CO. Werewolf decides whether to fake-CO as Seer.
@@ -259,6 +264,15 @@ def build_pre_night_prompt(agent: AgentState, alive_players: list[str], lang: st
         "",
         f"Your secret role is: {agent.role}",
         f"Players in this game: {', '.join(alive_players)}",
+    ]
+
+    if all_agents:
+        from collections import Counter
+        role_counts = Counter(a.role for a in all_agents)
+        role_summary = ", ".join(f"{count} {role}" for role, count in sorted(role_counts.items()))
+        lines.append(f"Role distribution in this game: {role_summary}")
+
+    lines += [
         "",
         "Before Day 1 begins, you must secretly decide your opening strategy.",
         decision_desc,

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -309,6 +309,43 @@ Use {lang} only for internal reasoning if needed, but keep the JSON minimal.""")
     return "\n".join(lines)
 
 
+def build_wolf_chat_prompt(
+    agent: AgentState,
+    wolf_partners: list[str],
+    alive_players: list[str],
+    wolf_chat_log: list[SpeechEntry],
+    lang: str = "English",
+) -> str:
+    """Build prompt for werewolf team night chat (secret coordination before attack)."""
+    lines = [
+        f"You are {agent.name}, a Werewolf in a social deduction game.",
+        f"Your wolf partners tonight: {', '.join(wolf_partners)}.",
+        f"Alive players (potential targets): {', '.join(p for p in alive_players if p != agent.name and p not in wolf_partners)}.",
+        "",
+        "It is night. You are meeting secretly with your wolf partner(s) to coordinate.",
+        "Discuss who to attack tonight. You may propose a target and explain your reasoning.",
+    ]
+    if wolf_chat_log:
+        lines.append("\nWolf team conversation so far:")
+        for entry in wolf_chat_log:
+            lines.append(f"  {entry.agent}: {entry.text}")
+    lines.append(f"""
+--- OUTPUT FORMAT ---
+Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
+{{
+  "thought": "<your private reasoning>",
+  "speech": "<what you say to your wolf partner(s)>",
+  "vote_candidates": [
+    {{"target": "<player_name>", "score": <0.0-1.0>}},
+    ...
+  ]
+}}
+- "thought" and "speech" must be written in {lang}
+- "vote_candidates" lists your preferred attack targets (highest score = most preferred)
+- The JSON must contain exactly these three fields and nothing else.""")
+    return "\n".join(lines)
+
+
 def build_night_action_prompt(agent: AgentState, alive_players: list[str], context: str) -> str:
     """Build prompt for night action (attack or inspect)."""
     if agent.role == "Werewolf":

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -361,13 +361,16 @@ Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
 
 
 def build_night_action_prompt(agent: AgentState, alive_players: list[str], context: str) -> str:
-    """Build prompt for night action (attack or inspect)."""
+    """Build prompt for night action (attack, inspect, or guard)."""
     if agent.role == "Werewolf":
         action_desc = "choose one player to ATTACK (eliminate) tonight"
         instruction = "You must pick a non-Werewolf target. Respond with ONLY the player's exact name, nothing else."
     elif agent.role == "Seer":
-        action_desc = "choose one player to INSPECT (learn their true role) tonight"
+        action_desc = "choose one player to INSPECT (learn their alignment) tonight"
         instruction = "Pick a player you want to investigate. Respond with ONLY the player's exact name, nothing else."
+    elif agent.role == "Knight":
+        action_desc = "choose one player to GUARD (protect from werewolf attack) tonight"
+        instruction = "Pick a player you want to protect. You cannot guard yourself. Respond with ONLY the player's exact name, nothing else."
     else:
         return ""
 

--- a/src/llm/schema.py
+++ b/src/llm/schema.py
@@ -36,3 +36,9 @@ class AgentOutput(BaseModel):
     reasoning: str
     intent: Intent
     memory_update: list[str] = []
+
+
+class WolfChatOutput(BaseModel):
+    thought: str
+    speech: str
+    vote_candidates: list[VoteCandidate] = []

--- a/src/logger/event.py
+++ b/src/logger/event.py
@@ -12,6 +12,9 @@ class EventType(Enum):
     NIGHT_ATTACK = "night_attack"
     INSPECTION = "inspection"
     PRE_NIGHT_DECISION = "pre_night_decision"
+    WOLF_CHAT = "wolf_chat"
+    GUARD = "guard"
+    GUARD_BLOCK = "guard_block"
     GAME_OVER = "game_over"
     PHASE_START = "phase_start"
 

--- a/src/ui/cli.py
+++ b/src/ui/cli.py
@@ -3,7 +3,7 @@ from rich.panel import Panel
 
 from src.logger.event import LogEvent
 from src.agent.state import AgentState
-from src.ui.renderer import render_event
+from src.ui.renderer import render_event, _ROLE_COLORS
 
 console = Console()
 
@@ -24,7 +24,7 @@ class CLI:
         console.print()
         console.print("[bold yellow]=== ROLE REVEAL ===[/bold yellow]")
         for agent in self.agents:
-            role_style = "red" if agent.role == "Werewolf" else ("blue" if agent.role == "Seer" else "white")
+            role_style = _ROLE_COLORS.get(agent.role, "white")
             status = "" if agent.is_alive else " [dim](eliminated)[/dim]"
             console.print(f"  [{role_style}]{agent.name}[/{role_style}] — {agent.role}{status}")
         console.print()
@@ -55,6 +55,6 @@ class CLI:
             return
         console.print("\n[bold cyan]Agent Roster:[/bold cyan]")
         for agent in self.agents:
-            role_style = "red" if agent.role == "Werewolf" else ("blue" if agent.role == "Seer" else "white")
+            role_style = _ROLE_COLORS.get(agent.role, "white")
             console.print(f"  [{role_style}]{agent.name}[/{role_style}] — {agent.role} ({agent.persona.style})")
         console.print()

--- a/src/ui/cli.py
+++ b/src/ui/cli.py
@@ -28,9 +28,10 @@ class CLI:
             status = "" if agent.is_alive else " [dim](eliminated)[/dim]"
             console.print(f"  [{role_style}]{agent.name}[/{role_style}] — {agent.role}{status}")
         console.print()
+        result_style = "bold red" if winner == "Werewolves" else "bold green"
         console.print(
             Panel(
-                f"[bold green]{winner} WIN THE GAME![/bold green]",
+                f"[{result_style}]{winner} WIN THE GAME![/{result_style}]",
                 title="GAME OVER",
                 border_style="bold yellow",
                 padding=(1, 4),

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -84,6 +84,18 @@ def render_event(
         style = "red" if role == "Werewolf" else "cyan"
         text.append(f"[PRE-NIGHT] {event.content}", style=style)
 
+    elif event.event_type == EventType.WOLF_CHAT:
+        # Spectator only — red
+        text.append(f"[WOLF] {event.content}", style="red")
+
+    elif event.event_type == EventType.GUARD:
+        # Spectator only — cyan
+        text.append(f"[GUARD] {event.content}", style="cyan")
+
+    elif event.event_type == EventType.GUARD_BLOCK:
+        # Spectator only — bold cyan
+        text.append(f"[GUARD BLOCK] {event.content}", style="bold cyan")
+
     elif event.event_type == EventType.GAME_OVER:
         text.append(f"\n{'=' * 50}\n", style="bold yellow")
         text.append(event.content, style="bold green")

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -7,14 +7,35 @@ from src.agent.state import AgentState
 console = Console()
 
 
-def _get_claimed_role(agent_name: str | None, agents: list[AgentState]) -> str | None:
-    """Return the role the agent has publicly claimed (CO), or None if no CO."""
+_ROLE_COLORS: dict[str, str] = {
+    "Werewolf": "red",
+    "Seer": "blue",
+    "Knight": "bright_green",
+    "Villager": "white",
+}
+
+
+def _get_agent(agent_name: str | None, agents: list[AgentState]) -> AgentState | None:
     if agent_name is None:
         return None
-    for a in agents:
-        if a.name == agent_name:
-            return a.claimed_role
-    return None
+    return next((a for a in agents if a.name == agent_name), None)
+
+
+def _speech_style(agent_name: str | None, agents: list[AgentState], spectator_mode: bool) -> str:
+    """Return Rich color style for a speech event.
+
+    Spectator mode: color by true role.
+    Public mode: color by claimed role (CO'd role only), default white.
+    """
+    agent = _get_agent(agent_name, agents)
+    if agent is None:
+        return "white"
+    if spectator_mode:
+        return _ROLE_COLORS.get(agent.role, "white")
+    # public mode: only color if the agent has CO'd
+    if agent.claimed_role:
+        return _ROLE_COLORS.get(agent.claimed_role, "white")
+    return "white"
 
 
 def render_event(
@@ -30,7 +51,6 @@ def render_event(
     if not event.is_public and not spectator_mode:
         return None
 
-    claimed_role = _get_claimed_role(event.agent, agents)
     text = Text()
 
     if event.event_type == EventType.PHASE_START:
@@ -43,11 +63,7 @@ def render_event(
             text.append(f"  [THINK] {event.agent}: ", style="dim white")
             text.append(thought_content, style="dim white")
         else:
-            # Regular speech — blue only after Seer CO
-            if claimed_role == "Seer":
-                style = "blue"
-            else:
-                style = "white"
+            style = _speech_style(event.agent, agents, spectator_mode)
             prefix = f"[{event.speech_id}] " if event.speech_id is not None else ""
             reply = f" (→[{event.reply_to}])" if event.reply_to is not None else ""
             text.append(f"{prefix}{event.agent}{reply}: ", style=f"bold {style}")
@@ -78,10 +94,10 @@ def render_event(
         text.append(f"[INSPECT] {event.content}", style="cyan")
 
     elif event.event_type == EventType.PRE_NIGHT_DECISION:
-        # Spectator only — cyan for Seer, red for Werewolf
-        agent_state = next((a for a in agents if a.name == event.agent), None)
+        # Spectator only — role color
+        agent_state = _get_agent(event.agent, agents)
         role = agent_state.role if agent_state else ""
-        style = "red" if role == "Werewolf" else "cyan"
+        style = _ROLE_COLORS.get(role, "cyan")
         text.append(f"[PRE-NIGHT] {event.content}", style=style)
 
     elif event.event_type == EventType.WOLF_CHAT:


### PR DESCRIPTION
## Summary

Ideas.md §16.3 の実装。

### 7人制モード（`--players 5|7`）
- `config/roles.json` を `{"5": [...], "7": [...]}` 形式に変更。設定がない人数はエラー終了
- `config/agents.json` に Jonas・Methode を追加（計7人）
- `main.py` に `--players` 引数を追加（デフォルト: 5）

### 騎士（Knight）役職
- `src/engine/role.py`: Knight の夜行動 `guard` を追加
- `src/engine/game.py`: 護衛対象 == 襲撃対象のとき `GUARD_BLOCK` → 攻撃無効

### 狼同士の夜会話（狼が2人以上のとき）
- `NIGHT_WOLF_CHAT` フェーズで最大3往復の非公開会話
- 各ターンの `vote_candidates` スコアを集計して最終的な襲撃対象を決定
- 合意できない or 狼が1人のときは個別の `call_night_action()` にフォールバック

### UI・バグ修正
- `renderer.py`: `WOLF_CHAT`（赤）/ `GUARD`（シアン）/ `GUARD_BLOCK`（太字シアン）を追加
- `call()` の `max_tokens`: 1024 → 2048（日本語モードでの切断対策）

## Test plan

- [x] `ruff check .` パス
- [x] `pytest` 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)