### PR TITLE
refactor: consolidate path and game constants into src/config.py

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -205,8 +205,8 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 
 | モジュール | 責務 |
 |---|---|
-| `logger.py` | 共通定数（`STATE_DIR`, `PUBLIC_LOG`, `SPECTATOR_LOG`, `ARCHIVE_DIR`）を一元管理。writer/reader が参照する |
-| `writer.py` | `public_log.jsonl`（全員公開）と `spectator_log.jsonl`（真実込み）への書き込み。定数は `logger.py` から import |
+| `logger.py` | 削除済み。定数は `src/config.py` に移管 |
+| `writer.py` | `public_log.jsonl`（全員公開）と `spectator_log.jsonl`（真実込み）への書き込み。定数は `src/config` から import |
 | `reader.py` | `load_events(path: Path) -> list[LogEvent]` — JSONL ログの読み込みユーティリティ。GUI・リプレイ・将来の外部ツールが共通利用する |
 | `replay.py` | ログを読んで再生する（将来のリプレイUI用） |
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#90 | tech-debt | 🔴 | 2 | Extract shared _call_llm helper in client.py | call関数6種が同じAPIコール→JSON→fallbackパターンを重複している |
-| yukkie/AgentVillage#92 | tech-debt | 🔴 | 2 | Hardcoded relative path STATE_DIR in store.py and setup.py | カレントディレクトリ依存の相対パスが2箇所に重複 |
 | yukkie/AgentVillage#96 | tech-debt | 🔴 | 1 | Duplicated JSON format string in build_judgment_prompt | co_eligible分岐でフォーマット文字列がほぼ重複 |
 | yukkie/AgentVillage#107 | tech-debt | 🔴 | 2 | PR #106: _discussion_chain uses default-arg trick | snapshotをdefault引数で捕捉するスメルパターン |
 | yukkie/AgentVillage#108 | tech-debt | 🔴 | 1 | PR #106: _discussion_chain nested inside _run_day() (#58のブロッカー) | ネスト関数が#58の分割を難しくしている |

--- a/src/agent/store.py
+++ b/src/agent/store.py
@@ -1,9 +1,8 @@
 import json
 from pathlib import Path
 
+from src.config import STATE_DIR
 from src.domain.actor import Actor, ActorState, make_actor
-
-STATE_DIR = Path("state/agents")
 
 
 def _ensure_dir() -> None:

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+# Game settings
+DISCUSSION_ROUNDS = 2
+WOLF_CHAT_ROUNDS = 3
+
+# Environment
+PROJECT_ROOT = Path(__file__).parent.parent
+STATE_DIR = PROJECT_ROOT / "state/agents"
+LOG_DIR = PROJECT_ROOT / "state"
+PUBLIC_LOG = LOG_DIR / "public_log.jsonl"
+SPECTATOR_LOG = LOG_DIR / "spectator_log.jsonl"
+ARCHIVE_DIR = PROJECT_ROOT / "state_archive"

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -1,6 +1,7 @@
 import random
 from typing import Callable
 
+from src.config import DISCUSSION_ROUNDS, WOLF_CHAT_ROUNDS
 from src.domain.actor import Actor, Belief
 from src.agent import store, memory as memory_mod
 from src.engine.phase import Phase

--- a/src/engine/setup.py
+++ b/src/engine/setup.py
@@ -4,13 +4,14 @@ import random
 import sys
 from pathlib import Path
 
+from src.config import STATE_DIR
 from src.domain.actor import Actor, ActorState, Belief, Persona, make_actor
 from src.agent import store
 
 
 def initialize_agents(num_players: int) -> list[Actor]:
     """Create and persist initial agent states with randomized roles."""
-    Path("state/agents").mkdir(parents=True, exist_ok=True)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
 
     agent_configs = json.loads(Path("config/agents.json").read_text(encoding="utf-8"))
     roles_config = json.loads(Path("config/roles.json").read_text(encoding="utf-8"))

--- a/src/logger/logger.py
+++ b/src/logger/logger.py
@@ -1,7 +1,0 @@
-"""Shared constants for the logger package."""
-from pathlib import Path
-
-STATE_DIR = Path("state")
-PUBLIC_LOG = STATE_DIR / "public_log.jsonl"
-SPECTATOR_LOG = STATE_DIR / "spectator_log.jsonl"
-ARCHIVE_DIR = Path("state_archive")

--- a/src/logger/writer.py
+++ b/src/logger/writer.py
@@ -2,8 +2,8 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 
+from src.config import ARCHIVE_DIR, LOG_DIR, PUBLIC_LOG, SPECTATOR_LOG
 from src.domain.event import LogEvent
-from src.logger.logger import ARCHIVE_DIR, PUBLIC_LOG, SPECTATOR_LOG, STATE_DIR
 
 
 def archive_state() -> Path | None:
@@ -16,13 +16,13 @@ def archive_state() -> Path | None:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     dest = ARCHIVE_DIR / timestamp
     ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(str(STATE_DIR), str(dest))
+    shutil.copytree(str(LOG_DIR), str(dest))
     return dest
 
 
 class LogWriter:
     def __init__(self) -> None:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
         # Clear logs at start of new game
         PUBLIC_LOG.write_text("", encoding="utf-8")
         SPECTATOR_LOG.write_text("", encoding="utf-8")


### PR DESCRIPTION
## Summary
- `src/config.py` を新規作成し、ゲーム設定・環境パス定数を一元管理
- `STATE_DIR`（state/agents）、`LOG_DIR`（state）、`PUBLIC_LOG`、`SPECTATOR_LOG`、`ARCHIVE_DIR` を集約
- `DISCUSSION_ROUNDS`、`WOLF_CHAT_ROUNDS` も config.py に移動
- `src/logger/logger.py` を削除（定数が config.py に移管されたため）
- store.py、setup.py、game.py、writer.py のimport先を更新

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス (115 passed)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)