### PR TITLE
feat: parallelize LLM requests in day opening phase

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -33,6 +33,7 @@
 | yukkie/AgentVillage#27 | enhancement | 🟢 | 13 | Web / mobile app | FastAPI + WebSocket + React |
 | yukkie/AgentVillage#30 | enhancement | 🟢 | 13 | State management DB migration | JSON → DB 移行 |
 | yukkie/AgentVillage#79 | enhancement | 🟢 | - | Log analysis agent skill for post-game review | ゲームログをAgentに委譲して解析・サマリーを返すスキル |
+| yukkie/AgentVillage#84 | enhancement | 🟢 | - | Parallelize LLM requests in day speech phase | 発言順確定後にThreadPoolExecutorで並列リクエスト発行しゲームを高速化 |
 
 ---
 

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -135,41 +135,15 @@ class GameEngine:
         self._speech_id_counter += 1
         return self._speech_id_counter
 
-    def _do_speak(
+    def _apply_speech_output(
         self,
         actor: Actor,
+        output: AgentOutput,
         phase: Phase,
         reply_to_entry: SpeechEntry | None = None,
         force_co: bool = False,
     ) -> SpeechEntry:
-        """Generate a speech for actor, emit events, update memory, and append to today_log.
-
-        force_co=True injects the CO instruction into the speech prompt without mutating
-        actor.state.intended_co. Used when the actor chose "co" in the discussion judgment phase.
-        """
-        ctx = PublicContext(
-            today_log=list(self.today_log),
-            alive_players=self._alive_names(),
-            dead_players=self._dead_names(),
-            day=self.day,
-            all_agents=self.agents,
-            past_votes=self._past_votes,
-            past_deaths=self._past_deaths,
-        )
-        direction = SpeechDirection(
-            lang=self.lang,
-            reply_to_entry=reply_to_entry,
-            intended_co=actor.state.intended_co or force_co,
-        )
-        # TODO(#36): Add SeerSpecificContext / KnightSpecificContext / MediumSpecificContext
-        role_ctx = (
-            WolfSpecificContext(
-                wolf_partners=[a.name for a in self._alive_agents() if isinstance(a.role, Werewolf) and a.name != actor.name]
-            )
-            if isinstance(actor.role, Werewolf)
-            else None
-        )
-        output = llm_client.call(actor, ctx, direction, role_ctx)
+        """Post-process a speech output: emit events, update memory, append to today_log."""
         self._day_outputs[actor.name] = output
 
         # Safety net: enforce pre-night CO decision on the opening speech.
@@ -224,6 +198,52 @@ class GameEngine:
 
         return entry
 
+    def _build_speech_args(
+        self,
+        actor: Actor,
+        reply_to_entry: SpeechEntry | None = None,
+        force_co: bool = False,
+    ) -> tuple:
+        ctx = PublicContext(
+            today_log=list(self.today_log),
+            alive_players=self._alive_names(),
+            dead_players=self._dead_names(),
+            day=self.day,
+            all_agents=self.agents,
+            past_votes=self._past_votes,
+            past_deaths=self._past_deaths,
+        )
+        direction = SpeechDirection(
+            lang=self.lang,
+            reply_to_entry=reply_to_entry,
+            intended_co=actor.state.intended_co or force_co,
+        )
+        # TODO(#36): Add SeerSpecificContext / KnightSpecificContext / MediumSpecificContext
+        role_ctx = (
+            WolfSpecificContext(
+                wolf_partners=[a.name for a in self._alive_agents() if isinstance(a.role, Werewolf) and a.name != actor.name]
+            )
+            if isinstance(actor.role, Werewolf)
+            else None
+        )
+        return ctx, direction, role_ctx
+
+    def _do_speak(
+        self,
+        actor: Actor,
+        phase: Phase,
+        reply_to_entry: SpeechEntry | None = None,
+        force_co: bool = False,
+    ) -> SpeechEntry:
+        """Generate a speech for actor, emit events, update memory, and append to today_log.
+
+        force_co=True injects the CO instruction into the speech prompt without mutating
+        actor.state.intended_co. Used when the actor chose "co" in the discussion judgment phase.
+        """
+        ctx, direction, role_ctx = self._build_speech_args(actor, reply_to_entry, force_co)
+        output = llm_client.call(actor, ctx, direction, role_ctx)
+        return self._apply_speech_output(actor, output, phase, reply_to_entry, force_co)
+
     def _run_pre_night(self) -> None:
         """Pre-night phase: non-Villager agents secretly decide whether to CO on Day 1.
 
@@ -262,8 +282,10 @@ class GameEngine:
 
         opening_order = self._alive_agents()
         random.shuffle(opening_order)
-        for actor in opening_order:
-            self._do_speak(actor, Phase.DAY_OPENING)
+
+        opening_calls = [(actor, *self._build_speech_args(actor)) for actor in opening_order]
+        for actor, output in llm_client.call_speech_parallel(opening_calls):
+            self._apply_speech_output(actor, output, Phase.DAY_OPENING)
 
         # --- DISCUSSION × 2: 並列判断 → レスポンス順発言 ---
         self.phase = Phase.DAY_DISCUSSION

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -142,6 +142,19 @@ def call_judgment_parallel(
             yield actor, future.result()
 
 
+def call_speech_parallel(
+    calls: list[tuple[Actor, PublicContext, SpeechDirection, RoleSpecificContext | None]]
+) -> Iterator[tuple[Actor, AgentOutput]]:
+    """Fire all speech calls in parallel; yield results in completion order."""
+    with ThreadPoolExecutor() as executor:
+        future_to_actor = {
+            executor.submit(call, actor, ctx, direction, role_ctx): actor
+            for actor, ctx, direction, role_ctx in calls
+        }
+        for future in as_completed(future_to_actor):
+            yield future_to_actor[future], future.result()
+
+
 def call_pre_night_action(
     actor: Actor,
     alive_players: list[str],

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -51,6 +51,7 @@ class TestRunDayPhaseOrder:
         silent = JudgmentOutput(decision="silent")
 
         with (
+            patch("src.engine.game.llm_client.call_speech_parallel", side_effect=lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])),
             patch("src.engine.game.llm_client.call", side_effect=lambda ag, *a, **kw: _make_output(ag.name)),
             patch("src.engine.game.llm_client.call_judgment_parallel", return_value=iter(
                 [(agents[0], silent), (agents[1], silent), (agents[2], silent)]
@@ -75,6 +76,7 @@ class TestRunDayPhaseOrder:
         silent = JudgmentOutput(decision="silent")
 
         with (
+            patch("src.engine.game.llm_client.call_speech_parallel", side_effect=lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])),
             patch("src.engine.game.llm_client.call", side_effect=lambda ag, *a, **kw: _make_output(ag.name)),
             patch("src.engine.game.llm_client.call_judgment_parallel", return_value=iter(
                 [(agents[0], silent), (agents[1], silent)]
@@ -100,6 +102,7 @@ class TestRunDayPhaseOrder:
         silent = JudgmentOutput(decision="silent")
 
         with (
+            patch("src.engine.game.llm_client.call_speech_parallel", side_effect=lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])),
             patch("src.engine.game.llm_client.call", side_effect=lambda ag, *a, **kw: _make_output(ag.name)),
             patch("src.engine.game.llm_client.call_judgment_parallel", return_value=iter(
                 [(agents[1], challenge), (agents[0], silent)]
@@ -119,6 +122,7 @@ class TestRunDayPhaseOrder:
         silent = JudgmentOutput(decision="silent")
 
         with (
+            patch("src.engine.game.llm_client.call_speech_parallel", side_effect=lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])),
             patch("src.engine.game.llm_client.call", side_effect=lambda ag, *a, **kw: _make_output(ag.name)),
             patch("src.engine.game.llm_client.call_judgment_parallel", return_value=iter(
                 [(agents[0], silent), (agents[1], silent)]
@@ -150,6 +154,7 @@ class TestDiscussionCoDecision:
         )
 
         with (
+            patch("src.engine.game.llm_client.call_speech_parallel", side_effect=lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])),
             patch("src.engine.game.llm_client.call", return_value=co_output),
             patch("src.engine.game.llm_client.call_judgment_parallel", return_value=iter(
                 [(seer, co_judgment)]
@@ -171,6 +176,7 @@ class TestDiscussionCoDecision:
 
         call_mock = MagicMock(return_value=normal_output)
         with (
+            patch("src.engine.game.llm_client.call_speech_parallel", side_effect=lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])),
             patch("src.engine.game.llm_client.call", call_mock),
             patch("src.engine.game.llm_client.call_judgment_parallel", return_value=iter(
                 [(seer, co_judgment)]
@@ -194,6 +200,7 @@ class TestDiscussionCoDecision:
 
         call_mock = MagicMock(return_value=normal_output)
         with (
+            patch("src.engine.game.llm_client.call_speech_parallel", side_effect=lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])),
             patch("src.engine.game.llm_client.call", call_mock),
             patch("src.engine.game.llm_client.call_judgment_parallel", return_value=iter(
                 [(villager, co_judgment)]


### PR DESCRIPTION
## Summary
- 昼OPENINGフェーズの発言LLMリクエストを ThreadPoolExecutor で並列化
- `call_speech_parallel` を client.py に追加（call_judgment_parallel と同パターン）
- `_do_speak` から `_build_speech_args`（引数構築）と `_apply_speech_output`（post-processing）を分離
- DISCUSSIONフェーズは変更なし（reply_to/force_co の状態依存があるため sequential のまま）

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（112件）
- [ ] `call_speech_parallel` のモックをテスト全件に追加

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)