### PR TITLE
refactor: add store.load_all_from_dir() to deduplicate _load_agents()

### DIFF
--- a/src/agent/store.py
+++ b/src/agent/store.py
@@ -22,10 +22,14 @@ def load(name: str) -> AgentState:
     return AgentState.model_validate(data)
 
 
-def load_all() -> list[AgentState]:
-    _ensure_dir()
+def load_all_from_dir(path: Path) -> list[AgentState]:
     agents = []
-    for path in sorted(STATE_DIR.glob("*.json")):
-        data = json.loads(path.read_text(encoding="utf-8"))
+    for p in sorted(path.glob("*.json")):
+        data = json.loads(p.read_text(encoding="utf-8"))
         agents.append(AgentState.model_validate(data))
     return agents
+
+
+def load_all() -> list[AgentState]:
+    _ensure_dir()
+    return load_all_from_dir(STATE_DIR)

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -12,6 +12,7 @@ import msvcrt
 from rich.console import Console
 from rich.text import Text
 
+from src.agent import store
 from src.agent.state import AgentState
 from src.logger.event import EventType, LogEvent
 from src.ui.renderer import render_event
@@ -96,12 +97,7 @@ class ReplayPager:
         self._lines = self._build_lines()
 
     def _load_agents(self) -> list[AgentState]:
-        agents_dir = self._archive / "agents"
-        agents = []
-        for path in sorted(agents_dir.glob("*.json")):
-            data = json.loads(path.read_text(encoding="utf-8"))
-            agents.append(AgentState.model_validate(data))
-        return agents
+        return store.load_all_from_dir(self._archive / "agents")
 
     def _load_events(self) -> list[LogEvent]:
         log_file = "spectator_log.jsonl" if self._spectator else "public_log.jsonl"

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1,0 +1,64 @@
+"""store モジュールのテスト。"""
+import json
+from pathlib import Path
+
+import pytest
+
+from src.agent.state import AgentState, Persona
+from src.agent import store
+
+
+def _make_agent_json(name: str, role: str) -> dict:
+    return AgentState(
+        name=name,
+        role=role,
+        persona=Persona(style="calm"),
+        beliefs={},
+        memory_summary=[],
+        is_alive=True,
+    ).model_dump()
+
+
+@pytest.fixture()
+def agents_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "agents"
+    d.mkdir()
+    (d / "alice.json").write_text(
+        json.dumps(_make_agent_json("Alice", "Villager")), encoding="utf-8"
+    )
+    (d / "bob.json").write_text(
+        json.dumps(_make_agent_json("Bob", "Werewolf")), encoding="utf-8"
+    )
+    return d
+
+
+def test_load_all_from_dir_returns_agents(agents_dir: Path) -> None:
+    """指定ディレクトリから AgentState を全件読み込めること。"""
+    agents = store.load_all_from_dir(agents_dir)
+    assert len(agents) == 2
+    names = {a.name for a in agents}
+    assert names == {"Alice", "Bob"}
+
+
+def test_load_all_from_dir_empty(tmp_path: Path) -> None:
+    """JSONが0件のディレクトリでは空リストを返すこと。"""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    assert store.load_all_from_dir(empty_dir) == []
+
+
+def test_load_all_delegates_to_load_all_from_dir(agents_dir: Path, monkeypatch) -> None:
+    """load_all() が load_all_from_dir(STATE_DIR) に委譲していること。"""
+    called_with: list[Path] = []
+
+    original = store.load_all_from_dir
+
+    def spy(path: Path) -> list[AgentState]:
+        called_with.append(path)
+        return original(path)
+
+    monkeypatch.setattr(store, "load_all_from_dir", spy)
+    monkeypatch.setattr(store, "STATE_DIR", agents_dir)
+
+    store.load_all()
+    assert called_with == [agents_dir]


### PR DESCRIPTION
## Summary
- `store.load_all_from_dir(path)` を追加し、glob → JSON parse → model_validate のロジックを一か所に集約
- `store.load_all()` を `load_all_from_dir(STATE_DIR)` の薄いラッパーに変更（後方互換維持）
- `replay.py` の `_load_agents()` を `store.load_all_from_dir()` 呼び出しに置き換え

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `test_store.py`: `load_all_from_dir` の正常系・空ディレクトリ・委譲確認

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)