### PR TITLE
refactor: move discussion parallel execution to client.py

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -150,11 +150,17 @@ Day 1 OPENINGで `intended_co=True` なのにLLMがCOを出力しなかった場
 | `call_night_action()` | 夜行動 | 夜フェーズ専用 | `str`（ターゲット名） |
 | `call_pre_night_action()` | 前夜判断・単体呼び出し | 役職・性格・参加者情報 | `PreNightOutput` |
 | `call_pre_night_parallel()` | 前夜判断・並列呼び出し（`call_speech_parallel` と同パターン） | 同上 | `Iterator[tuple[AgentState, PreNightOutput]]` |
+| `call_discussion_parallel()` | 昼DISCUSSION 判断→発言チェーンの並列実行 | — | `Iterator[tuple[Actor, JudgmentOutput, AgentOutput \| None, SpeechEntry \| None, bool]]` |
 
 #### 並列実行
 
-`call_judgment()` は全生存エージェント分を `concurrent.futures.ThreadPoolExecutor` で並列実行する。
-outputが数トークンで済むため、全員分をほぼ同時に完了できる。
+並列 LLM 実行の責任は **client.py が一元管理する**。`ThreadPoolExecutor` は game.py に書かない。
+
+| 並列関数 | 用途 |
+|---|---|
+| `call_speech_parallel()` | DAY_OPENING — 全員発言を並列実行 |
+| `call_pre_night_parallel()` | PRE_NIGHT — CO判断を並列実行 |
+| `call_discussion_parallel()` | DAY_DISCUSSION — 判断→発言チェーンを並列実行 |
 
 #### Extended thinking
 
@@ -275,8 +281,9 @@ SQLite、PostgreSQL。
 昼フェーズに「判断ターン」を導入する。全エージェントに「challenge / speak / silent」の3択を並列で判断させ、発言意思があるエージェントだけ発言を生成する。発言順はAPIレスポンスが返ってきた順とする。
 
 **実装方法**
-- 各アクターに「`call_judgment()` → non-silent なら `call()`」をチェーンした callable を構成
-- `ThreadPoolExecutor` で全アクター分を並列実行
+- 各アクターに「`call_judgment()` → non-silent なら `build_speech_args()` → `call()`」をチェーンした callable を構成
+- `call_discussion_parallel()` が `ThreadPoolExecutor` で全アクター分を並列実行（client.py 内）
+- game.py はチェーン用の `build_speech_args` コールバックを渡し、並列実行自体は client.py に委譲する
 - `as_completed()` でレスポンス順に post-processing（`today_log` 更新・イベント発行）を逐次実行
 - 発言コンテキストはラウンド開始時のスナップショットを共有（同ラウンド内の他者発言は見えない）
 - challenge 時は `reply_to`（speech_id）をスナップショット内で解決しプロンプトに含める

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -33,10 +33,7 @@
 | yukkie/AgentVillage#103 | tech-debt | 🟢 | - | LogWriter.write() does not handle IOError — log failure crashes the game | ログ書き込み失敗でゲームが止まる |
 | yukkie/AgentVillage#104 | tech-debt | 🟢 | - | load_events() fails entirely if any log line is corrupted | 1行でも壊れると全ログが読めなくなる |
 | yukkie/AgentVillage#105 | tech-debt | 🟢 | - | ReplayPager crashes if archive agents/ dir is missing or has invalid JSON | アーカイブ破損時にリプレイ起動でクラッシュ |
-| yukkie/AgentVillage#107 | tech-debt | 🟢 | - | PR #106: _discussion_chain default-arg snapshot capture — smelly closure pattern | default引数でクロージャ問題を回避するやっつけパターン |
-| yukkie/AgentVillage#108 | tech-debt | 🟢 | - | PR #106: _discussion_chain nested in _run_day() worsens GameEngine bloat (#58) | ネスト関数がIssue #58の解決をさらに難しくした |
 | yukkie/AgentVillage#109 | tech-debt | 🟢 | - | PR #106: local import of Villager moved deeper into nested function, worsening #97 | ローカルインポートがさらに深いネストに埋没 |
-| yukkie/AgentVillage#110 | tech-debt | 🔴 | - | PR #106: ThreadPoolExecutor in game.py breaks client.py parallel execution convention | client.pyが並列実行を持つ規約をgame.pyが破った |
 | yukkie/AgentVillage#111 | tech-debt | 🟢 | - | PR #106: test_challenge_reply_to_recorded mock is not round-aware | モックがラウンド区別不可でアサーションが緩められた |
 | yukkie/AgentVillage#33 | enhancement | 🟢 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#36 | enhancement | 🟢 | 5 | Belief updates from agent reasoning | suspicion/trust を推理結果から更新 |

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -1,5 +1,4 @@
 import random
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable
 
 from src.domain.actor import Actor, Belief
@@ -288,49 +287,29 @@ class GameEngine:
             alive = self._alive_agents()
             snapshot = list(self.today_log)
 
-            def _discussion_chain(
-                actor: Actor,
-                _snap: list[SpeechEntry] = snapshot,
-            ) -> tuple:
-                from src.domain.roles import Villager
-                judgment = llm_client.call_judgment(
-                    actor, _snap, self._alive_names(), self.day, self.lang
-                )
-                if judgment.decision == "silent":
-                    return actor, judgment, None, None, False
-                is_co_eligible = actor.state.claimed_role is None and not isinstance(actor.role, Villager)
-                force_co = judgment.decision == "co" and is_co_eligible
-                reply_to_entry: SpeechEntry | None = None
-                if judgment.decision == "challenge" and judgment.reply_to is not None:
-                    reply_to_entry = next(
-                        (e for e in _snap if e.speech_id == judgment.reply_to),
-                        None,
-                    )
-                ctx, direction, role_ctx = self._build_speech_args(
-                    actor, reply_to_entry, force_co, today_log_snapshot=_snap
-                )
-                output = llm_client.call(actor, ctx, direction, role_ctx)
-                return actor, judgment, output, reply_to_entry, force_co
-
             spoke_anyone = False
