### PR TITLE
refactor: add guard to build_role_prompt for wolf_partners

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -34,9 +34,7 @@
 
 | # | 優先度 | タイトル |
 |---|---|---|
-| yukkie/AgentVillage#37 | 🟡 | `build_system_prompt` のパラメータ過多 |
 | yukkie/AgentVillage#38 | 🟡 | `build_role_prompt` に guard がない |
-| yukkie/AgentVillage#39 | 🟡 | `_load_agents()` が `store.load_all()` と重複 |
 | yukkie/AgentVillage#40 | 🟢 | `_load_events()` の JSONL パースが重複しうる |
 | yukkie/AgentVillage#41 | 🟢 | 役職名がすべて文字列リテラル |
 | yukkie/AgentVillage#42 | 🟢 | CO 判断プロンプトの Werewolf / Madman ブロックが類似 |

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -88,6 +88,15 @@ def build_persona_prompt(agent: AgentState) -> str:
 
 def build_role_prompt(role: str, wolf_partners: list[str] | None = None) -> str:
     """Generate role-specific action guidelines."""
+    # TODO: remove this guard when Role class refactoring is done (#24)
+    if role == "Werewolf":
+        assert wolf_partners is not None, (
+            "wolf_partners must not be None for Werewolf (use [] if last surviving)"
+        )
+    else:
+        assert wolf_partners is None, (
+            f"wolf_partners must be None for non-Werewolf roles, got role={role!r}"
+        )
     if role == "Villager":
         return (
             "You are a Villager. Your goal is to identify and eliminate the Werewolf through "

--- a/tests/unit/test_pre_night.py
+++ b/tests/unit/test_pre_night.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 from src.agent.state import AgentState, Persona
 from src.engine.game import GameEngine
 from src.engine.phase import Phase
-from src.llm.prompt import PublicContext, SpeechDirection, build_pre_night_prompt, build_system_prompt
+from src.llm.prompt import PublicContext, SpeechDirection, WolfSpecificContext, build_pre_night_prompt, build_system_prompt
 from src.llm.schema import PreNightOutput
 from src.logger.event import EventType, LogEvent
 from src.logger.writer import LogWriter
@@ -88,7 +88,8 @@ class TestBuildSystemPromptIntendedCo:
     def test_werewolf_intended_co_adds_fake_co_instruction(self):
         agent = _make_agent("SQ", "Werewolf")
         ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
-        prompt = build_system_prompt(agent, ctx, SpeechDirection(intended_co=True))
+        role_ctx = WolfSpecificContext(wolf_partners=[])
+        prompt = build_system_prompt(agent, ctx, SpeechDirection(intended_co=True), role_ctx)
         assert "CO DECISION" in prompt
         assert "Seer" in prompt  # instructs to claim Seer
         assert "intent.co" in prompt

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.llm.prompt import build_role_prompt
+
+
+def test_build_role_prompt_wolf_partners_non_none_for_non_werewolf_raises():
+    with pytest.raises(AssertionError):
+        build_role_prompt("Seer", wolf_partners=["Alice"])
+
+
+def test_build_role_prompt_wolf_partners_none_for_werewolf_raises():
+    with pytest.raises(AssertionError):
+        build_role_prompt("Werewolf", wolf_partners=None)
+
+
+def test_build_role_prompt_wolf_partners_empty_for_werewolf_is_allowed():
+    result = build_role_prompt("Werewolf", wolf_partners=[])
+    assert "last surviving Werewolf" in result
+
+
+def test_build_role_prompt_wolf_partners_list_for_werewolf_is_allowed():
+    result = build_role_prompt("Werewolf", wolf_partners=["Bob"])
+    assert "Bob" in result


### PR DESCRIPTION
## Summary
- `build_role_prompt()` に assert ガードを追加: Werewolf は `wolf_partners` に `None` 不可、非 Werewolf は `None` 必須
- `test_pre_night.py` の Werewolf テストに `WolfSpecificContext` を正しく渡すよう修正
- `tests/unit/test_prompt.py` を新規作成（4ケース）
- `doc/Ideas.md` から完了済みの #37・#39 を削除

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（55 passed）
- [x] guard の AssertionError が正しく発火することをテストで確認

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)