### PR TITLE
refactor: introduce Actor class and rename AgentState to ActorState (#68)

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -79,7 +79,8 @@ LLMの出力は自然文のパースに頼らず、常にPydanticモデルで検
 
 - エージェントの状態（役職・信念・記憶・人格パラメータ）を管理
 - 状態は `state/agents/{name}.json` に永続化
-- Pydanticモデルは `src/domain/agent.py` で定義（`AgentState`, `Belief`, `Persona`）
+- Pydanticモデルは `src/domain/actor.py` で定義（`ActorState`, `Belief`, `Persona`）
+- ランタイムラッパー `Actor`（dataclass）は `state: ActorState` と `role: Role` を持つ。永続化対象は `ActorState` のみ
 
 #### Persona フィールド
 
@@ -98,11 +99,11 @@ LLMの出力は自然文のパースに頼らず、常にPydanticモデルで検
 
 #### claimed_role（公開役職）と intended_co（前夜CO意思）
 
-`AgentState` に以下のフィールドを持つ。
+`ActorState` に以下のフィールドを持つ。
 
 | フィールド | 内容 |
 |---|---|
-| `role` | 真の役職（システム管理。LLMには渡さない） |
+| `role` | 真の役職文字列（システム管理。LLMには渡さない。ランタイムでは `Actor.role`（Role instance）を使う） |
 | `claimed_role` | エージェントが公言した役職（CO済みなら設定。未COはNull） |
 | `intended_co` | 前夜ターンで「初日COする」と決めた場合 `True`（Day 1 OPENINGプロンプトに反映後は参照不要） |
 

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -43,7 +43,7 @@
 
 | モジュール | 責務 |
 |---|---|
-| `agent.py` | `AgentState`, `Belief`, `Persona` のPydanticモデル定義 |
+| `actor.py` | `ActorState`, `Belief`, `Persona` のPydanticモデル定義 + `Actor` dataclass（`state: ActorState`, `role: Role`） |
 | `event.py` | `EventType`, `LogEvent` のPydanticモデル定義 |
 | `role.py` | `Role` ABC + 具象クラス（Villager, Werewolf, Seer, Knight, Medium, Madman）+ `get_role()` ファクトリ。役職の定義を一箇所に集約する |
 | `schema.py` | `AgentOutput`, `SpeechEntry`, `JudgmentOutput` 等のPydanticモデル定義 |
@@ -85,6 +85,16 @@ def get_role(role: str) -> Role:
 | `memory.py` | 短期・中期・長期記憶の更新ロジック |
 | `belief.py` | 疑い・信頼スコアの更新（`memory_update` を受けて反映） |
 | `store.py` | JSONファイルへのread/write |
+
+### Actor と ActorState の分離
+
+`Actor`（dataclass）はランタイムのみで使われる：
+- `state: ActorState` — JSON 永続化される Pydantic モデル
+- `role: Role` — 役職 Strategy インスタンス（`get_role(state.role)` で構築）
+- 便利 property: `name`（`state.name`）、`is_alive`（`state.is_alive`）
+- 永続化は `state` のみ。`store.save(actor)` は `actor.state` を書き出す
+
+`Actor.role` により `get_role(agent.role)` の繰り返し呼び出しが不要になる。
 
 ### エージェント状態JSONスキーマ例
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | タイトル | 内容 |
 |---|---|---|---|---|
-| yukkie/AgentVillage#68 | tech-debt | 🟢 | Introduce Actor class; rename AgentState to ActorState | Actor(state: ActorState, role: Role) を導入。AgentState を ActorState にリネーム。#66 の前提 |
 | yukkie/AgentVillage#66 | tech-debt | 🟢 | Add color property to Role classes and resolve MEDIUM_RESULT color mismatch | Role クラスに color プロパティ追加・renderer.py の _ROLE_COLORS 廃止（#68 完了後に着手） |
 | yukkie/AgentVillage#61 | tech-debt | 🟢 | Move common prompt content to Role ABC default methods | prompt.py のコンテンツ文字列を Role ABC のデフォルトメソッドに移動し、prompt.py をアセンブルのみに |
 | yukkie/AgentVillage#59 | tech-debt | 🟢 | Replace msvcrt with cross-platform key input | replay.py の Windows 専用 msvcrt をクロスプラットフォーム対応に置換 |

--- a/src/action/resolver.py
+++ b/src/action/resolver.py
@@ -1,28 +1,29 @@
 from src.action.types import Vote, Inspect, Attack, CO
-from src.domain.agent import AgentState
+from src.domain.actor import Actor
+from src.domain.roles import Werewolf
 
 ActionType = Vote | Inspect | Attack | CO
 
 
-def resolve_vote(action: Vote, agents: list[AgentState]) -> str:
+def resolve_vote(action: Vote, agents: list[Actor]) -> str:
     """Return the target of the vote (validated externally)."""
     return action.target
 
 
-def resolve_inspect(action: Inspect, agents: list[AgentState]) -> tuple[str, str]:
+def resolve_inspect(action: Inspect, agents: list[Actor]) -> tuple[str, str]:
     """
     Resolve a Seer's inspect action.
     Returns (target_name, result) where result is "Werewolf" or "Not Werewolf".
     The Seer only learns alignment, not the specific role.
     """
-    for agent in agents:
-        if agent.name == action.target:
-            result = "Werewolf" if agent.role == "Werewolf" else "Not Werewolf"
-            return (agent.name, result)
+    for actor in agents:
+        if actor.name == action.target:
+            result = "Werewolf" if isinstance(actor.role, Werewolf) else "Not Werewolf"
+            return (actor.name, result)
     return (action.target, "Unknown")
 
 
-def resolve_attack(action: Attack, agents: list[AgentState]) -> str:
+def resolve_attack(action: Attack, agents: list[Actor]) -> str:
     """
     Resolve a Werewolf's attack action.
     Returns the name of the attacked player.
@@ -30,7 +31,7 @@ def resolve_attack(action: Attack, agents: list[AgentState]) -> str:
     return action.target
 
 
-def resolve_co(action: CO, actor: AgentState) -> str:
+def resolve_co(action: CO, actor: Actor) -> str:
     """
     Resolve a CO (Coming Out) action.
     Returns the claimed role.

--- a/src/action/validator.py
+++ b/src/action/validator.py
@@ -1,10 +1,11 @@
 from src.action.types import Vote, Inspect, Attack, CO
-from src.domain.agent import AgentState
+from src.domain.actor import Actor
+from src.domain.roles import Seer, Werewolf
 
 ActionType = Vote | Inspect | Attack | CO
 
 
-def validate(action: ActionType, actor: AgentState, alive_players: list[str]) -> bool:
+def validate(action: ActionType, actor: Actor, alive_players: list[str]) -> bool:
     """
     Validate that an action is legal given the current game state.
     Returns True if the action is valid, False otherwise.
@@ -15,13 +16,13 @@ def validate(action: ActionType, actor: AgentState, alive_players: list[str]) ->
 
     elif isinstance(action, Inspect):
         # Only Seer can inspect
-        if actor.role != "Seer":
+        if not isinstance(actor.role, Seer):
             return False
         return action.target in alive_players and action.target != actor.name
 
     elif isinstance(action, Attack):
         # Only Werewolf can attack
-        if actor.role != "Werewolf":
+        if not isinstance(actor.role, Werewolf):
             return False
         return action.target in alive_players and action.target != actor.name
 

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -1,11 +1,11 @@
-from src.domain.agent import AgentState
+from src.domain.actor import Actor
 from src.agent import store
 
 
-def update_memory(agent: AgentState, memory_updates: list[str]) -> AgentState:
-    """Append memory_updates to agent's memory_summary and persist."""
+def update_memory(actor: Actor, memory_updates: list[str]) -> Actor:
+    """Append memory_updates to actor's memory_summary and persist."""
     for item in memory_updates:
-        if item and item not in agent.memory_summary:
-            agent.memory_summary.append(item)
-    store.save(agent)
-    return agent
+        if item and item not in actor.state.memory_summary:
+            actor.state.memory_summary.append(item)
+    store.save(actor)
+    return actor

--- a/src/agent/store.py
+++ b/src/agent/store.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from src.domain.agent import AgentState
+from src.domain.actor import Actor, ActorState, make_actor
 
 STATE_DIR = Path("state/agents")
 
@@ -10,26 +10,26 @@ def _ensure_dir() -> None:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def save(agent: AgentState) -> None:
+def save(actor: Actor) -> None:
     _ensure_dir()
-    path = STATE_DIR / f"{agent.name.lower()}.json"
-    path.write_text(agent.model_dump_json(indent=2), encoding="utf-8")
+    path = STATE_DIR / f"{actor.name.lower()}.json"
+    path.write_text(actor.state.model_dump_json(indent=2), encoding="utf-8")
 
 
-def load(name: str) -> AgentState:
+def load(name: str) -> Actor:
     path = STATE_DIR / f"{name.lower()}.json"
     data = json.loads(path.read_text(encoding="utf-8"))
-    return AgentState.model_validate(data)
+    return make_actor(ActorState.model_validate(data))
 
 
-def load_all_from_dir(path: Path) -> list[AgentState]:
-    agents = []
+def load_all_from_dir(path: Path) -> list[Actor]:
+    actors = []
     for p in sorted(path.glob("*.json")):
         data = json.loads(p.read_text(encoding="utf-8"))
-        agents.append(AgentState.model_validate(data))
-    return agents
+        actors.append(make_actor(ActorState.model_validate(data)))
+    return actors
 
 
-def load_all() -> list[AgentState]:
+def load_all() -> list[Actor]:
     _ensure_dir()
     return load_all_from_dir(STATE_DIR)

--- a/src/domain/actor.py
+++ b/src/domain/actor.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from src.domain.roles import Role, get_role
+
+
+class Persona(BaseModel):
+    style: str
+    lie_tendency: float = 0.2
+    aggression: float = 0.3
+    gender: str | None = None
+    age: str | None = None
+    speech_style: str = "casual"
+
+
+class Belief(BaseModel):
+    suspicion: float = 0.5
+    trust: float = 0.5
+    reason: list[str] = []
+
+
+class ActorState(BaseModel):
+    name: str
+    role: str  # "Villager" | "Werewolf" | "Seer"
+    model: str = "claude-haiku-4-5-20251001"
+    persona: Persona
+    beliefs: dict[str, Belief] = {}
+    memory_summary: list[str] = []
+    is_alive: bool = True
+    claimed_role: str | None = None  # publicly claimed role via CO; None until CO
+    intended_co: bool = False  # set True by pre-night phase if agent decided to CO on Day 1
+
+
+@dataclass
+class Actor:
+    state: ActorState
+    role: Role
+
+    @property
+    def name(self) -> str:
+        return self.state.name
+
+    @property
+    def is_alive(self) -> bool:
+        return self.state.is_alive
+
+
+def make_actor(state: ActorState) -> Actor:
+    """Construct an Actor from an ActorState by resolving its role."""
+    return Actor(state=state, role=get_role(state.role))

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -1,7 +1,7 @@
 import random
 from typing import Callable
 
-from src.domain.agent import AgentState, Belief
+from src.domain.actor import Actor, Belief
 from src.agent import store, memory as memory_mod
 from src.engine.phase import Phase
 from src.engine.vote import tally_votes
@@ -13,13 +13,14 @@ from src.action.types import Vote, Inspect, Attack
 from src.action.validator import validate
 from src.action.resolver import resolve_inspect, resolve_attack
 from src.domain.event import LogEvent, EventType
+from src.domain.roles import Werewolf, Knight, Seer, Medium
 from src.logger.writer import LogWriter
 
 
 class GameEngine:
     def __init__(
         self,
-        agents: list[AgentState],
+        agents: list[Actor],
         log_writer: LogWriter,
         event_callback: Callable[[LogEvent], None] | None = None,
         lang: str = "English",
@@ -42,7 +43,7 @@ class GameEngine:
         self.log_writer.write(event)
         self.event_callback(event)
 
-    def _alive_agents(self) -> list[AgentState]:
+    def _alive_agents(self) -> list[Actor]:
         return [a for a in self.agents if a.is_alive]
 
     def _alive_names(self) -> list[str]:
@@ -51,17 +52,17 @@ class GameEngine:
     def _dead_names(self) -> list[str]:
         return [a.name for a in self.agents if not a.is_alive]
 
-    def _get_agent(self, name: str) -> AgentState | None:
+    def _get_agent(self, name: str) -> Actor | None:
         for a in self.agents:
             if a.name == name:
                 return a
         return None
 
     def _eliminate(self, name: str, event_type: EventType, phase_str: str) -> None:
-        agent = self._get_agent(name)
-        if agent:
-            agent.is_alive = False
-            store.save(agent)
+        actor = self._get_agent(name)
+        if actor:
+            actor.state.is_alive = False
+            store.save(actor)
             if event_type == EventType.NIGHT_ATTACK:
                 content = f"Werewolves attacked {name}! {name} was found dead at dawn."
                 cause = "attack"
@@ -136,15 +137,15 @@ class GameEngine:
 
     def _do_speak(
         self,
-        agent: AgentState,
+        actor: Actor,
         phase: Phase,
         reply_to_entry: SpeechEntry | None = None,
         force_co: bool = False,
     ) -> SpeechEntry:
-        """Generate a speech for agent, emit events, update memory, and append to today_log.
+        """Generate a speech for actor, emit events, update memory, and append to today_log.
 
         force_co=True injects the CO instruction into the speech prompt without mutating
-        agent.intended_co. Used when the agent chose "co" in the discussion judgment phase.
+        actor.state.intended_co. Used when the actor chose "co" in the discussion judgment phase.
         """
         ctx = PublicContext(
             today_log=list(self.today_log),
@@ -158,51 +159,51 @@ class GameEngine:
         direction = SpeechDirection(
             lang=self.lang,
             reply_to_entry=reply_to_entry,
-            intended_co=agent.intended_co or force_co,
+            intended_co=actor.state.intended_co or force_co,
         )
         # TODO(#36): Add SeerSpecificContext / KnightSpecificContext / MediumSpecificContext
         role_ctx = (
             WolfSpecificContext(
-                wolf_partners=[a.name for a in self._alive_agents() if a.role == "Werewolf" and a.name != agent.name]
+                wolf_partners=[a.name for a in self._alive_agents() if isinstance(a.role, Werewolf) and a.name != actor.name]
             )
-            if agent.role == "Werewolf"
+            if isinstance(actor.role, Werewolf)
             else None
         )
-        output = llm_client.call(agent, ctx, direction, role_ctx)
-        self._day_outputs[agent.name] = output
+        output = llm_client.call(actor, ctx, direction, role_ctx)
+        self._day_outputs[actor.name] = output
 
         # Safety net: enforce pre-night CO decision on the opening speech.
         # Werewolf and Madman fall back to "Seer" (fake CO); others use their true role.
-        if agent.intended_co and phase == Phase.DAY_OPENING and not output.intent.co:
-            output.intent.co = "Seer" if agent.role in ("Werewolf", "Madman") else agent.role
+        if actor.state.intended_co and phase == Phase.DAY_OPENING and not output.intent.co:
+            output.intent.co = "Seer" if isinstance(actor.role, (Werewolf,)) else actor.role.name
 
         # Update claimed_role BEFORE emitting the speech so the CO speech itself
         # is rendered with the correct role color.
         # Only emit CO_ANNOUNCEMENT when the claimed role actually changes
         # (prevents duplicate announcements when LLM spontaneously repeats intent.co).
-        if output.intent.co and output.intent.co != agent.claimed_role:
-            agent.claimed_role = output.intent.co
-            agent.intended_co = False  # clear once CO is made
-            store.save(agent)
+        if output.intent.co and output.intent.co != actor.state.claimed_role:
+            actor.state.claimed_role = output.intent.co
+            actor.state.intended_co = False  # clear once CO is made
+            store.save(actor)
             self._emit(LogEvent.make(
                 day=self.day,
                 phase=phase.value,
                 event_type=EventType.CO_ANNOUNCEMENT,
-                agent=agent.name,
-                content=f"{agent.name} claims to be {agent.claimed_role}",
+                agent=actor.name,
+                content=f"{actor.name} claims to be {actor.state.claimed_role}",
                 is_public=True,
-                claimed_role=agent.claimed_role,
+                claimed_role=actor.state.claimed_role,
             ))
 
         speech_id = self._next_speech_id()
-        entry = SpeechEntry(speech_id=speech_id, agent=agent.name, text=output.speech)
+        entry = SpeechEntry(speech_id=speech_id, agent=actor.name, text=output.speech)
         self.today_log.append(entry)
 
         self._emit(LogEvent.make(
             day=self.day,
             phase=phase.value,
             event_type=EventType.SPEECH,
-            agent=agent.name,
+            agent=actor.name,
             content=output.speech,
             is_public=True,
             speech_id=speech_id,
@@ -212,14 +213,14 @@ class GameEngine:
             day=self.day,
             phase=phase.value,
             event_type=EventType.SPEECH,
-            agent=agent.name,
+            agent=actor.name,
             content=f"[THINK] {output.thought}",
             is_public=False,
             speech_id=speech_id,
         ))
 
         if output.memory_update:
-            memory_mod.update_memory(agent, output.memory_update)
+            memory_mod.update_memory(actor, output.memory_update)
 
         return entry
 
@@ -229,25 +230,26 @@ class GameEngine:
         Only runs once at game start. Results logged as spectator-only.
         Filter: role != "Villager" — covers Seer (true CO) and Werewolf (fake CO as Seer).
         """
-        targets = [a for a in self._alive_agents() if a.role != "Villager"]
+        from src.domain.roles import Villager
+        targets = [a for a in self._alive_agents() if not isinstance(a.role, Villager)]
         if not targets:
             return
 
         self._phase_start(Phase.PRE_NIGHT)
 
-        for agent, output in llm_client.call_pre_night_parallel(
+        for actor, output in llm_client.call_pre_night_parallel(
             targets, self._alive_names(), self.lang, self.agents
         ):
-            agent.intended_co = output.decision == "co"
-            memory_mod.update_memory(agent, [f"Pre-game decision: {output.reasoning}"])
+            actor.state.intended_co = output.decision == "co"
+            memory_mod.update_memory(actor, [f"Pre-game decision: {output.reasoning}"])
 
-            decision_label = "decided to CO" if agent.intended_co else "decided to wait"
+            decision_label = "decided to CO" if actor.state.intended_co else "decided to wait"
             self._emit(LogEvent.make(
                 day=self.day,
                 phase=Phase.PRE_NIGHT.value,
                 event_type=EventType.PRE_NIGHT_DECISION,
-                agent=agent.name,
-                content=f"{agent.name} ({agent.role}) {decision_label}. Reasoning: {output.reasoning}",
+                agent=actor.name,
+                content=f"{actor.name} ({actor.role.name}) {decision_label}. Reasoning: {output.reasoning}",
                 is_public=False,
             ))
 
@@ -260,8 +262,8 @@ class GameEngine:
 
         opening_order = self._alive_agents()
         random.shuffle(opening_order)
-        for agent in opening_order:
-            self._do_speak(agent, Phase.DAY_OPENING)
+        for actor in opening_order:
+            self._do_speak(actor, Phase.DAY_OPENING)
 
         # --- DISCUSSION × 2: 並列判断 → レスポンス順発言 ---
         self.phase = Phase.DAY_DISCUSSION
@@ -272,7 +274,7 @@ class GameEngine:
             judgment_snapshot = list(self.today_log)
             spoke_anyone = False
 
-            for agent, judgment in llm_client.call_judgment_parallel(
+            for actor, judgment in llm_client.call_judgment_parallel(
                 alive, judgment_snapshot, self._alive_names(), self.day, self.lang
             ):
                 if judgment.decision == "silent":
@@ -280,8 +282,8 @@ class GameEngine:
                         day=self.day,
                         phase=Phase.DAY_DISCUSSION.value,
                         event_type=EventType.SPEECH,
-                        agent=agent.name,
-                        content=f"{agent.name} is watching the village silently...",
+                        agent=actor.name,
+                        content=f"{actor.name} is watching the village silently...",
                         is_public=True,
                     ))
                     continue
@@ -289,7 +291,8 @@ class GameEngine:
 
                 # "co" is only valid for agents that have not yet claimed a role
                 # and are not a plain Villager. Fall back to "speak" if ineligible.
-                is_co_eligible = agent.claimed_role is None and agent.role != "Villager"
+                from src.domain.roles import Villager
+                is_co_eligible = actor.state.claimed_role is None and not isinstance(actor.role, Villager)
                 force_co = judgment.decision == "co" and is_co_eligible
 
                 reply_to_entry: SpeechEntry | None = None
@@ -299,7 +302,7 @@ class GameEngine:
                         None,
                     )
 
-                self._do_speak(agent, Phase.DAY_DISCUSSION, reply_to_entry=reply_to_entry, force_co=force_co)
+                self._do_speak(actor, Phase.DAY_DISCUSSION, reply_to_entry=reply_to_entry, force_co=force_co)
 
             if not spoke_anyone:
                 break  # 全員silentなら2巡目はスキップ
@@ -311,8 +314,8 @@ class GameEngine:
         votes: dict[str, str] = {}
         alive_names = self._alive_names()
 
-        for agent in self._alive_agents():
-            output = self._day_outputs.get(agent.name)
+        for actor in self._alive_agents():
+            output = self._day_outputs.get(actor.name)
             target = None
 
             if output and output.intent.vote_candidates:
@@ -322,25 +325,25 @@ class GameEngine:
                     reverse=True,
                 )
                 for vc in sorted_candidates:
