### PR TITLE
refactor: extract load_events() to deduplicate JSONL parsing (#40)

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -166,7 +166,9 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 | モジュール | 責務 |
 |---|---|
 | `event.py` | ログイベントの型定義（発言・投票・死亡・夜行動など） |
-| `writer.py` | `public_log.jsonl`（全員公開）と `spectator_log.jsonl`（真実込み）への書き込み |
+| `logger.py` | 共通定数（`STATE_DIR`, `PUBLIC_LOG`, `SPECTATOR_LOG`, `ARCHIVE_DIR`）を一元管理。writer/reader が参照する |
+| `writer.py` | `public_log.jsonl`（全員公開）と `spectator_log.jsonl`（真実込み）への書き込み。定数は `logger.py` から import |
+| `reader.py` | `load_events(path: Path) -> list[LogEvent]` — JSONL ログの読み込みユーティリティ。GUI・リプレイ・将来の外部ツールが共通利用する |
 | `replay.py` | ログを読んで再生する（将来のリプレイUI用） |
 
 #### event.py — EventType 一覧

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -35,7 +35,6 @@
 | # | 優先度 | タイトル |
 |---|---|---|
 | yukkie/AgentVillage#38 | 🟡 | `build_role_prompt` に guard がない |
-| yukkie/AgentVillage#40 | 🟢 | `_load_events()` の JSONL パースが重複しうる |
 | yukkie/AgentVillage#41 | 🟢 | 役職名がすべて文字列リテラル |
 | yukkie/AgentVillage#42 | 🟢 | CO 判断プロンプトの Werewolf / Madman ブロックが類似 |
 | yukkie/AgentVillage#43 | 🟢 | replay.py のコメントが WHAT 説明になっている |

--- a/src/logger/logger.py
+++ b/src/logger/logger.py
@@ -1,0 +1,7 @@
+"""Shared constants for the logger package."""
+from pathlib import Path
+
+STATE_DIR = Path("state")
+PUBLIC_LOG = STATE_DIR / "public_log.jsonl"
+SPECTATOR_LOG = STATE_DIR / "spectator_log.jsonl"
+ARCHIVE_DIR = Path("state_archive")

--- a/src/logger/reader.py
+++ b/src/logger/reader.py
@@ -1,0 +1,20 @@
+"""JSONL log reading utilities shared across UI and future tooling."""
+import json
+from pathlib import Path
+
+from src.logger.event import LogEvent
+
+
+def load_events(path: Path) -> list[LogEvent]:
+    """Load all LogEvents from a JSONL file.
+
+    Returns an empty list if the file does not exist or is empty.
+    """
+    if not path.exists():
+        return []
+    events = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            events.append(LogEvent.model_validate(json.loads(line)))
+    return events

--- a/src/logger/writer.py
+++ b/src/logger/writer.py
@@ -3,11 +3,7 @@ from datetime import datetime
 from pathlib import Path
 
 from src.logger.event import LogEvent
-
-STATE_DIR = Path("state")
-PUBLIC_LOG = STATE_DIR / "public_log.jsonl"
-SPECTATOR_LOG = STATE_DIR / "spectator_log.jsonl"
-ARCHIVE_DIR = Path("state_archive")
+from src.logger.logger import ARCHIVE_DIR, PUBLIC_LOG, SPECTATOR_LOG, STATE_DIR
 
 
 def archive_state() -> Path | None:

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -1,7 +1,6 @@
 """Replay mode: archive selector UI + pager for JSONL log files."""
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import sys
@@ -15,6 +14,7 @@ from rich.text import Text
 from src.agent import store
 from src.agent.state import AgentState
 from src.logger.event import EventType, LogEvent
+from src.logger.reader import load_events
 from src.ui.renderer import render_event
 
 ARCHIVE_DIR = Path("state_archive")
@@ -101,15 +101,7 @@ class ReplayPager:
 
     def _load_events(self) -> list[LogEvent]:
         log_file = "spectator_log.jsonl" if self._spectator else "public_log.jsonl"
-        path = self._archive / log_file
-        if not path.exists():
-            return []
-        events = []
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line:
-                events.append(LogEvent.model_validate(json.loads(line)))
-        return events
+        return load_events(self._archive / log_file)
 
     def _build_lines(self) -> list[str]:
         width = shutil.get_terminal_size().columns

--- a/tests/unit/test_logger_reader.py
+++ b/tests/unit/test_logger_reader.py
@@ -1,0 +1,57 @@
+"""Unit tests for src/logger/reader.py — load_events()."""
+from pathlib import Path
+
+from src.logger.event import EventType, LogEvent
+from src.logger.reader import load_events
+
+
+def _make_event(day: int = 1, content: str = "hello") -> LogEvent:
+    return LogEvent.make(
+        day=day,
+        phase="day_opening",
+        event_type=EventType.SPEECH,
+        agent="Alice",
+        content=content,
+        is_public=True,
+    )
+
+
+def test_load_events_returns_empty_for_missing_file(tmp_path: Path) -> None:
+    result = load_events(tmp_path / "nonexistent.jsonl")
+    assert result == []
+
+
+def test_load_events_returns_empty_for_empty_file(tmp_path: Path) -> None:
+    p = tmp_path / "log.jsonl"
+    p.write_text("", encoding="utf-8")
+    assert load_events(p) == []
+
+
+def test_load_events_parses_single_event(tmp_path: Path) -> None:
+    event = _make_event()
+    p = tmp_path / "log.jsonl"
+    p.write_text(event.model_dump_json() + "\n", encoding="utf-8")
+
+    result = load_events(p)
+    assert len(result) == 1
+    assert result[0].agent == "Alice"
+    assert result[0].event_type == EventType.SPEECH
+
+
+def test_load_events_parses_multiple_events(tmp_path: Path) -> None:
+    events = [_make_event(day=i, content=f"msg {i}") for i in range(1, 4)]
+    p = tmp_path / "log.jsonl"
+    p.write_text("\n".join(e.model_dump_json() for e in events), encoding="utf-8")
+
+    result = load_events(p)
+    assert len(result) == 3
+    assert [r.day for r in result] == [1, 2, 3]
+
+
+def test_load_events_skips_blank_lines(tmp_path: Path) -> None:
+    event = _make_event()
+    p = tmp_path / "log.jsonl"
+    p.write_text(f"\n{event.model_dump_json()}\n\n", encoding="utf-8")
+
+    result = load_events(p)
+    assert len(result) == 1


### PR DESCRIPTION
## Summary
- `src/logger/logger.py` を新設し、PATH定数を一元管理
- `src/logger/reader.py` を新設し、`load_events(path)` を共通ユーティリティとして定義
- `writer.py` は定数を `logger.py` から import するよう変更
- `replay.py` の inline JSONL パースを `load_events()` 1行呼び出しに置き換え
- `load_events()` のユニットテスト5件追加

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` 63件全通過
- [x] 欠損ファイル・空ファイル・空行スキップの各ケースをテストで確認

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)