### PR TITLE
refactor: replace role string literals in resolve_inspect (#41)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#61 | tech-debt | 🔴 | 3 | Move common prompt content to Role ABC default methods | prompt.py のコンテンツ文字列を Role ABC のデフォルトメソッドに移動し、prompt.py をアセンブルのみに |
-| yukkie/AgentVillage#41 | tech-debt | 🔴 | 1 | Replace role string literals | タイポ時に実行時エラーにならない。#24 のRole化で定数に集約 |
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#81 | tech-debt | 🟡 | 5 | Separate night action declaration and resolution phases | 夜フェーズの宣言・実行・公表を3段階に分離。seer_survived フラグ削除。キツネ等の複雑な相互作用に対応 |
@@ -24,7 +23,6 @@
 | yukkie/AgentVillage#92 | tech-debt | 🟢 | - | Hardcoded relative path STATE_DIR in store.py and setup.py | カレントディレクトリ依存の相対パスが2箇所に重複 |
 | yukkie/AgentVillage#93 | tech-debt | 🟢 | - | Module-level Anthropic client singleton makes testing difficult | _clientがモジュールロード時に生成されテスト時に差し替え不可 |
 | yukkie/AgentVillage#94 | tech-debt | 🟢 | - | store.load() does not handle FileNotFoundError | ファイル不在時に未ハンドルの例外が伝播する |
-| yukkie/AgentVillage#95 | tech-debt | 🟢 | - | resolve_inspect() returns 'Unknown' but callers assume Werewolf/Not Werewolf | "Unknown"ケースをgame.py側が未処理。beliefs不整合の温床 |
 | yukkie/AgentVillage#96 | tech-debt | 🟢 | - | Duplicated JSON format string in build_judgment_prompt | co_eligible分岐でフォーマット文字列がほぼ重複 |
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | - | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
 | yukkie/AgentVillage#97 | tech-debt | 🟢 | - | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |

--- a/src/action/resolver.py
+++ b/src/action/resolver.py
@@ -10,17 +10,16 @@ def resolve_vote(action: Vote, agents: list[Actor]) -> str:
     return action.target
 
 
-def resolve_inspect(action: Inspect, agents: list[Actor]) -> tuple[str, str]:
+def resolve_inspect(action: Inspect, agents: list[Actor]) -> tuple[str, Werewolf | None]:
     """
     Resolve a Seer's inspect action.
-    Returns (target_name, result) where result is "Werewolf" or "Not Werewolf".
+    Returns (target_name, result) where result is Werewolf instance if target is a Werewolf, else None.
     The Seer only learns alignment, not the specific role.
     """
     for actor in agents:
         if actor.name == action.target:
-            result = "Werewolf" if isinstance(actor.role, Werewolf) else "Not Werewolf"
-            return (actor.name, result)
-    return (action.target, "Unknown")
+            return (actor.name, actor.role if isinstance(actor.role, Werewolf) else None)
+    raise ValueError(f"resolve_inspect: target '{action.target}' not found in agents")
 
 
 def resolve_attack(action: Attack, agents: list[Actor]) -> str:

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -523,7 +523,7 @@ class GameEngine:
             name, result = resolve_inspect(inspect, self.agents)
             if name not in seer.state.beliefs:
                 seer.state.beliefs[name] = Belief()
-            if result == "Werewolf":
+            if isinstance(result, Werewolf):
                 seer.state.beliefs[name].suspicion = 1.0
                 seer.state.beliefs[name].trust = 0.0
                 seer.state.beliefs[name].reason.append(f"Day {self.day}: inspected as Werewolf")


### PR DESCRIPTION
## Summary
- \`resolve_inspect()\` の戻り型を \`tuple[str, str]\` → \`tuple[str, Werewolf | None]\` に変更
- \`"Werewolf"\` / \`"Not Werewolf"\` 文字列比較を廃止、\`isinstance(result, Werewolf)\` に統一
- \`"Unknown"\` サイレント返却を \`ValueError\` に変更（#95 も解消）

## Test plan
- [x] \`ruff check .\` パス
- [x] \`pytest\` パス（112件）

Closes #41
Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)