### PR TITLE
refactor: reduce build_system_prompt params via context dataclasses

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -91,8 +91,41 @@
 | モジュール | 責務 |
 |---|---|
 | `client.py` | anthropic SDKのラッパー。APIコールと `AgentOutput` へのパース |
-| `prompt.py` | 性格プロンプト・役職プロンプトを組み合わせてシステムプロンプトを生成。`build_role_prompt` が `wolf_partners` を受け取り、人狼役職のプロンプトに仲間情報を追記する。`wolf_partners` が空リストの場合は「最後の人狼」として通知する |
+| `prompt.py` | 性格プロンプト・役職プロンプトを組み合わせてシステムプロンプトを生成。`build_system_prompt(agent, ctx, direction, role_ctx)` の4引数シグネチャ。公開情報は `PublicContext`、発言制御は `SpeechDirection`、役職固有情報は `RoleSpecificContext` サブクラス（現在は `WolfSpecificContext` のみ）で渡す |
 | `schema.py` | `AgentOutput` のPydanticモデル定義（`thought`, `speech`, `intent`, `memory_update`） |
+
+### prompt.py — コンテキスト dataclass
+
+```python
+@dataclass
+class PublicContext:
+    today_log: list[SpeechEntry]   # 今日の発言ログ
+    alive_players: list[str]
+    dead_players: list[str]
+    day: int
+    all_agents: list[AgentState] | None = None   # 役職分布・CO状況
+    past_votes: list[dict] | None = None
+    past_deaths: list[dict] | None = None
+
+@dataclass
+class SpeechDirection:
+    lang: str = "English"
+    reply_to_entry: SpeechEntry | None = None   # challenge 対象
+    intended_co: bool = False
+
+@dataclass
+class RoleSpecificContext:
+    """役職固有コンテキストの基底クラス"""
+    pass
+
+@dataclass
+class WolfSpecificContext(RoleSpecificContext):
+    wolf_partners: list[str]   # 生存中の仲間狼の名前リスト
+```
+
+- `PublicContext` は1フェーズ内で全エージェント共通のため1回構築して使い回せる
+- `SpeechDirection` はエージェントごとに異なる（reply_to, co フラグ）
+- `RoleSpecificContext` サブクラスは役職固有のランタイム情報を型安全に渡す手段。Seer/Knight/Medium 向けサブクラスは Issue #36 実装時に追加予定
 
 ### AgentOutput スキーマ
 

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -7,6 +7,7 @@ from src.engine.phase import Phase
 from src.engine.vote import tally_votes
 from src.engine.victory import check_victory
 from src.llm import client as llm_client
+from src.llm.prompt import PublicContext, SpeechDirection, WolfSpecificContext
 from src.llm.schema import AgentOutput, SpeechEntry
 from src.action.types import Vote, Inspect, Attack
 from src.action.validator import validate
