### PR TITLE
fix: store claimed_role in LogEvent instead of parsing CO_ANNOUNCEMENT content

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -150,8 +150,15 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 | `GUARD_BLOCK` | False / True | 護衛成功の詳細（観戦者）/ 全体通知（村人全員） |
 | `WOLF_CHAT` | False | 狼チャット（観戦者のみ） |
 | `PRE_NIGHT_DECISION` | False | 前夜CO判断（観戦者のみ） |
+| `CO_ANNOUNCEMENT` | True | 役職公言。`claimed_role` フィールドに公言した役職名を格納 |
 | `PHASE_START` | True / False | フェーズ開始通知 |
 | `GAME_OVER` | True | ゲーム終了 |
+
+#### event.py — LogEvent フィールド
+
+`CO_ANNOUNCEMENT` イベントには `claimed_role: str | None` フィールドを使う。
+`content` の文字列フォーマット（`"{name} claims to be {role}"`）に依存せず、型安全に公言役職名を参照できる。
+既存アーカイブとの後方互換は `default=None` で対応する。
 
 ---
 

--- a/doc/TechnicalDebt.md
+++ b/doc/TechnicalDebt.md
@@ -5,21 +5,10 @@
 
 ---
 
-## 🔴 CO_ANNOUNCEMENT の文字列パース（replay.py）
+## ✅ CO_ANNOUNCEMENT の文字列パース（replay.py） — 解決済み
 
-**場所:** `src/ui/replay.py` `ReplayPager._build_lines()`
-
-```python
-marker = "claims to be "
-idx = event.content.find(marker)
-dynamic_agents[event.agent].claimed_role = event.content[idx + len(marker):].strip()
-```
-
-`game.py` のログ出力フォーマット（`f"{agent.name} claims to be {agent.claimed_role}"`）を文字列パースしている。
-フォーマットを変えると即壊れる。
-
-**修正案:** `LogEvent` に `claimed_role: str | None` フィールドを追加し、`CO_ANNOUNCEMENT` 記録時に値を入れる。
-既存アーカイブとの後方互換は `default=None` で対応可能。
+`LogEvent` に `claimed_role: str | None` フィールドを追加し、`CO_ANNOUNCEMENT` 記録時に値を格納するよう修正。
+`replay.py` の文字列パース（`"claims to be "` マーカー検索）を削除し、`event.claimed_role` を直接参照するよう変更。
 
 ---
 

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -186,6 +186,7 @@ class GameEngine:
                 agent=agent.name,
                 content=f"{agent.name} claims to be {agent.claimed_role}",
                 is_public=True,
+                claimed_role=agent.claimed_role,
             ))
 
         speech_id = self._next_speech_id()

--- a/src/logger/event.py
+++ b/src/logger/event.py
@@ -32,6 +32,7 @@ class LogEvent(BaseModel):
     is_public: bool = True
     speech_id: int | None = None
     reply_to: int | None = None
+    claimed_role: str | None = None
 
     @classmethod
     def make(
@@ -45,6 +46,7 @@ class LogEvent(BaseModel):
         is_public: bool = True,
         speech_id: int | None = None,
         reply_to: int | None = None,
+        claimed_role: str | None = None,
     ) -> "LogEvent":
         return cls(
             day=day,
@@ -56,4 +58,5 @@ class LogEvent(BaseModel):
             is_public=is_public,
             speech_id=speech_id,
             reply_to=reply_to,
+            claimed_role=claimed_role,
         )

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -128,12 +128,10 @@ class ReplayPager:
         all_lines: list[str] = []
         for event in events:
             # Update claimed_role in real time when a CO is announced.
-            # Content format: "{name} claims to be {role}"
-            if event.event_type == EventType.CO_ANNOUNCEMENT and event.agent:
-                marker = "claims to be "
-                idx = event.content.find(marker)
-                if idx != -1 and event.agent in dynamic_agents:
-                    dynamic_agents[event.agent].claimed_role = event.content[idx + len(marker):].strip()
+            # Use event.claimed_role (structured field) rather than parsing content text.
+            if event.event_type == EventType.CO_ANNOUNCEMENT and event.agent and event.claimed_role:
+                if event.agent in dynamic_agents:
+                    dynamic_agents[event.agent].claimed_role = event.claimed_role
 
             rich_text = render_event(event, list(dynamic_agents.values()), self._spectator)
             if rich_text is None:


### PR DESCRIPTION
## Summary

- `LogEvent` に `claimed_role: str | None = None` フィールドを追加
- `game.py` が `CO_ANNOUNCEMENT` 記録時に `claimed_role=agent.claimed_role` をセット
- `replay.py` の文字列パース（`"claims to be "` マーカー検索）を削除し、`event.claimed_role` を直接参照
- `doc/DetailDesign.md` に `CO_ANNOUNCEMENT` と `LogEvent.claimed_role` の説明を追記
- `doc/TechnicalDebt.md` の 🔴 項目を ✅ 解決済みに更新

## 後方互換

旧アーカイブの JSONL には `claimed_role` フィールドがないが、`default=None` のため `model_validate` は問題なし。

Closes TechnicalDebt.md 🔴 item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)