### PR TITLE
refactor: add color property to Role classes (closes #66)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -16,7 +16,6 @@
 | yukkie/AgentVillage#74 | tech-debt | 🟢 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#71 | tech-debt | 🟢 | Eliminate redundant role: str from ActorState | ActorState.role: str と Actor.role.name の冗長性を解消 |
 | yukkie/AgentVillage#72 | tech-debt | 🟢 | Replace role name strings with Role type in Intent, ActorState.claimed_role, LogEvent | Intent.co / claimed_role / LogEvent.claimed_role を str から Role 型に変更 |
-| yukkie/AgentVillage#66 | tech-debt | 🟢 | Add color property to Role classes and resolve MEDIUM_RESULT color mismatch | Role クラスに color プロパティ追加・renderer.py の _ROLE_COLORS 廃止（#68 完了後に着手） |
 | yukkie/AgentVillage#61 | tech-debt | 🟢 | Move common prompt content to Role ABC default methods | prompt.py のコンテンツ文字列を Role ABC のデフォルトメソッドに移動し、prompt.py をアセンブルのみに |
 | yukkie/AgentVillage#59 | tech-debt | 🟢 | Replace msvcrt with cross-platform key input | replay.py の Windows 専用 msvcrt をクロスプラットフォーム対応に置換 |
 | yukkie/AgentVillage#58 | tech-debt | 🟢 | Split GameEngine phases into dedicated modules | game.py を前夜・昼・夜フェーズモジュールに分割 |

--- a/src/domain/roles/knight.py
+++ b/src/domain/roles/knight.py
@@ -7,6 +7,10 @@ class Knight(Role):
         return "Knight"
 
     @property
+    def color(self) -> str:
+        return "bright_green"
+
+    @property
     def faction(self) -> str:
         return "village"
 

--- a/src/domain/roles/madman.py
+++ b/src/domain/roles/madman.py
@@ -7,6 +7,10 @@ class Madman(Role):
         return "Madman"
 
     @property
+    def color(self) -> str:
+        return "orange3"
+
+    @property
     def faction(self) -> str:
         return "werewolf"
 

--- a/src/domain/roles/medium.py
+++ b/src/domain/roles/medium.py
@@ -7,6 +7,10 @@ class Medium(Role):
         return "Medium"
 
     @property
+    def color(self) -> str:
+        return "cyan"
+
+    @property
     def faction(self) -> str:
         return "village"
 

--- a/src/domain/roles/role.py
+++ b/src/domain/roles/role.py
@@ -10,6 +10,10 @@ class Role(ABC):
 
     @property
     @abstractmethod
+    def color(self) -> str: ...
+
+    @property
+    @abstractmethod
     def faction(self) -> str: ...
 
     @property

--- a/src/domain/roles/seer.py
+++ b/src/domain/roles/seer.py
@@ -7,6 +7,10 @@ class Seer(Role):
         return "Seer"
 
     @property
+    def color(self) -> str:
+        return "blue"
+
+    @property
     def faction(self) -> str:
         return "village"
 

--- a/src/domain/roles/villager.py
+++ b/src/domain/roles/villager.py
@@ -7,6 +7,10 @@ class Villager(Role):
         return "Villager"
 
     @property
+    def color(self) -> str:
+        return "white"
+
+    @property
     def faction(self) -> str:
         return "village"
 

--- a/src/domain/roles/werewolf.py
+++ b/src/domain/roles/werewolf.py
@@ -7,6 +7,10 @@ class Werewolf(Role):
         return "Werewolf"
 
     @property
+    def color(self) -> str:
+        return "red"
+
+    @property
     def faction(self) -> str:
         return "werewolf"
 

--- a/src/ui/cli.py
+++ b/src/ui/cli.py
@@ -3,7 +3,7 @@ from rich.panel import Panel
 
 from src.domain.event import LogEvent
 from src.domain.actor import Actor
-from src.ui.renderer import render_event, _ROLE_COLORS
+from src.ui.renderer import render_event
 
 console = Console()
 
@@ -24,7 +24,7 @@ class CLI:
         console.print()
         console.print("[bold yellow]=== ROLE REVEAL ===[/bold yellow]")
         for actor in self.agents:
-            role_style = _ROLE_COLORS.get(actor.role.name, "white")
+            role_style = actor.role.color
             status = "" if actor.is_alive else " [dim](eliminated)[/dim]"
             console.print(f"  [{role_style}]{actor.name}[/{role_style}] — {actor.role.name}{status}")
         console.print()
@@ -55,6 +55,6 @@ class CLI:
             return
         console.print("\n[bold cyan]Agent Roster:[/bold cyan]")
         for actor in self.agents:
-            role_style = _ROLE_COLORS.get(actor.role.name, "white")
+            role_style = actor.role.color
             console.print(f"  [{role_style}]{actor.name}[/{role_style}] — {actor.role.name} ({actor.state.persona.style})")
         console.print()

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -3,18 +3,9 @@ from rich.console import Console
 
 from src.domain.event import LogEvent, EventType
 from src.domain.actor import Actor
+from src.domain.roles import get_role
 
 console = Console()
-
-
-_ROLE_COLORS: dict[str, str] = {
-    "Werewolf": "red",
-    "Madman": "orange3",
-    "Seer": "blue",
-    "Medium": "cyan",
-    "Knight": "bright_green",
-    "Villager": "white",
-}
 
 
 def _get_agent(agent_name: str | None, agents: list[Actor]) -> Actor | None:
@@ -33,10 +24,10 @@ def _speech_style(agent_name: str | None, agents: list[Actor], spectator_mode: b
     if actor is None:
         return "white"
     if spectator_mode:
-        return _ROLE_COLORS.get(actor.role.name, "white")
+        return actor.role.color
     # public mode: only color if the agent has CO'd
     if actor.state.claimed_role:
-        return _ROLE_COLORS.get(actor.state.claimed_role, "white")
+        return get_role(actor.state.claimed_role).color
     return "white"
 
 
@@ -98,8 +89,7 @@ def render_event(
     elif event.event_type == EventType.PRE_NIGHT_DECISION:
         # Spectator only — role color
         actor = _get_agent(event.agent, agents)
-        role = actor.role.name if actor else ""
-        style = _ROLE_COLORS.get(role, "cyan")
+        style = actor.role.color if actor else "cyan"
         text.append(f"[PRE-NIGHT] {event.content}", style=style)
 
     elif event.event_type == EventType.WOLF_CHAT:
@@ -119,8 +109,8 @@ def render_event(
         text.append(f"[CO] {event.content}", style="bold white")
 
     elif event.event_type == EventType.MEDIUM_RESULT:
-        # Spectator only — yellow
-        text.append(f"[MEDIUM] {event.content}", style="yellow")
+        # Spectator only — cyan (Medium's role color)
+        text.append(f"[MEDIUM] {event.content}", style="cyan")
 
     elif event.event_type == EventType.GAME_OVER:
         text.append(f"\n{'=' * 50}\n", style="bold yellow")

--- a/tests/unit/test_role.py
+++ b/tests/unit/test_role.py
@@ -43,6 +43,20 @@ class TestRoleProperties:
         assert role.faction == faction
         assert role.night_action == night_action
 
+    @pytest.mark.parametrize(
+        "role_name, expected_color",
+        [
+            ("Villager", "white"),
+            ("Werewolf", "red"),
+            ("Seer", "blue"),
+            ("Knight", "bright_green"),
+            ("Medium", "cyan"),
+            ("Madman", "orange3"),
+        ],
+    )
+    def test_color(self, role_name, expected_color):
+        assert get_role(role_name).color == expected_color
+
 
 class TestRolePrompt:
     def test_villager(self):


### PR DESCRIPTION
## Summary
- `Role` 基底クラスに抽象 `color: str` プロパティを追加
- 全6サブクラス（Werewolf/Seer/Medium/Knight/Madman/Villager）に `color` を実装
- `renderer.py` と `cli.py` の `_ROLE_COLORS` dict を削除し `actor.role.color` に統一
- `MEDIUM_RESULT` イベントの色を yellow → cyan（Medium のロールカラー）に修正

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（112 passed）
- [x] `color` プロパティの全6ロールのパラメトリックテスト追加

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)