### PR TITLE
fix: paginate archive list in ArchiveSelector (#121)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -49,6 +49,7 @@
 | yukkie/AgentVillage#79 | enhancement | 🟢 | - | Log analysis agent skill for post-game review | ゲームログをAgentに委譲して解析・サマリーを返すスキル |
 | yukkie/AgentVillage#84 | enhancement | 🟢 | - | Parallelize LLM requests in day speech phase | 発言順確定後にThreadPoolExecutorで並列リクエスト発行しゲームを高速化 |
 | yukkie/AgentVillage#88 | enhancement | 🟢 | - | Merge judgment and speech into single LLM call using tool use | tool useで発言+アクション構造化を1ステップ化。OPENING/DISCUSSION設計を統一 |
+| yukkie/AgentVillage#121 | bug | 🔴 | - | fix: restore cursor-key log selection in replay UI | readchar移行後にreplayのカーソルキー選択が動かなくなったデグレ。原因はbefe3df（推測）|
 
 ---
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -49,7 +49,6 @@
 | yukkie/AgentVillage#79 | enhancement | 🟢 | - | Log analysis agent skill for post-game review | ゲームログをAgentに委譲して解析・サマリーを返すスキル |
 | yukkie/AgentVillage#84 | enhancement | 🟢 | - | Parallelize LLM requests in day speech phase | 発言順確定後にThreadPoolExecutorで並列リクエスト発行しゲームを高速化 |
 | yukkie/AgentVillage#88 | enhancement | 🟢 | - | Merge judgment and speech into single LLM call using tool use | tool useで発言+アクション構造化を1ステップ化。OPENING/DISCUSSION設計を統一 |
-| yukkie/AgentVillage#121 | bug | 🔴 | - | fix: restore cursor-key log selection in replay UI | readchar移行後にreplayのカーソルキー選択が動かなくなったデグレ。原因はbefe3df（推測）|
 
 ---
 

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -68,9 +68,14 @@ class ArchiveSelector:
         while True:
             _clear()
             print("Select an archive to replay:\n")
-            for i, arch in enumerate(archives):
+            size = shutil.get_terminal_size()
+            visible = max(1, size.lines - 4)
+            start = max(0, cursor - visible // 2)
+            end = min(len(archives), start + visible)
+            start = max(0, end - visible)
+            for i in range(start, end):
                 prefix = "  > " if i == cursor else "    "
-                print(f"{prefix}{arch.name}")
+                print(f"{prefix}{archives[i].name}")
             print("\n[↑↓] Move  [Enter] Select  [q] Quit")
 
             key = _getch()


### PR DESCRIPTION
## Summary
- ArchiveSelector のアーカイブ一覧がターミナル高さを超えると `>` カーソルが画面外に出て見えなくなる問題を修正
- `shutil.get_terminal_size()` でターミナル高さを取得し、cursor 周辺のウィンドウ分だけ表示するよう変更

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] アーカイブが33件ある状態でreplayを起動し、↑↓でカーソルが常に画面内に表示されること
- [ ] アーカイブが3件以下でも正常に動作すること

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)