@@ -145,25 +146,29 @@ class GameEngine:
         force_co=True injects the CO instruction into the speech prompt without mutating
         agent.intended_co. Used when the agent chose "co" in the discussion judgment phase.
         """
-        wolf_partners = (
-            [a.name for a in self._alive_agents() if a.role == "Werewolf" and a.name != agent.name]
-            if agent.role == "Werewolf"
-            else None
-        )
-        output = llm_client.call(
-            agent,
-            list(self.today_log),
-            self._alive_names(),
-            self._dead_names(),
-            self.day,
-            self.lang,
-            reply_to_entry=reply_to_entry,
+        ctx = PublicContext(
+            today_log=list(self.today_log),
+            alive_players=self._alive_names(),
+            dead_players=self._dead_names(),
+            day=self.day,
             all_agents=self.agents,
             past_votes=self._past_votes,
             past_deaths=self._past_deaths,
-            intended_co=agent.intended_co or force_co,
-            wolf_partners=wolf_partners,
         )
+        direction = SpeechDirection(
+            lang=self.lang,
+            reply_to_entry=reply_to_entry,
+            intended_co=agent.intended_co or force_co,
+        )
+        # TODO(#36): Add SeerSpecificContext / KnightSpecificContext / MediumSpecificContext
+        role_ctx = (
+            WolfSpecificContext(
+                wolf_partners=[a.name for a in self._alive_agents() if a.role == "Werewolf" and a.name != agent.name]
+            )
+            if agent.role == "Werewolf"
+            else None
+        )
+        output = llm_client.call(agent, ctx, direction, role_ctx)
         self._day_outputs[agent.name] = output
 
         # Safety net: enforce pre-night CO decision on the opening speech.

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator
 import anthropic
 
 from src.agent.state import AgentState
-from src.llm.prompt import build_system_prompt, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_wolf_chat_prompt
+from src.llm.prompt import PublicContext, SpeechDirection, RoleSpecificContext, build_system_prompt, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_wolf_chat_prompt
 from src.llm.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, SpeechEntry, WolfChatOutput
 
 _client = anthropic.Anthropic()
@@ -61,20 +61,12 @@ def _extract_json(text: str) -> str:
 
 def call(
     agent: AgentState,
-    today_log: list[SpeechEntry],
-    alive_players: list[str],
-    dead_players: list[str],
-    day: int = 1,
-    lang: str = "English",
-    reply_to_entry: SpeechEntry | None = None,
-    all_agents: list[AgentState] | None = None,
-    past_votes: list[dict] | None = None,
-    past_deaths: list[dict] | None = None,
-    intended_co: bool = False,
-    wolf_partners: list[str] | None = None,
+    ctx: PublicContext,
+    direction: SpeechDirection,
+    role_ctx: RoleSpecificContext | None = None,
 ) -> AgentOutput:
     """Call LLM for day-phase speech and return structured AgentOutput."""
-    system_prompt = build_system_prompt(agent, today_log, alive_players, dead_players, day, lang, reply_to_entry, all_agents, past_votes, past_deaths, intended_co, wolf_partners)
+    system_prompt = build_system_prompt(agent, ctx, direction, role_ctx)
     raw = ""
     try:
         message = _client.messages.create(

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -1,5 +1,36 @@
+from dataclasses import dataclass, field
+
 from src.agent.state import AgentState
 from src.llm.schema import SpeechEntry
+
+
+@dataclass
+class PublicContext:
+    today_log: list[SpeechEntry]
+    alive_players: list[str]
+    dead_players: list[str]
+    day: int
+    all_agents: list[AgentState] | None = None
+    past_votes: list[dict] | None = None
+    past_deaths: list[dict] | None = None
+
+
+@dataclass
+class SpeechDirection:
+    lang: str = "English"
+    reply_to_entry: SpeechEntry | None = None
+    intended_co: bool = False
+
+
+@dataclass
+class RoleSpecificContext:
+    """Base class for role-specific runtime context."""
+    pass
+
+
+@dataclass
+class WolfSpecificContext(RoleSpecificContext):
+    wolf_partners: list[str] = field(default_factory=list)
 
 
 _SPEECH_STYLE_PROMPTS: dict[str, str] = {
@@ -109,53 +140,45 @@ def build_role_prompt(role: str, wolf_partners: list[str] | None = None) -> str:
         return f"You are a {role}. Play to win."
 
 
-def build_public_info_prompt(
-    today_log: list[SpeechEntry],
-    alive_players: list[str],
-    dead_players: list[str],
-    day: int,
-    all_agents: list[AgentState] | None = None,
-    past_votes: list[dict] | None = None,
-    past_deaths: list[dict] | None = None,
-) -> str:
+def build_public_info_prompt(ctx: PublicContext) -> str:
     """Build prompt section with public game information."""
     from collections import Counter
-    lines = [f"\n--- PUBLIC INFORMATION (Day {day}) ---"]
+    lines = [f"\n--- PUBLIC INFORMATION (Day {ctx.day}) ---"]
 
-    if all_agents:
-        role_counts = Counter(a.role for a in all_agents)
+    if ctx.all_agents:
+        role_counts = Counter(a.role for a in ctx.all_agents)
         role_summary = ", ".join(f"{count} {role}" for role, count in sorted(role_counts.items()))
         lines.append(f"Role distribution: {role_summary}")
 
     lines += [
-        f"Alive players: {', '.join(alive_players)}",
-        f"Dead players: {', '.join(dead_players) if dead_players else 'none'}",
+        f"Alive players: {', '.join(ctx.alive_players)}",
+        f"Dead players: {', '.join(ctx.dead_players) if ctx.dead_players else 'none'}",
     ]
 
-    if past_deaths:
+    if ctx.past_deaths:
         lines.append("\nPast deaths:")
-        for d in past_deaths:
+        for d in ctx.past_deaths:
             cause = "executed" if d["cause"] == "execution" else "killed by werewolves"
             lines.append(f"  Day {d['day']}: {d['name']} was {cause}")
 
-    if past_votes:
+    if ctx.past_votes:
         lines.append("\nPast votes:")
-        for v in past_votes:
+        for v in ctx.past_votes:
             vote_str = ", ".join(f"{voter}→{target}" for voter, target in v["votes"].items())
             lines.append(f"  Day {v['day']}: {vote_str}")
 
-    if all_agents:
+    if ctx.all_agents:
         claims = [
             f"{a.name} claims {a.claimed_role}"
-            for a in all_agents
+            for a in ctx.all_agents
             if a.claimed_role is not None
         ]
         if claims:
             lines.append(f"Known role claims: {', '.join(claims)}")
 
-    if today_log:
+    if ctx.today_log:
         lines.append("\nToday's discussion so far:")
-        for entry in today_log:
+        for entry in ctx.today_log:
             lines.append(f"  [{entry.speech_id}] {entry.agent}: {entry.text}")
     else:
         lines.append("\nNo discussion yet today.")
@@ -217,34 +240,27 @@ Rules:
 
 def build_system_prompt(
     agent: AgentState,
-    today_log: list[SpeechEntry],
-    alive_players: list[str],
-    dead_players: list[str],
-    day: int,
-    lang: str = "English",
-    reply_to_entry: SpeechEntry | None = None,
-    all_agents: list[AgentState] | None = None,
-    past_votes: list[dict] | None = None,
-    past_deaths: list[dict] | None = None,
-    intended_co: bool = False,
-    wolf_partners: list[str] | None = None,
+    ctx: PublicContext,
+    direction: SpeechDirection,
+    role_ctx: RoleSpecificContext | None = None,
 ) -> str:
     """Assemble full system prompt for an agent."""
+    wolf_partners = role_ctx.wolf_partners if isinstance(role_ctx, WolfSpecificContext) else None
     parts = [
         build_persona_prompt(agent),
         "\n",
         build_role_prompt(agent.role, wolf_partners),
-        build_public_info_prompt(today_log, alive_players, dead_players, day, all_agents, past_votes, past_deaths),
+        build_public_info_prompt(ctx),
         build_personal_info_prompt(agent),
     ]
-    if reply_to_entry is not None:
+    if direction.reply_to_entry is not None:
         parts.append(
             f"\n--- YOUR TURN (CHALLENGE) ---\n"
-            f"You decided to challenge speech [{reply_to_entry.speech_id}] by {reply_to_entry.agent}:\n"
-            f'  "{reply_to_entry.text}"\n'
+            f"You decided to challenge speech [{direction.reply_to_entry.speech_id}] by {direction.reply_to_entry.agent}:\n"
+            f'  "{direction.reply_to_entry.text}"\n'
             f"Respond directly to this statement in your speech."
         )
-    if intended_co:
+    if direction.intended_co:
         if agent.role == "Werewolf":
             parts.append(
                 "\n--- YOUR CO DECISION ---\n"
@@ -267,7 +283,7 @@ def build_system_prompt(
                 f"Your speech MUST explicitly state that you are the {agent.role} (e.g. 'I am the {agent.role}'). "
                 f'Set "intent.co" to "{agent.role}" in your JSON output.'
             )
-    parts.append(build_output_format_prompt(lang))
+    parts.append(build_output_format_prompt(direction.lang))
     return "\n".join(parts)
 
 

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -178,9 +178,10 @@ class TestDiscussionCoDecision:
         ):
             engine._run_day()
 
-        # _do_speak should be called with force_co=False (ineligible)
-        _, kwargs = call_mock.call_args
-        assert kwargs.get("intended_co") is False or kwargs.get("intended_co") == seer.intended_co
+        # _do_speak should be called with force_co=False (ineligible): direction.intended_co == False
+        args, _ = call_mock.call_args
+        direction = args[2]
+        assert direction.intended_co is False
 
     def test_villager_co_treated_as_speak(self):
         """Villager cannot CO — co judgment falls back to speak."""
@@ -200,6 +201,6 @@ class TestDiscussionCoDecision:
         ):
             engine._run_day()
 
-        # force_co must be False for Villager
-        _, kwargs = call_mock.call_args
-        assert kwargs.get("intended_co") is False
+        # force_co must be False for Villager: direction.intended_co == False
+        args, _ = call_mock.call_args
+        assert args[2].intended_co is False

--- a/tests/unit/test_pre_night.py
+++ b/tests/unit/test_pre_night.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 from src.agent.state import AgentState, Persona
 from src.engine.game import GameEngine
 from src.engine.phase import Phase
-from src.llm.prompt import build_pre_night_prompt, build_system_prompt
+from src.llm.prompt import PublicContext, SpeechDirection, build_pre_night_prompt, build_system_prompt
 from src.llm.schema import PreNightOutput
 from src.logger.event import EventType, LogEvent
 from src.logger.writer import LogWriter
@@ -71,12 +71,14 @@ class TestBuildPreNightPrompt:
 class TestBuildSystemPromptIntendedCo:
     def test_no_intended_co_section_by_default(self):
         agent = _make_agent("Gina", "Seer")
-        prompt = build_system_prompt(agent, [], ["Gina", "SQ"], [], day=1)
+        ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
+        prompt = build_system_prompt(agent, ctx, SpeechDirection())
         assert "CO DECISION" not in prompt
 
     def test_seer_intended_co_adds_true_co_instruction(self):
         agent = _make_agent("Gina", "Seer")
-        prompt = build_system_prompt(agent, [], ["Gina", "SQ"], [], day=1, intended_co=True)
+        ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
+        prompt = build_system_prompt(agent, ctx, SpeechDirection(intended_co=True))
         assert "CO DECISION" in prompt
         assert "Seer" in prompt
         assert "intent.co" in prompt
@@ -85,7 +87,8 @@ class TestBuildSystemPromptIntendedCo:
 
     def test_werewolf_intended_co_adds_fake_co_instruction(self):
         agent = _make_agent("SQ", "Werewolf")
-        prompt = build_system_prompt(agent, [], ["Gina", "SQ"], [], day=1, intended_co=True)
+        ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
+        prompt = build_system_prompt(agent, ctx, SpeechDirection(intended_co=True))
         assert "CO DECISION" in prompt
         assert "Seer" in prompt  # instructs to claim Seer
         assert "intent.co" in prompt


### PR DESCRIPTION
## Summary
- `PublicContext` / `SpeechDirection` / `RoleSpecificContext` / `WolfSpecificContext` dataclass を `prompt.py` に追加
- `build_system_prompt` を 12 引数 → `(agent, ctx, direction, role_ctx)` の 4 引数に削減
- `build_public_info_prompt` も `PublicContext` を直接受け取るよう変更
- `client.py` の `call()` も同様に変更、`game.py` の呼び出し箇所を更新
- `DetailDesign.md` を新シグネチャに合わせて更新
- Issue #36 に Seer/Knight/Medium サブクラスの拡張方針をコメント追記

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス (51 passed)
- [x] `build_system_prompt` の `intended_co` / CO DECISION セクションの既存テスト通過確認
- [x] 手動動作確認済み

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)