-                    if vc.target in alive_names and vc.target != agent.name:
+                    if vc.target in alive_names and vc.target != actor.name:
                         target = vc.target
                         break
 
             if target is None:
-                others = [n for n in alive_names if n != agent.name]
+                others = [n for n in alive_names if n != actor.name]
                 target = others[0] if others else None
 
             if target:
                 vote_action = Vote(target=target)
-                if validate(vote_action, agent, alive_names):
-                    votes[agent.name] = target
+                if validate(vote_action, actor, alive_names):
+                    votes[actor.name] = target
                     self._emit(LogEvent.make(
                         day=self.day,
                         phase=Phase.DAY_VOTE.value,
                         event_type=EventType.VOTE,
-                        agent=agent.name,
+                        agent=actor.name,
                         target=target,
-                        content=f"{agent.name} votes for {target}",
+                        content=f"{actor.name} votes for {target}",
                         is_public=True,
                     ))
 
@@ -350,11 +353,11 @@ class GameEngine:
             self._eliminate(eliminated, EventType.ELIMINATION, Phase.DAY_VOTE.value)
 
             # Notify Medium of the executed player's alignment (Werewolf or Not Werewolf)
-            medium = next((a for a in self._alive_agents() if a.role == "Medium"), None)
+            medium = next((a for a in self._alive_agents() if isinstance(a.role, Medium)), None)
             if medium:
