### PR TITLE
docs: remove issue #42 from Ideas.md (resolved in #24)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -18,7 +18,6 @@
 | yukkie/AgentVillage#58 | tech-debt | 🟢 | Split GameEngine phases into dedicated modules | game.py を前夜・昼・夜フェーズモジュールに分割 |
 | yukkie/AgentVillage#21 | enhancement | 🟡 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#41 | tech-debt | 🟢 | Replace role string literals | タイポ時に実行時エラーにならない。#24 のRole化で定数に集約 |
-| yukkie/AgentVillage#42 | tech-debt | 🟢 | Merge similar CO prompt blocks | Werewolf/Madman の類似ブロックを統合。#24 の副産物として解消 |
 | yukkie/AgentVillage#33 | enhancement | 🟢 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#36 | enhancement | 🟢 | Belief updates from agent reasoning | suspicion/trust を推理結果から更新 |
 | yukkie/AgentVillage#47 | enhancement | 🟢 | Reasoning field for Vote/Guard/Divination/Judgment | 各アクションに reasoning を追加し spectator ログ・memory_update に記録 |


### PR DESCRIPTION
## Summary
- Issue #42 (Merge similar CO prompt blocks for Werewolf/Madman) was already resolved as part of #24 (Role class refactoring)
- `build_system_prompt()` already delegates to `get_role(agent.role).co_prompt()`
- Werewolf and Madman both have their own `co_prompt()` implementations in their Role classes
- Closing the issue and removing it from Ideas.md

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)