### PR TITLE
refactor: replace magic round counts with named constants

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#90 | tech-debt | 🔴 | 2 | Extract shared _call_llm helper in client.py | call関数6種が同じAPIコール→JSON→fallbackパターンを重複している |
-| yukkie/AgentVillage#91 | tech-debt | 🔴 | 1 | Hardcoded discussion/wolf-chat round counts in GameEngine | range(2)/range(3)が直書き。設定変更にコード編集が必要 |
 | yukkie/AgentVillage#92 | tech-debt | 🔴 | 2 | Hardcoded relative path STATE_DIR in store.py and setup.py | カレントディレクトリ依存の相対パスが2箇所に重複 |
 | yukkie/AgentVillage#96 | tech-debt | 🔴 | 1 | Duplicated JSON format string in build_judgment_prompt | co_eligible分岐でフォーマット文字列がほぼ重複 |
 | yukkie/AgentVillage#107 | tech-debt | 🔴 | 2 | PR #106: _discussion_chain uses default-arg trick | snapshotをdefault引数で捕捉するスメルパターン |

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -16,6 +16,9 @@ from src.domain.event import LogEvent, EventType
 from src.domain.roles import Werewolf, Knight, Seer, Medium
 from src.logger.writer import LogWriter
 
+DISCUSSION_ROUNDS = 2
+WOLF_CHAT_ROUNDS = 3
+
 
 class GameEngine:
     def __init__(
@@ -282,7 +285,7 @@ class GameEngine:
 
         # --- DISCUSSION × 2: 全アクターの（判断→発言）チェーンを並列実行 ---
         self.phase = Phase.DAY_DISCUSSION
-        for _round in range(2):
+        for _round in range(DISCUSSION_ROUNDS):
             self._phase_start(Phase.DAY_DISCUSSION)
             alive = self._alive_agents()
             snapshot = list(self.today_log)
@@ -401,7 +404,7 @@ class GameEngine:
             wolf_names = [w.name for w in wolves]
             last_wolf_outputs = {w.name: None for w in wolves}
 
-            for _round in range(3):
+            for _round in range(WOLF_CHAT_ROUNDS):
                 for wolf in wolves:
                     partners = [n for n in wolf_names if n != wolf.name]
                     output = llm_client.call_wolf_chat(


### PR DESCRIPTION
## Summary
- `DISCUSSION_ROUNDS = 2` と `WOLF_CHAT_ROUNDS = 3` をモジュールレベル定数として定義
- game.py の `range(2)` / `range(3)` をそれぞれの定数に置き換え

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス (115 passed)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)