### PR TITLE
refactor: replace msvcrt with cross-platform readchar in replay.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "anthropic>=0.50.0",
     "pydantic>=2.0.0",
+    "readchar>=4.0.0",
     "rich>=13.0.0",
     "python-dotenv>=1.0.0",
 ]

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -7,7 +7,7 @@ import sys
 from io import StringIO
 from pathlib import Path
 
-import msvcrt
+import readchar
 from rich.console import Console
 from rich.text import Text
 
@@ -21,16 +21,15 @@ ARCHIVE_DIR = Path("state_archive")
 
 
 def _getch() -> str:
-    """Read a single keypress from the terminal (Windows msvcrt)."""
-    ch = msvcrt.getch()
-    if ch in (b"\x00", b"\xe0"):
-        ch2 = msvcrt.getch()
-        mapping = {b"H": "UP", b"P": "DOWN", b"K": "LEFT", b"M": "RIGHT"}
-        return mapping.get(ch2, "UNKNOWN")
-    try:
-        return ch.decode("utf-8")
-    except Exception:
-        return ""
+    """Read a single keypress from the terminal (cross-platform)."""
+    key = readchar.readkey()
+    mapping = {
+        readchar.key.UP: "UP",
+        readchar.key.DOWN: "DOWN",
+        readchar.key.LEFT: "LEFT",
+        readchar.key.RIGHT: "RIGHT",
+    }
+    return mapping.get(key, key)
 
 
 def _clear() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "readchar" },
     { name = "rich" },
 ]
 
@@ -24,6 +25,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.50.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "readchar", specifier = ">=4.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
 ]
 
@@ -390,6 +392,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "readchar"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/49/a10341024c45bed95d13197ec9ef0f4e2fd10b5ca6e7f8d7684d18082398/readchar-4.2.2.tar.gz", hash = "sha256:e3b270fe16fc90c50ac79107700330a133dd4c63d22939f5b03b4f24564d5dd8", size = 9762, upload-time = "2026-04-06T19:45:54.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ca/36133653e00939922dd1416f4c56177361289172a30563fcb9552c9ccde4/readchar-4.2.2-py3-none-any.whl", hash = "sha256:92daf7e42c52b0787e6c75d01ecfb9a94f4ceff3764958b570c1dddedd47b200", size = 9401, upload-time = "2026-04-06T19:45:52.993Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `replay.py` の Windows 専用 `msvcrt` を `readchar` ライブラリに置き換え
- `_getch()` のインターフェース（"UP"/"DOWN" 等の文字列返却）を維持したため呼び出し側の変更なし
- `pyproject.toml` に `readchar>=4.0.0` を追加

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` 全106件パス

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)