-                executed_agent = self._get_agent(eliminated)
-                if executed_agent:
-                    result = "Werewolf" if executed_agent.role == "Werewolf" else "Not Werewolf"
+                executed_actor = self._get_agent(eliminated)
+                if executed_actor:
+                    result = "Werewolf" if isinstance(executed_actor.role, Werewolf) else "Not Werewolf"
                     memory_mod.update_memory(
                         medium,
                         [f"Day {self.day}: {eliminated} was executed, they were {result}"],
@@ -383,7 +386,7 @@ class GameEngine:
         guard_target: str | None = None
 
         # --- ① 狼同士の会話（最大3往復） ---
-        wolves = [a for a in self._alive_agents() if a.role == "Werewolf"]
+        wolves = [a for a in self._alive_agents() if isinstance(a.role, Werewolf)]
         if len(wolves) >= 2:
             self.phase = Phase.NIGHT_WOLF_CHAT
             self._phase_start(Phase.NIGHT_WOLF_CHAT)
@@ -426,12 +429,12 @@ class GameEngine:
 
         # --- ② 狼単体フォールバック（チャットで合意できなかった場合） ---
         if attack_target is None:
-            for agent in self._alive_agents():
-                if agent.role != "Werewolf":
+            for actor in self._alive_agents():
+                if not isinstance(actor.role, Werewolf):
                     continue
-                target_name = llm_client.call_night_action(agent, night_context, alive_names)
+                target_name = llm_client.call_night_action(actor, night_context, alive_names)
                 attack = Attack(target=target_name)
-                if validate(attack, agent, alive_names):
+                if validate(attack, actor, alive_names):
                     attack_target = resolve_attack(attack, self.agents)
                     break
 
@@ -447,31 +450,31 @@ class GameEngine:
             ))
 
         # --- ③ 全役職が行動意思を決定（騎士・占い師） ---
-        seer_inspect: tuple[AgentState, Inspect] | None = None  # (seer, inspect_action)
+        seer_inspect: tuple[Actor, Inspect] | None = None  # (seer, inspect_action)
 
