### PR TITLE
refactor: add can_co property to Role ABC (#116)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -26,7 +26,6 @@
 | yukkie/AgentVillage#94 | tech-debt | 🟢 | - | store.load() does not handle FileNotFoundError | ファイル不在時に未ハンドルの例外が伝播する |
 | yukkie/AgentVillage#95 | tech-debt | 🟢 | - | resolve_inspect() returns 'Unknown' but callers assume Werewolf/Not Werewolf | "Unknown"ケースをgame.py側が未処理。beliefs不整合の温床 |
 | yukkie/AgentVillage#96 | tech-debt | 🟢 | - | Duplicated JSON format string in build_judgment_prompt | co_eligible分岐でフォーマット文字列がほぼ重複 |
-| yukkie/AgentVillage#116 | tech-debt | 🔴 | - | Add can_co property to Role ABC to eliminate duplicated co-eligibility logic | client.pyの2箇所にis_co_eligibleの重複式、Role ABCに委譲すべき |
 | yukkie/AgentVillage#97 | tech-debt | 🟢 | - | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |
 | yukkie/AgentVillage#99 | tech-debt | 🟢 | - | setup.py silently ignores JSON parse errors in config files | config JSON破損時にトレースバックが素通りする |
 | yukkie/AgentVillage#101 | tech-debt | 🟢 | - | check_victory() only supports two-faction win conditions | 二項対立のみ。第三陣営・Madman単独勝利に対応不可 |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -26,6 +26,7 @@
 | yukkie/AgentVillage#94 | tech-debt | 🟢 | - | store.load() does not handle FileNotFoundError | ファイル不在時に未ハンドルの例外が伝播する |
 | yukkie/AgentVillage#95 | tech-debt | 🟢 | - | resolve_inspect() returns 'Unknown' but callers assume Werewolf/Not Werewolf | "Unknown"ケースをgame.py側が未処理。beliefs不整合の温床 |
 | yukkie/AgentVillage#96 | tech-debt | 🟢 | - | Duplicated JSON format string in build_judgment_prompt | co_eligible分岐でフォーマット文字列がほぼ重複 |
+| yukkie/AgentVillage#119 | tech-debt | 🟡 | - | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
 | yukkie/AgentVillage#97 | tech-debt | 🟢 | - | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |
 | yukkie/AgentVillage#99 | tech-debt | 🟢 | - | setup.py silently ignores JSON parse errors in config files | config JSON破損時にトレースバックが素通りする |
 | yukkie/AgentVillage#101 | tech-debt | 🟢 | - | check_victory() only supports two-faction win conditions | 二項対立のみ。第三陣営・Madman単独勝利に対応不可 |

--- a/src/domain/roles/role.py
+++ b/src/domain/roles/role.py
@@ -23,6 +23,10 @@ class Role(ABC):
     @abstractmethod
     def night_action(self) -> str | None: ...
 
+    @property
+    def can_co(self) -> bool:
+        return True
+
     @abstractmethod
     def role_prompt(self, wolf_partners: list[str] | None = None) -> str: ...
 

--- a/src/domain/roles/villager.py
+++ b/src/domain/roles/villager.py
@@ -18,6 +18,10 @@ class Villager(Role):
     def night_action(self) -> str | None:
         return None
 
+    @property
+    def can_co(self) -> bool:
+        return False
+
     def role_prompt(self, wolf_partners: list[str] | None = None) -> str:
         return (
             "You are a Villager. Your goal is to identify and eliminate the Werewolf through "

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -6,7 +6,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import anthropic
 
 from src.domain.actor import Actor
-from src.domain.roles import Villager
 from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, SpeechEntry, WolfChatOutput
 from src.llm.prompt import PublicContext, RoleSpecificContext, SpeechDirection, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_system_prompt, build_wolf_chat_prompt
 
@@ -102,7 +101,7 @@ def call_judgment(
     lang: str = "English",
 ) -> JudgmentOutput:
     """Call LLM for the lightweight parallel judgment decision."""
-    co_eligible = actor.state.claimed_role is None and not isinstance(actor.role, Villager)
+    co_eligible = actor.state.claimed_role is None and actor.role.can_co
     prompt = build_judgment_prompt(actor, today_log, alive_players, day, lang, co_eligible)
     raw = ""
     try:
@@ -200,7 +199,7 @@ def call_discussion_parallel(
         judgment = call_judgment(actor, today_log_snapshot, alive_names, day, lang)
         if judgment.decision == "silent":
             return actor, judgment, None, None, False
-        is_co_eligible = actor.state.claimed_role is None and not isinstance(actor.role, Villager)
+        is_co_eligible = actor.state.claimed_role is None and actor.role.can_co
         force_co = judgment.decision == "co" and is_co_eligible
         reply_to_entry: SpeechEntry | None = None
         if judgment.decision == "challenge" and judgment.reply_to is not None:


### PR DESCRIPTION
## Summary
- \`Role\` ABC に \`can_co: bool\` property を追加（デフォルト \`True\`）
- \`Villager\` が \`can_co = False\` でオーバーライド
- \`client.py\` の2箇所にあった \`isinstance(actor.role, Villager)\` による CO 可否チェックを \`actor.role.can_co\` に統一
- \`client.py\` から \`Villager\` インポートを削除

## Test plan
- [x] \`ruff check .\` パス
- [x] \`pytest\` パス（112件）
- [x] \`can_co\` property が Role Strategy パターンに沿って正しく委譲されることを確認

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)