-            with ThreadPoolExecutor() as executor:
-                futures = {executor.submit(_discussion_chain, actor): actor for actor in alive}
-                for future in as_completed(futures):
-                    actor, judgment, output, reply_to_entry, force_co = future.result()
-                    if output is None:
-                        self._emit(LogEvent.make(
-                            day=self.day,
-                            phase=Phase.DAY_DISCUSSION.value,
-                            event_type=EventType.SPEECH,
-                            agent=actor.name,
-                            content=f"{actor.name} is watching the village silently...",
-                            is_public=True,
-                        ))
-                    else:
-                        spoke_anyone = True
-                        self._apply_speech_output(
-                            actor, output, Phase.DAY_DISCUSSION, reply_to_entry, force_co
-                        )
+            for actor, judgment, output, reply_to_entry, force_co in llm_client.call_discussion_parallel(
+                alive,
+                snapshot,
+                self._alive_names(),
+                self.day,
+                self.lang,
+                self._build_speech_args,
+            ):
+                if output is None:
+                    self._emit(LogEvent.make(
+                        day=self.day,
+                        phase=Phase.DAY_DISCUSSION.value,
+                        event_type=EventType.SPEECH,
+                        agent=actor.name,
+                        content=f"{actor.name} is watching the village silently...",
+                        is_public=True,
+                    ))
+                else:
+                    spoke_anyone = True
+                    self._apply_speech_output(
+                        actor, output, Phase.DAY_DISCUSSION, reply_to_entry, force_co
+                    )
 
             if not spoke_anyone:
                 break  # 全員silentなら2巡目はスキップ

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -1,14 +1,14 @@
 import json
 import sys
+from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from collections.abc import Iterator
 
 import anthropic
 
 from src.domain.actor import Actor
-from src.llm.prompt import PublicContext, SpeechDirection, RoleSpecificContext, build_system_prompt, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_wolf_chat_prompt
-from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, SpeechEntry, WolfChatOutput
 from src.domain.roles import Villager
+from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, SpeechEntry, WolfChatOutput
+from src.llm.prompt import PublicContext, RoleSpecificContext, SpeechDirection, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_system_prompt, build_wolf_chat_prompt
 
 _client = anthropic.Anthropic()
 
@@ -181,6 +181,41 @@ def call_pre_night_parallel(
         for future in as_completed(future_to_agent):
             actor = future_to_agent[future]
             yield actor, future.result()
+
+
+def call_discussion_parallel(
+    actors: list[Actor],
+    today_log_snapshot: list[SpeechEntry],
+    alive_names: list[str],
+    day: int,
+    lang: str,
+    build_speech_args: Callable[
+        [Actor, SpeechEntry | None, bool, list[SpeechEntry]],
+        tuple[PublicContext, SpeechDirection, RoleSpecificContext | None],
+    ],
+) -> Iterator[tuple[Actor, JudgmentOutput, AgentOutput | None, SpeechEntry | None, bool]]:
+    """Run judgment→speech chain for all actors in parallel; yield results in completion order."""
+
+    def _chain(actor: Actor) -> tuple[Actor, JudgmentOutput, AgentOutput | None, SpeechEntry | None, bool]:
+        judgment = call_judgment(actor, today_log_snapshot, alive_names, day, lang)
+        if judgment.decision == "silent":
+            return actor, judgment, None, None, False
+        is_co_eligible = actor.state.claimed_role is None and not isinstance(actor.role, Villager)
+        force_co = judgment.decision == "co" and is_co_eligible
+        reply_to_entry: SpeechEntry | None = None
+        if judgment.decision == "challenge" and judgment.reply_to is not None:
+            reply_to_entry = next(
+                (e for e in today_log_snapshot if e.speech_id == judgment.reply_to),
+                None,
+            )
+        ctx, direction, role_ctx = build_speech_args(actor, reply_to_entry, force_co, today_log_snapshot)
+        output = call(actor, ctx, direction, role_ctx)
+        return actor, judgment, output, reply_to_entry, force_co
+
+    with ThreadPoolExecutor() as executor:
+        futures = {executor.submit(_chain, actor): actor for actor in actors}
+        for future in as_completed(futures):
+            yield future.result()
 
 
 def call_wolf_chat(


### PR DESCRIPTION
## Summary
- `client.py` に `call_discussion_parallel()` を新設し、昼DISCUSSION フェーズの判断→発言チェーン並列実行を担わせた
- `game.py` から `ThreadPoolExecutor` / `as_completed` のインポートと `_discussion_chain` ネスト関数を削除
- client.py が全並列 LLM 実行を一元管理する規約を回復（`call_speech_parallel`, `call_pre_night_parallel` との一貫性）

副次的に以下も解消:
- #107: `_discussion_chain` の default-arg スナップショットキャプチャ（ネスト関数自体が消えたため）
- #108: `_run_day()` 内のネスト関数による GameEngine bloat（30行のネスト関数を削除）

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（112件）
- [x] 既存の `test_game_day_loop.py` テストが変更なしで全件通過

Closes #110, #107, #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)