-        knight: AgentState | None = None
-        for agent in self._alive_agents():
-            if agent.role == "Knight":
-                knight = agent
-                target_name = llm_client.call_night_action(agent, night_context, alive_names)
-                candidates = [n for n in alive_names if n != agent.name]
+        knight: Actor | None = None
+        for actor in self._alive_agents():
+            if isinstance(actor.role, Knight):
+                knight = actor
+                target_name = llm_client.call_night_action(actor, night_context, alive_names)
+                candidates = [n for n in alive_names if n != actor.name]
                 if target_name in candidates:
                     guard_target = target_name
                     self._emit(LogEvent.make(
                         day=self.day,
                         phase=Phase.NIGHT.value,
                         event_type=EventType.GUARD,
-                        agent=agent.name,
+                        agent=actor.name,
                         target=guard_target,
-                        content=f"{agent.name} guards {guard_target}",
+                        content=f"{actor.name} guards {guard_target}",
                         is_public=False,
                     ))
 
-            elif agent.role == "Seer":
-                target_name = llm_client.call_night_action(agent, night_context, alive_names)
+            elif isinstance(actor.role, Seer):
+                target_name = llm_client.call_night_action(actor, night_context, alive_names)
                 inspect = Inspect(target=target_name)
-                if validate(inspect, agent, alive_names):
-                    seer_inspect = (agent, inspect)  # 結果適用は後回し
+                if validate(inspect, actor, alive_names):
+                    seer_inspect = (actor, inspect)  # 結果適用は後回し
 
         # --- ④ 解決フェーズ ---
         # 騎士の護衛判定 → 狼の襲撃判定 → 占い師の占い判定
@@ -511,16 +514,16 @@ class GameEngine:
         if seer_inspect and seer_survived:
             seer, inspect = seer_inspect
             name, result = resolve_inspect(inspect, self.agents)
-            if name not in seer.beliefs:
-                seer.beliefs[name] = Belief()
+            if name not in seer.state.beliefs:
+                seer.state.beliefs[name] = Belief()
             if result == "Werewolf":
-                seer.beliefs[name].suspicion = 1.0
-                seer.beliefs[name].trust = 0.0
-                seer.beliefs[name].reason.append(f"Day {self.day}: inspected as Werewolf")
+                seer.state.beliefs[name].suspicion = 1.0
+                seer.state.beliefs[name].trust = 0.0
+                seer.state.beliefs[name].reason.append(f"Day {self.day}: inspected as Werewolf")
             else:
