### PR TITLE
docs: add issue #76 to Ideas.md, remove closed #59

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,11 +13,11 @@
 
 | # | 種別 | 優先度 | タイトル | 内容 |
 |---|---|---|---|---|
+| yukkie/AgentVillage#76 | tech-debt | 🟢 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟢 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#71 | tech-debt | 🟢 | Eliminate redundant role: str from ActorState | ActorState.role: str と Actor.role.name の冗長性を解消 |
 | yukkie/AgentVillage#72 | tech-debt | 🟢 | Replace role name strings with Role type in Intent, ActorState.claimed_role, LogEvent | Intent.co / claimed_role / LogEvent.claimed_role を str から Role 型に変更 |
 | yukkie/AgentVillage#61 | tech-debt | 🟢 | Move common prompt content to Role ABC default methods | prompt.py のコンテンツ文字列を Role ABC のデフォルトメソッドに移動し、prompt.py をアセンブルのみに |
-| yukkie/AgentVillage#59 | tech-debt | 🟢 | Replace msvcrt with cross-platform key input | replay.py の Windows 専用 msvcrt をクロスプラットフォーム対応に置換 |
 | yukkie/AgentVillage#58 | tech-debt | 🟢 | Split GameEngine phases into dedicated modules | game.py を前夜・昼・夜フェーズモジュールに分割 |
 | yukkie/AgentVillage#21 | enhancement | 🟡 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#41 | tech-debt | 🟢 | Replace role string literals | タイポ時に実行時エラーにならない。#24 のRole化で定数に集約 |


### PR DESCRIPTION
- Issue #76（Refactor renderer.py into Renderer class with GUI migration hint）を Ideas.md に追記
- Issue #59（Replace msvcrt）はクローズ済みのため削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)