### PR TITLE
refactor: remove WHAT comment from replay._build_lines

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | タイトル | 内容 |
 |---|---|---|---|---|
 | yukkie/AgentVillage#52 | tech-debt | 🔴 | Consolidate Pydantic domain models | Pydanticモデルを src/domain/ に集約し責務境界を明確化 |
-| yukkie/AgentVillage#43 | tech-debt | 🔴 | replay.py: remove WHAT comments | WHY コメントのみ残し WHAT コメントは削除 |
 | yukkie/AgentVillage#24 | enhancement | 🟡 | Role class refactoring | Strategy パターンで役職クラス化 |
 | yukkie/AgentVillage#21 | enhancement | 🟡 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#41 | tech-debt | 🟢 | Replace role string literals | タイポ時に実行時エラーにならない。#24 のRole化で定数に集約 |

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -115,7 +115,6 @@ class ReplayPager:
 
         all_lines: list[str] = []
         for event in events:
-            # Update claimed_role in real time when a CO is announced.
             # Use event.claimed_role (structured field) rather than parsing content text.
             if event.event_type == EventType.CO_ANNOUNCEMENT and event.agent and event.claimed_role:
                 if event.agent in dynamic_agents:


### PR DESCRIPTION
## Summary
- `_build_lines()` 内の「Update claimed_role in real time when a CO is announced.」を削除
- WHY コメント（structured field を使う理由、end-of-game state を避ける理由）は保持

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` 63件パス

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)