### PR TITLE
refactor: remove hardcoded fake-CO fallback, delegate to LLM

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -28,7 +28,6 @@
 | yukkie/AgentVillage#96 | tech-debt | 🟢 | - | Duplicated JSON format string in build_judgment_prompt | co_eligible分岐でフォーマット文字列がほぼ重複 |
 | yukkie/AgentVillage#97 | tech-debt | 🟢 | - | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |
 | yukkie/AgentVillage#99 | tech-debt | 🟢 | - | setup.py silently ignores JSON parse errors in config files | config JSON破損時にトレースバックが素通りする |
-| yukkie/AgentVillage#100 | tech-debt | 🟢 | - | Madman fake-CO role hardcoded to Seer instead of delegating to Role class | Madman偽COがRole未委譲でgame.pyにハードコード |
 | yukkie/AgentVillage#101 | tech-debt | 🟢 | - | check_victory() only supports two-faction win conditions | 二項対立のみ。第三陣営・Madman単独勝利に対応不可 |
 | yukkie/AgentVillage#102 | tech-debt | 🟢 | - | memory.update_memory() silently propagates IOError from store.save() | IOError無言伝播。呼び出し元で対処不可 |
 | yukkie/AgentVillage#103 | tech-debt | 🟢 | - | LogWriter.write() does not handle IOError — log failure crashes the game | ログ書き込み失敗でゲームが止まる |

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -147,10 +147,18 @@ class GameEngine:
         """Post-process a speech output: emit events, update memory, append to today_log."""
         self._day_outputs[actor.name] = output
 
-        # Safety net: enforce pre-night CO decision on the opening speech.
-        # Werewolf and Madman fall back to "Seer" (fake CO); others use their true role.
+        # If the actor intended to CO but did not declare in speech, log silently and clear the flag.
         if actor.state.intended_co and phase == Phase.DAY_OPENING and not output.intent.co:
-            output.intent.co = get_role("Seer") if isinstance(actor.role, Werewolf) else actor.role
+            actor.state.intended_co = False
+            store.save(actor)
+            self._emit(LogEvent.make(
+                day=self.day,
+                phase=phase.value,
+                event_type=EventType.PRE_NIGHT_DECISION,
+                agent=actor.name,
+                content=f"{actor.name} decided to CO but did not declare in speech",
+                is_public=False,
+            ))
 
         # Update claimed_role BEFORE emitting the speech so the CO speech itself
         # is rendered with the correct role color.

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -14,7 +14,7 @@ from src.action.types import Vote, Inspect, Attack
 from src.action.validator import validate
 from src.action.resolver import resolve_inspect, resolve_attack
 from src.domain.event import LogEvent, EventType
-from src.domain.roles import Werewolf, Knight, Seer, Medium, get_role
+from src.domain.roles import Werewolf, Knight, Seer, Medium
 from src.logger.writer import LogWriter
 
 


### PR DESCRIPTION
## Summary
- game.py L152 のハードコードフォールバック（`isinstance(Werewolf)` → Seer強制）を削除
- `intended_co=True` なのに LLM が `intent.co` を出力しなかった場合、非公開ログを残して `intended_co` をクリアする
- CO 戦略の判断はロール側の `co_prompt` を通じて LLM に委譲する設計に統一

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス (112 passed)
- [ ] 実ゲームで Madman / Werewolf が CO する場面を目視確認

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)