-                seer.beliefs[name].suspicion = 0.0
-                seer.beliefs[name].trust = 1.0
-                seer.beliefs[name].reason.append(f"Day {self.day}: inspected as Not Werewolf")
+                seer.state.beliefs[name].suspicion = 0.0
+                seer.state.beliefs[name].trust = 1.0
+                seer.state.beliefs[name].reason.append(f"Day {self.day}: inspected as Not Werewolf")
             store.save(seer)
             self._emit(LogEvent.make(
                 day=self.day,

--- a/src/engine/setup.py
+++ b/src/engine/setup.py
@@ -4,11 +4,11 @@ import random
 import sys
 from pathlib import Path
 
-from src.domain.agent import AgentState, Belief, Persona
+from src.domain.actor import Actor, ActorState, Belief, Persona, make_actor
 from src.agent import store
 
 
-def initialize_agents(num_players: int) -> list[AgentState]:
+def initialize_agents(num_players: int) -> list[Actor]:
     """Create and persist initial agent states with randomized roles."""
     Path("state/agents").mkdir(parents=True, exist_ok=True)
 
@@ -30,7 +30,7 @@ def initialize_agents(num_players: int) -> list[AgentState]:
     shuffled_roles = roles[:]
     random.shuffle(shuffled_roles)
 
-    agents = []
+    actors = []
     for config, role in zip(selected_configs, shuffled_roles):
         name = config["name"]
         beliefs = {
@@ -38,7 +38,7 @@ def initialize_agents(num_players: int) -> list[AgentState]:
             for other in selected_configs
             if other["name"] != name
         }
-        agent = AgentState(
+        state = ActorState(
             name=name,
             role=role,
             persona=Persona.model_validate(config),
@@ -46,7 +46,8 @@ def initialize_agents(num_players: int) -> list[AgentState]:
             memory_summary=[],
             is_alive=True,
         )
-        store.save(agent)
-        agents.append(agent)
+        actor = make_actor(state)
+        store.save(actor)
+        actors.append(actor)
 
-    return agents
+    return actors

--- a/src/engine/victory.py
+++ b/src/engine/victory.py
@@ -1,7 +1,8 @@
-from src.domain.agent import AgentState
+from src.domain.actor import Actor
+from src.domain.roles import Werewolf
 
 
-def check_victory(agents: list[AgentState]) -> str | None:
+def check_victory(agents: list[Actor]) -> str | None:
     """
     Check win condition among alive agents.
     Returns:
@@ -10,8 +11,8 @@ def check_victory(agents: list[AgentState]) -> str | None:
       None if game continues
     """
     alive = [a for a in agents if a.is_alive]
-    werewolves = [a for a in alive if a.role == "Werewolf"]
-    villagers = [a for a in alive if a.role != "Werewolf"]
+    werewolves = [a for a in alive if isinstance(a.role, Werewolf)]
+    villagers = [a for a in alive if not isinstance(a.role, Werewolf)]
 
     if len(werewolves) == 0:
         return "Villagers"

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -5,14 +5,15 @@ from collections.abc import Iterator
 
 import anthropic
 
-from src.domain.agent import AgentState
+from src.domain.actor import Actor
 from src.llm.prompt import PublicContext, SpeechDirection, RoleSpecificContext, build_system_prompt, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_wolf_chat_prompt
 from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, SpeechEntry, WolfChatOutput
+from src.domain.roles import Villager
 
 _client = anthropic.Anthropic()
 
 
-def _default_output(agent: AgentState) -> AgentOutput:
+def _default_output(actor: Actor) -> AgentOutput:
     """Fallback AgentOutput when LLM call or parse fails."""
     return AgentOutput(
         thought="...",
@@ -60,17 +61,17 @@ def _extract_json(text: str) -> str:
 
 
 def call(
-    agent: AgentState,
+    actor: Actor,
     ctx: PublicContext,
     direction: SpeechDirection,
     role_ctx: RoleSpecificContext | None = None,
 ) -> AgentOutput:
     """Call LLM for day-phase speech and return structured AgentOutput."""
-    system_prompt = build_system_prompt(agent, ctx, direction, role_ctx)
+    system_prompt = build_system_prompt(actor, ctx, direction, role_ctx)
     raw = ""
     try:
         message = _client.messages.create(
-            model=agent.model,
+            model=actor.state.model,
             max_tokens=2048,
             system=system_prompt,
             messages=[
@@ -82,154 +83,154 @@ def call(
         )
         raw = message.content[0].text
     except Exception as e:
-        _log_error("call", agent.name, "api", e, raw)
-        return _default_output(agent)
+        _log_error("call", actor.name, "api", e, raw)
+        return _default_output(actor)
     try:
         json_str = _extract_json(raw)
         data = json.loads(json_str)
         return AgentOutput.model_validate(data)
     except Exception as e:
-        _log_error("call", agent.name, "parse", e, raw)
-        return _default_output(agent)
+        _log_error("call", actor.name, "parse", e, raw)
+        return _default_output(actor)
 
 
 def call_judgment(
-    agent: AgentState,
+    actor: Actor,
     today_log: list[SpeechEntry],
     alive_players: list[str],
     day: int = 1,
     lang: str = "English",
 ) -> JudgmentOutput:
     """Call LLM for the lightweight parallel judgment decision."""
-    co_eligible = agent.claimed_role is None and agent.role != "Villager"
-    prompt = build_judgment_prompt(agent, today_log, alive_players, day, lang, co_eligible)
+    co_eligible = actor.state.claimed_role is None and not isinstance(actor.role, Villager)
+    prompt = build_judgment_prompt(actor, today_log, alive_players, day, lang, co_eligible)
     raw = ""
     try:
         message = _client.messages.create(
-            model=agent.model,
+            model=actor.state.model,
             max_tokens=1024,
             messages=[{"role": "user", "content": prompt}],
         )
         raw = message.content[0].text
     except Exception as e:
-        _log_error("call_judgment", agent.name, "api", e, raw)
+        _log_error("call_judgment", actor.name, "api", e, raw)
         return JudgmentOutput(decision="silent")
     try:
         json_str = _extract_json(raw)
         data = json.loads(json_str)
         return JudgmentOutput.model_validate(data)
     except Exception as e:
-        _log_error("call_judgment", agent.name, "parse", e, raw)
+        _log_error("call_judgment", actor.name, "parse", e, raw)
         return JudgmentOutput(decision="silent")
 
 
 def call_judgment_parallel(
-    agents: list[AgentState],
+    agents: list[Actor],
     today_log: list[SpeechEntry],
     alive_players: list[str],
     day: int = 1,
     lang: str = "English",
-) -> Iterator[tuple[AgentState, JudgmentOutput]]:
+) -> Iterator[tuple[Actor, JudgmentOutput]]:
     """Call judgment for all agents in parallel; yield results in completion order."""
     with ThreadPoolExecutor() as executor:
         future_to_agent = {
-            executor.submit(call_judgment, agent, today_log, alive_players, day, lang): agent
-            for agent in agents
+            executor.submit(call_judgment, actor, today_log, alive_players, day, lang): actor
+            for actor in agents
         }
         for future in as_completed(future_to_agent):
-            agent = future_to_agent[future]
-            yield agent, future.result()
+            actor = future_to_agent[future]
+            yield actor, future.result()
 
 
 def call_pre_night_action(
-    agent: AgentState,
+    actor: Actor,
     alive_players: list[str],
     lang: str = "English",
-    all_agents: list[AgentState] | None = None,
+    all_agents: list[Actor] | None = None,
 ) -> PreNightOutput:
     """Call LLM for pre-night CO decision and return structured PreNightOutput."""
-    prompt = build_pre_night_prompt(agent, alive_players, lang, all_agents)
+    prompt = build_pre_night_prompt(actor, alive_players, lang, all_agents)
     raw = ""
     try:
         message = _client.messages.create(
-            model=agent.model,
+            model=actor.state.model,
             max_tokens=1024,
             messages=[{"role": "user", "content": prompt}],
         )
         raw = message.content[0].text
     except Exception as e:
-        _log_error("call_pre_night_action", agent.name, "api", e, raw)
+        _log_error("call_pre_night_action", actor.name, "api", e, raw)
         return PreNightOutput(thought="...", decision="wait", reasoning="Defaulting to wait.")
     try:
         json_str = _extract_json(raw)
         data = json.loads(json_str)
         return PreNightOutput.model_validate(data)
     except Exception as e:
-        _log_error("call_pre_night_action", agent.name, "parse", e, raw)
+        _log_error("call_pre_night_action", actor.name, "parse", e, raw)
         return PreNightOutput(thought="...", decision="wait", reasoning="Defaulting to wait.")
 
 
 def call_pre_night_parallel(
-    agents: list[AgentState],
+    agents: list[Actor],
     alive_players: list[str],
     lang: str = "English",
-    all_agents: list[AgentState] | None = None,
-) -> Iterator[tuple[AgentState, PreNightOutput]]:
+    all_agents: list[Actor] | None = None,
+) -> Iterator[tuple[Actor, PreNightOutput]]:
     """Call pre-night CO decision for all agents in parallel; yield results in completion order."""
     with ThreadPoolExecutor() as executor:
         future_to_agent = {
-            executor.submit(call_pre_night_action, agent, alive_players, lang, all_agents): agent
-            for agent in agents
+            executor.submit(call_pre_night_action, actor, alive_players, lang, all_agents): actor
+            for actor in agents
         }
         for future in as_completed(future_to_agent):
-            agent = future_to_agent[future]
-            yield agent, future.result()
+            actor = future_to_agent[future]
+            yield actor, future.result()
 
 
 def call_wolf_chat(
-    agent: AgentState,
+    actor: Actor,
     wolf_partners: list[str],
     alive_players: list[str],
     wolf_chat_log: list[SpeechEntry],
     lang: str = "English",
 ) -> WolfChatOutput:
     """Call LLM for werewolf team night chat and return structured WolfChatOutput."""
-    prompt = build_wolf_chat_prompt(agent, wolf_partners, alive_players, wolf_chat_log, lang)
+    prompt = build_wolf_chat_prompt(actor, wolf_partners, alive_players, wolf_chat_log, lang)
     raw = ""
     try:
         message = _client.messages.create(
-            model=agent.model,
+            model=actor.state.model,
             max_tokens=2048,
             messages=[{"role": "user", "content": prompt}],
         )
         raw = message.content[0].text
     except Exception as e:
-        _log_error("call_wolf_chat", agent.name, "api", e, raw)
+        _log_error("call_wolf_chat", actor.name, "api", e, raw)
         return WolfChatOutput(thought="...", speech="...", vote_candidates=[])
     try:
         json_str = _extract_json(raw)
         data = json.loads(json_str)
         return WolfChatOutput.model_validate(data)
     except Exception as e:
-        _log_error("call_wolf_chat", agent.name, "parse", e, raw)
+        _log_error("call_wolf_chat", actor.name, "parse", e, raw)
         return WolfChatOutput(thought="...", speech="...", vote_candidates=[])
 
 
 def call_night_action(
-    agent: AgentState,
+    actor: Actor,
     context: str,
     alive_players: list[str],
 ) -> str:
     """Call LLM for night action and return target player name."""
-    prompt = build_night_action_prompt(agent, alive_players, context)
+    prompt = build_night_action_prompt(actor, alive_players, context)
     if not prompt:
         return ""
 
-    candidates = [p for p in alive_players if p != agent.name]
+    candidates = [p for p in alive_players if p != actor.name]
     raw = ""
     try:
         message = _client.messages.create(
-            model=agent.model,
+            model=actor.state.model,
             max_tokens=64,
             messages=[
                 {
@@ -240,7 +241,7 @@ def call_night_action(
         )
         raw = message.content[0].text.strip()
     except Exception as e:
-        _log_error("call_night_action", agent.name, "api", e, raw)
+        _log_error("call_night_action", actor.name, "api", e, raw)
         return candidates[0] if candidates else ""
     # Validate that the returned name is a valid alive player
     for candidate in candidates:

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
-from src.domain.agent import AgentState
-from src.domain.roles import get_role
+from src.domain.actor import Actor
+from src.domain.roles import Role, Werewolf
 from src.domain.schema import SpeechEntry
 
 
@@ -11,7 +11,7 @@ class PublicContext:
     alive_players: list[str]
     dead_players: list[str]
     day: int
-    all_agents: list[AgentState] | None = None
+    all_agents: list[Actor] | None = None
     past_votes: list[dict] | None = None
     past_deaths: list[dict] | None = None
 
@@ -50,17 +50,17 @@ _SPEECH_STYLE_PROMPTS: dict[str, str] = {
 }
 
 
-def build_persona_prompt(agent: AgentState) -> str:
-    """Generate personality prompt from agent persona."""
-    style = agent.persona.style
-    lie = agent.persona.lie_tendency
-    agg = agent.persona.aggression
+def build_persona_prompt(actor: Actor) -> str:
+    """Generate personality prompt from actor persona."""
+    style = actor.state.persona.style
+    lie = actor.state.persona.lie_tendency
+    agg = actor.state.persona.aggression
 
-    identity_parts = [agent.name]
-    if agent.persona.age is not None:
-        identity_parts.append(f"age {agent.persona.age}")
-    if agent.persona.gender is not None:
-        identity_parts.append(agent.persona.gender)
+    identity_parts = [actor.name]
+    if actor.state.persona.age is not None:
+        identity_parts.append(f"age {actor.state.persona.age}")
+    if actor.state.persona.gender is not None:
+        identity_parts.append(actor.state.persona.gender)
     identity = ", ".join(identity_parts)
 
     lines = [
@@ -68,11 +68,11 @@ def build_persona_prompt(agent: AgentState) -> str:
         f"Your personality style: {style}.",
     ]
 
-    speech_prompt = _SPEECH_STYLE_PROMPTS.get(agent.persona.speech_style)
+    speech_prompt = _SPEECH_STYLE_PROMPTS.get(actor.state.persona.speech_style)
     if speech_prompt:
         lines.append(speech_prompt)
-    elif agent.persona.speech_style != "casual":
-        lines.append(f"Your speaking style: {agent.persona.speech_style}.")
+    elif actor.state.persona.speech_style != "casual":
+        lines.append(f"Your speaking style: {actor.state.persona.speech_style}.")
 
     if lie > 0.5:
         lines.append("You are comfortable bending the truth when it serves your survival.")
@@ -87,16 +87,16 @@ def build_persona_prompt(agent: AgentState) -> str:
     return "\n".join(lines)
 
 
-def build_role_prompt(role: str, wolf_partners: list[str] | None = None) -> str:
+def build_role_prompt(role: Role, wolf_partners: list[str] | None = None) -> str:
     """Generate role-specific action guidelines.
 
     Delegates to the Role class (Strategy pattern). See src/domain/roles/.
     """
-    if role != "Werewolf":
+    if not isinstance(role, Werewolf):
         assert wolf_partners is None, (
             f"wolf_partners must be None for non-Werewolf roles, got role={role!r}"
         )
-    return get_role(role).role_prompt(wolf_partners)
+    return role.role_prompt(wolf_partners)
 
 
 def build_public_info_prompt(ctx: PublicContext) -> str:
@@ -105,7 +105,7 @@ def build_public_info_prompt(ctx: PublicContext) -> str:
     lines = [f"\n--- PUBLIC INFORMATION (Day {ctx.day}) ---"]
 
     if ctx.all_agents:
-        role_counts = Counter(a.role for a in ctx.all_agents)
+        role_counts = Counter(a.role.name for a in ctx.all_agents)
         role_summary = ", ".join(f"{count} {role}" for role, count in sorted(role_counts.items()))
         lines.append(f"Role distribution: {role_summary}")
 
@@ -128,9 +128,9 @@ def build_public_info_prompt(ctx: PublicContext) -> str:
 
     if ctx.all_agents:
         claims = [
-            f"{a.name} claims {a.claimed_role}"
+            f"{a.name} claims {a.state.claimed_role}"
             for a in ctx.all_agents
-            if a.claimed_role is not None
+            if a.state.claimed_role is not None
         ]
         if claims:
             lines.append(f"Known role claims: {', '.join(claims)}")
@@ -144,18 +144,18 @@ def build_public_info_prompt(ctx: PublicContext) -> str:
     return "\n".join(lines)
 
 
-def build_personal_info_prompt(agent: AgentState) -> str:
-    """Build prompt section with agent's personal beliefs and memory."""
+def build_personal_info_prompt(actor: Actor) -> str:
+    """Build prompt section with actor's personal beliefs and memory."""
     lines = ["\n--- YOUR PERSONAL INFORMATION ---"]
 
-    if agent.memory_summary:
+    if actor.state.memory_summary:
         lines.append("Your memory from previous days:")
-        for mem in agent.memory_summary:
+        for mem in actor.state.memory_summary:
             lines.append(f"  - {mem}")
 
-    if agent.beliefs:
+    if actor.state.beliefs:
         lines.append("\nYour current beliefs about other players:")
-        for name, belief in agent.beliefs.items():
+        for name, belief in actor.state.beliefs.items():
             lines.append(
                 f"  {name}: suspicion={belief.suspicion:.2f}, trust={belief.trust:.2f}"
             )
@@ -198,19 +198,19 @@ Rules:
 
 
 def build_system_prompt(
-    agent: AgentState,
+    actor: Actor,
     ctx: PublicContext,
     direction: SpeechDirection,
     role_ctx: RoleSpecificContext | None = None,
 ) -> str:
-    """Assemble full system prompt for an agent."""
+    """Assemble full system prompt for an actor."""
     wolf_partners = role_ctx.wolf_partners if isinstance(role_ctx, WolfSpecificContext) else None
     parts = [
-        build_persona_prompt(agent),
+        build_persona_prompt(actor),
         "\n",
-        build_role_prompt(agent.role, wolf_partners),
+        build_role_prompt(actor.role, wolf_partners),
         build_public_info_prompt(ctx),
-        build_personal_info_prompt(agent),
+        build_personal_info_prompt(actor),
     ]
     if direction.reply_to_entry is not None:
         parts.append(
@@ -220,7 +220,7 @@ def build_system_prompt(
             f"Respond directly to this statement in your speech."
         )
     if direction.intended_co:
-        co_text = get_role(agent.role).co_prompt()
+        co_text = actor.role.co_prompt()
         if co_text:
             parts.append(co_text)
     parts.append(build_output_format_prompt(direction.lang))
@@ -228,10 +228,10 @@ def build_system_prompt(
 
 
 def build_pre_night_prompt(
-    agent: AgentState,
+    actor: Actor,
     alive_players: list[str],
     lang: str = "English",
-    all_agents: list[AgentState] | None = None,
+    all_agents: list[Actor] | None = None,
 ) -> str:
     """Build prompt for pre-night decision phase (non-Villager roles only).
 
@@ -240,19 +240,19 @@ def build_pre_night_prompt(
     Madman decides whether to falsely claim to be a Villager-side role.
     All choices are encoded as "co" | "wait".
     """
-    decision_desc = get_role(agent.role).pre_night_prompt()
+    decision_desc = actor.role.pre_night_prompt()
 
     lines = [
-        f"You are {agent.name}, a player in a social deduction game (Werewolf/Mafia).",
-        f"Your personality style: {agent.persona.style}.",
+        f"You are {actor.name}, a player in a social deduction game (Werewolf/Mafia).",
+        f"Your personality style: {actor.state.persona.style}.",
         "",
-        f"Your secret role is: {agent.role}",
+        f"Your secret role is: {actor.role.name}",
         f"Players in this game: {', '.join(alive_players)}",
     ]
 
     if all_agents:
         from collections import Counter
-        role_counts = Counter(a.role for a in all_agents)
+        role_counts = Counter(a.role.name for a in all_agents)
         role_summary = ", ".join(f"{count} {role}" for role, count in sorted(role_counts.items()))
         lines.append(f"Role distribution in this game: {role_summary}")
 
@@ -274,13 +274,8 @@ def build_pre_night_prompt(
     return "\n".join(lines)
 
 
-def _build_co_strategy_hint(role: str) -> str:
-    """Return a role-specific strategic hint for the discussion-phase CO decision."""
-    return get_role(role).co_strategy_hint()
-
-
 def build_judgment_prompt(
-    agent: AgentState,
+    actor: Actor,
     today_log: list[SpeechEntry],
     alive_players: list[str],
     day: int,
@@ -295,18 +290,18 @@ def build_judgment_prompt(
     """
     recent = today_log[-6:] if len(today_log) > 6 else today_log
     lines = [
-        f"You are {agent.name} ({agent.role}) in a Werewolf game. Day {day}.",
+        f"You are {actor.name} ({actor.role.name}) in a Werewolf game. Day {day}.",
         f"Alive players: {', '.join(alive_players)}",
     ]
-    if agent.memory_summary:
-        lines.append(f"Your memory: {'; '.join(agent.memory_summary)}")
+    if actor.state.memory_summary:
+        lines.append(f"Your memory: {'; '.join(actor.state.memory_summary)}")
     if recent:
         lines.append("\nRecent speeches:")
         for e in recent:
             lines.append(f"  [{e.speech_id}] {e.agent}: {e.text}")
 
     if co_eligible:
-        co_hint = _build_co_strategy_hint(agent.role)
+        co_hint = actor.role.co_strategy_hint()
         lines.append(f"""
 Decide your next action. Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
 {{
@@ -336,7 +331,7 @@ Use {lang} only for internal reasoning if needed, but keep the JSON minimal.""")
 
 
 def build_wolf_chat_prompt(
-    agent: AgentState,
+    actor: Actor,
     wolf_partners: list[str],
     alive_players: list[str],
     wolf_chat_log: list[SpeechEntry],
@@ -344,9 +339,9 @@ def build_wolf_chat_prompt(
 ) -> str:
     """Build prompt for werewolf team night chat (secret coordination before attack)."""
     lines = [
-        f"You are {agent.name}, a Werewolf in a social deduction game.",
+        f"You are {actor.name}, a Werewolf in a social deduction game.",
         f"Your wolf partners tonight: {', '.join(wolf_partners)}.",
-        f"Alive players (potential targets): {', '.join(p for p in alive_players if p != agent.name and p not in wolf_partners)}.",
+        f"Alive players (potential targets): {', '.join(p for p in alive_players if p != actor.name and p not in wolf_partners)}.",
         "",
         "It is night. You are meeting secretly with your wolf partner(s) to coordinate.",
         "Discuss who to attack tonight. You may propose a target and explain your reasoning.",
@@ -372,6 +367,6 @@ Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
     return "\n".join(lines)
 
 
-def build_night_action_prompt(agent: AgentState, alive_players: list[str], context: str) -> str:
+def build_night_action_prompt(actor: Actor, alive_players: list[str], context: str) -> str:
     """Build prompt for night action (attack, inspect, or guard)."""
-    return get_role(agent.role).night_action_prompt(agent.name, alive_players, context)
+    return actor.role.night_action_prompt(actor.name, alive_players, context)

--- a/src/ui/cli.py
+++ b/src/ui/cli.py
@@ -2,14 +2,14 @@ from rich.console import Console
 from rich.panel import Panel
 
 from src.domain.event import LogEvent
-from src.domain.agent import AgentState
+from src.domain.actor import Actor
 from src.ui.renderer import render_event, _ROLE_COLORS
 
 console = Console()
 
 
 class CLI:
-    def __init__(self, agents: list[AgentState], spectator_mode: bool = False):
+    def __init__(self, agents: list[Actor], spectator_mode: bool = False):
         self.agents = agents
         self.spectator_mode = spectator_mode
 
@@ -23,10 +23,10 @@ class CLI:
         """Display the winner and full role reveal."""
         console.print()
         console.print("[bold yellow]=== ROLE REVEAL ===[/bold yellow]")
-        for agent in self.agents:
-            role_style = _ROLE_COLORS.get(agent.role, "white")
-            status = "" if agent.is_alive else " [dim](eliminated)[/dim]"
-            console.print(f"  [{role_style}]{agent.name}[/{role_style}] — {agent.role}{status}")
+        for actor in self.agents:
+            role_style = _ROLE_COLORS.get(actor.role.name, "white")
+            status = "" if actor.is_alive else " [dim](eliminated)[/dim]"
+            console.print(f"  [{role_style}]{actor.name}[/{role_style}] — {actor.role.name}{status}")
         console.print()
         result_style = "bold red" if winner == "Werewolves" else "bold green"
         console.print(
@@ -54,7 +54,7 @@ class CLI:
         if not self.spectator_mode:
             return
         console.print("\n[bold cyan]Agent Roster:[/bold cyan]")
-        for agent in self.agents:
-            role_style = _ROLE_COLORS.get(agent.role, "white")
-            console.print(f"  [{role_style}]{agent.name}[/{role_style}] — {agent.role} ({agent.persona.style})")
+        for actor in self.agents:
+            role_style = _ROLE_COLORS.get(actor.role.name, "white")
+            console.print(f"  [{role_style}]{actor.name}[/{role_style}] — {actor.role.name} ({actor.state.persona.style})")
         console.print()

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -2,7 +2,7 @@ from rich.text import Text
 from rich.console import Console
 
 from src.domain.event import LogEvent, EventType
-from src.domain.agent import AgentState
+from src.domain.actor import Actor
 
 console = Console()
 
@@ -17,32 +17,32 @@ _ROLE_COLORS: dict[str, str] = {
 }
 
 
-def _get_agent(agent_name: str | None, agents: list[AgentState]) -> AgentState | None:
+def _get_agent(agent_name: str | None, agents: list[Actor]) -> Actor | None:
     if agent_name is None:
         return None
     return next((a for a in agents if a.name == agent_name), None)
 
 
-def _speech_style(agent_name: str | None, agents: list[AgentState], spectator_mode: bool) -> str:
+def _speech_style(agent_name: str | None, agents: list[Actor], spectator_mode: bool) -> str:
     """Return Rich color style for a speech event.
 
     Spectator mode: color by true role.
     Public mode: color by claimed role (CO'd role only), default white.
     """
-    agent = _get_agent(agent_name, agents)
-    if agent is None:
+    actor = _get_agent(agent_name, agents)
+    if actor is None:
         return "white"
     if spectator_mode:
-        return _ROLE_COLORS.get(agent.role, "white")
+        return _ROLE_COLORS.get(actor.role.name, "white")
     # public mode: only color if the agent has CO'd
-    if agent.claimed_role:
-        return _ROLE_COLORS.get(agent.claimed_role, "white")
+    if actor.state.claimed_role:
+        return _ROLE_COLORS.get(actor.state.claimed_role, "white")
     return "white"
 
 
 def render_event(
     event: LogEvent,
-    agents: list[AgentState],
+    agents: list[Actor],
     spectator_mode: bool = False,
 ) -> Text | None:
     """
@@ -97,8 +97,8 @@ def render_event(
 
     elif event.event_type == EventType.PRE_NIGHT_DECISION:
         # Spectator only — role color
-        agent_state = _get_agent(event.agent, agents)
-        role = agent_state.role if agent_state else ""
+        actor = _get_agent(event.agent, agents)
+        role = actor.role.name if actor else ""
         style = _ROLE_COLORS.get(role, "cyan")
         text.append(f"[PRE-NIGHT] {event.content}", style=style)
 

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -12,7 +12,7 @@ from rich.console import Console
 from rich.text import Text
 
 from src.agent import store
-from src.domain.agent import AgentState
+from src.domain.actor import Actor, make_actor
 from src.domain.event import EventType, LogEvent
 from src.logger.reader import load_events
 from src.ui.renderer import render_event
@@ -95,7 +95,7 @@ class ReplayPager:
         self._agents = self._load_agents()
         self._lines = self._build_lines()
 
-    def _load_agents(self) -> list[AgentState]:
+    def _load_agents(self) -> list[Actor]:
         return store.load_all_from_dir(self._archive / "agents")
 
     def _load_events(self) -> list[LogEvent]:
@@ -108,18 +108,21 @@ class ReplayPager:
 
         # Reset claimed_role to None so public-mode colors reflect what was
         # publicly known at each moment, not the end-of-game state.
-        dynamic_agents = {a.name: a.model_copy() for a in self._agents}
-        for a in dynamic_agents.values():
-            a.claimed_role = None
+        dynamic_actors: dict[str, Actor] = {
+            a.name: make_actor(a.state.model_copy())
+            for a in self._agents
+        }
+        for a in dynamic_actors.values():
+            a.state.claimed_role = None
 
         all_lines: list[str] = []
         for event in events:
             # Use event.claimed_role (structured field) rather than parsing content text.
             if event.event_type == EventType.CO_ANNOUNCEMENT and event.agent and event.claimed_role:
-                if event.agent in dynamic_agents:
-                    dynamic_agents[event.agent].claimed_role = event.claimed_role
+                if event.agent in dynamic_actors:
+                    dynamic_actors[event.agent].state.claimed_role = event.claimed_role
 
-            rich_text = render_event(event, list(dynamic_agents.values()), self._spectator)
+            rich_text = render_event(event, list(dynamic_actors.values()), self._spectator)
             if rich_text is None:
                 continue
             rendered = _render_rich_to_lines(rich_text, width)

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -4,7 +4,7 @@ LLM呼び出し (llm_client.call / call_judgment_parallel) はモック。
 """
 from unittest.mock import MagicMock, patch
 
-from src.domain.agent import AgentState, Persona
+from src.domain.actor import ActorState, Actor, Persona, make_actor
 from src.engine.game import GameEngine
 from src.engine.phase import Phase
 from src.domain.schema import AgentOutput, Intent, JudgmentOutput
@@ -12,8 +12,8 @@ from src.domain.event import EventType, LogEvent
 from src.logger.writer import LogWriter
 
 
-def _make_agent(name: str, role: str = "Villager") -> AgentState:
-    return AgentState(
+def _make_agent(name: str, role: str = "Villager") -> Actor:
+    state = ActorState(
         name=name,
         role=role,
         persona=Persona(style="calm", lie_tendency=0.1, aggression=0.2),
@@ -21,6 +21,7 @@ def _make_agent(name: str, role: str = "Villager") -> AgentState:
         memory_summary=[],
         is_alive=True,
     )
+    return make_actor(state)
 
 
 def _make_output(name: str, speech: str = "Hello.") -> AgentOutput:
@@ -33,7 +34,7 @@ def _make_output(name: str, speech: str = "Hello.") -> AgentOutput:
     )
 
 
-def _make_engine(agents: list[AgentState]) -> tuple[GameEngine, list[LogEvent]]:
+def _make_engine(agents: list[Actor]) -> tuple[GameEngine, list[LogEvent]]:
     events: list[LogEvent] = []
     log_writer = MagicMock(spec=LogWriter)
     log_writer.write.side_effect = lambda e: events.append(e)
@@ -135,7 +136,7 @@ class TestDiscussionCoDecision:
     def test_eligible_agent_co_sets_claimed_role(self):
         """Seer (unclaimed) chooses co → claimed_role is set after speaking."""
         seer = _make_agent("Seer1", "Seer")
-        assert seer.claimed_role is None
+        assert seer.state.claimed_role is None
         engine, _ = _make_engine([seer])
 
         co_judgment = JudgmentOutput(decision="co")
@@ -157,12 +158,12 @@ class TestDiscussionCoDecision:
         ):
             engine._run_day()
 
-        assert seer.claimed_role == "Seer"
+        assert seer.state.claimed_role == "Seer"
 
     def test_ineligible_agent_co_treated_as_speak(self):
         """Agent that already claimed a role cannot CO again — falls back to speak."""
         seer = _make_agent("Seer1", "Seer")
-        seer.claimed_role = "Seer"  # already claimed
+        seer.state.claimed_role = "Seer"  # already claimed
         engine, events = _make_engine([seer])
 
         co_judgment = JudgmentOutput(decision="co")

--- a/tests/unit/test_judgment_prompt.py
+++ b/tests/unit/test_judgment_prompt.py
@@ -1,4 +1,4 @@
-from src.domain.agent import AgentState, Persona, Belief
+from src.domain.actor import ActorState, Actor, Persona, Belief, make_actor
 from src.llm.prompt import build_judgment_prompt
 from src.domain.schema import SpeechEntry
 
@@ -8,8 +8,8 @@ def _make_agent(
     role: str = "Villager",
     memory: list[str] | None = None,
     claimed_role: str | None = None,
-) -> AgentState:
-    return AgentState(
+) -> Actor:
+    state = ActorState(
         name=name,
         role=role,
         persona=Persona(style="calm", lie_tendency=0.1, aggression=0.2),
@@ -18,6 +18,7 @@ def _make_agent(
         is_alive=True,
         claimed_role=claimed_role,
     )
+    return make_actor(state)
 
 
 def _make_log(*texts: str) -> list[SpeechEntry]:

--- a/tests/unit/test_pre_night.py
+++ b/tests/unit/test_pre_night.py
@@ -7,7 +7,7 @@
 from unittest.mock import MagicMock, patch
 
 
-from src.domain.agent import AgentState, Persona
+from src.domain.actor import ActorState, Actor, Persona, make_actor
 from src.engine.game import GameEngine
 from src.engine.phase import Phase
 from src.llm.prompt import PublicContext, SpeechDirection, WolfSpecificContext, build_pre_night_prompt, build_system_prompt
@@ -16,8 +16,8 @@ from src.domain.event import EventType, LogEvent
 from src.logger.writer import LogWriter
 
 
-def _make_agent(name: str, role: str) -> AgentState:
-    return AgentState(
+def _make_agent(name: str, role: str) -> Actor:
+    state = ActorState(
         name=name,
         role=role,
         persona=Persona(style="calm", lie_tendency=0.1, aggression=0.2),
@@ -25,9 +25,10 @@ def _make_agent(name: str, role: str) -> AgentState:
         memory_summary=[],
         is_alive=True,
     )
+    return make_actor(state)
 
 
-def _make_engine(agents: list[AgentState]) -> tuple[GameEngine, list[LogEvent]]:
+def _make_engine(agents: list[Actor]) -> tuple[GameEngine, list[LogEvent]]:
     events: list[LogEvent] = []
     log_writer = MagicMock(spec=LogWriter)
     log_writer.write.side_effect = lambda e: events.append(e)
@@ -137,7 +138,7 @@ class TestRunPreNight:
             engine._run_pre_night()
 
         seer = next(a for a in agents if a.name == "Gina")
-        assert seer.intended_co is True
+        assert seer.state.intended_co is True
 
     def test_wait_decision_sets_intended_co_false(self):
         agents = [_make_agent("Gina", "Seer"), _make_agent("SQ", "Villager")]
@@ -150,7 +151,7 @@ class TestRunPreNight:
             engine._run_pre_night()
 
         seer = next(a for a in agents if a.name == "Gina")
-        assert seer.intended_co is False
+        assert seer.state.intended_co is False
 
     def test_decision_events_are_spectator_only(self):
         agents = [_make_agent("Gina", "Seer"), _make_agent("SQ", "Villager")]

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -1,28 +1,29 @@
 import pytest
 
 from src.llm.prompt import build_role_prompt
+from src.domain.roles import get_role
 
 
 def test_build_role_prompt_wolf_partners_non_none_for_non_werewolf_raises():
     with pytest.raises(AssertionError):
-        build_role_prompt("Seer", wolf_partners=["Alice"])
+        build_role_prompt(get_role("Seer"), wolf_partners=["Alice"])
 
 
 def test_build_role_prompt_wolf_partners_none_for_werewolf_raises():
     with pytest.raises(AssertionError):
-        build_role_prompt("Werewolf", wolf_partners=None)
+        build_role_prompt(get_role("Werewolf"), wolf_partners=None)
 
 
 def test_build_role_prompt_wolf_partners_empty_for_werewolf_is_allowed():
-    result = build_role_prompt("Werewolf", wolf_partners=[])
+    result = build_role_prompt(get_role("Werewolf"), wolf_partners=[])
     assert "last surviving Werewolf" in result
 
 
 def test_build_role_prompt_wolf_partners_list_for_werewolf_is_allowed():
-    result = build_role_prompt("Werewolf", wolf_partners=["Bob"])
+    result = build_role_prompt(get_role("Werewolf"), wolf_partners=["Bob"])
     assert "Bob" in result
 
 
-def test_build_role_prompt_unknown_role_raises():
+def test_get_role_unknown_role_raises():
     with pytest.raises(ValueError, match="Unknown role"):
-        build_role_prompt("UnknownRole")
+        get_role("UnknownRole")

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -9,7 +9,7 @@ from src.engine.setup import initialize_agents
 
 
 def test_initialize_agents_count():
-    """5人分のAgentStateが返ること。"""
+    """5人分のActorが返ること。"""
     with patch("src.agent.store.save"):
         result = initialize_agents(5)
 
@@ -21,7 +21,7 @@ def test_initialize_agents_roles_distribution():
     with patch("src.agent.store.save"):
         agents = initialize_agents(5)
 
-    roles = [a.role for a in agents]
+    roles = [a.role.name for a in agents]
     roles_config = json.loads(Path("config/roles.json").read_text(encoding="utf-8"))
     expected = sorted(roles_config["5"])
     assert sorted(roles) == expected
@@ -42,7 +42,7 @@ def test_initialize_agents_beliefs_exclude_self():
         agents = initialize_agents(5)
 
     for agent in agents:
-        assert agent.name not in agent.beliefs
+        assert agent.name not in agent.state.beliefs
 
 
 def test_initialize_agents_invalid_player_count():

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -4,12 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from src.domain.agent import AgentState, Persona
+from src.domain.actor import Actor, ActorState, Persona
 from src.agent import store
 
 
 def _make_agent_json(name: str, role: str) -> dict:
-    return AgentState(
+    return ActorState(
         name=name,
         role=role,
         persona=Persona(style="calm"),
@@ -33,7 +33,7 @@ def agents_dir(tmp_path: Path) -> Path:
 
 
 def test_load_all_from_dir_returns_agents(agents_dir: Path) -> None:
-    """指定ディレクトリから AgentState を全件読み込めること。"""
+    """指定ディレクトリから Actor を全件読み込めること。"""
     agents = store.load_all_from_dir(agents_dir)
     assert len(agents) == 2
     names = {a.name for a in agents}
@@ -53,7 +53,7 @@ def test_load_all_delegates_to_load_all_from_dir(agents_dir: Path, monkeypatch) 
 
     original = store.load_all_from_dir
 
-    def spy(path: Path) -> list[AgentState]:
+    def spy(path: Path) -> list[Actor]:
         called_with.append(path)
         return original(path)
 

--- a/tests/unit/ui/test_replay.py
+++ b/tests/unit/ui/test_replay.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from src.domain.agent import AgentState, Persona
+from src.domain.actor import ActorState, Persona
 from src.domain.event import EventType, LogEvent
 from src.ui.replay import ArchiveSelector, ReplayPager, run_replay
 
@@ -20,7 +20,7 @@ from src.ui.replay import ArchiveSelector, ReplayPager, run_replay
 
 
 def _make_agent_json(name: str, role: str) -> dict:
-    return AgentState(
+    return ActorState(
         name=name,
         role=role,
         persona=Persona(style="calm"),
@@ -89,7 +89,7 @@ def test_replay_spectator_does_not_call_llm(tmp_archive: Path) -> None:
 
 
 def test_pager_loads_agents(tmp_archive: Path) -> None:
-    """アーカイブから正しく AgentState が読み込まれること。"""
+    """アーカイブから正しく Actor が読み込まれること。"""
     pager = ReplayPager(tmp_archive, spectator_mode=False)
     names = {a.name for a in pager._agents}
     assert names == {"Alice", "Bob"}


### PR DESCRIPTION
## Summary
- Add `src/domain/actor.py` with `ActorState` (Pydantic), `Actor` (dataclass), and `make_actor()`
- `Actor` wraps `state: ActorState` and `role: Role`, with `name`/`is_alive` convenience properties
- Replace all `AgentState` usages across 13 src files and 6 test files with `Actor`/`ActorState`
- Role comparisons now use `isinstance()` instead of string equality
- `build_role_prompt()` signature changed from `role: str` to `role: Role`
- `PublicContext.all_agents` updated to `list[Actor]`

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス (106 tests)
- [ ] `AgentState` が全ソースから消えていること

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)