### PR TITLE
refactor: dedup JSON format string in build_judgment_prompt

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#90 | tech-debt | 🔴 | 2 | Extract shared _call_llm helper in client.py | call関数6種が同じAPIコール→JSON→fallbackパターンを重複している |
-| yukkie/AgentVillage#96 | tech-debt | 🔴 | 1 | Duplicated JSON format string in build_judgment_prompt | co_eligible分岐でフォーマット文字列がほぼ重複 |
 | yukkie/AgentVillage#107 | tech-debt | 🔴 | 2 | PR #106: _discussion_chain uses default-arg trick | snapshotをdefault引数で捕捉するスメルパターン |
 | yukkie/AgentVillage#108 | tech-debt | 🔴 | 1 | PR #106: _discussion_chain nested inside _run_day() (#58のブロッカー) | ネスト関数が#58の分割を難しくしている |
 | yukkie/AgentVillage#109 | tech-debt | 🔴 | 1 | PR #106: local import of Villager moved deeper (#97のブロッカー) | ローカルインポートがさらに深いネストに埋没 |

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -268,32 +268,20 @@ def build_judgment_prompt(
         for e in recent:
             lines.append(f"  [{e.speech_id}] {e.agent}: {e.text}")
 
+    decision_options = '"challenge" | "speak" | "silent" | "co"' if co_eligible else '"challenge" | "speak" | "silent"'
+    lines.append(f"""
+Decide your next action. Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
+{{
+  "decision": {decision_options},
+  "reply_to": <speech_id to challenge, or null>
+}}
+- "challenge": directly counter a specific speech (set reply_to to its speech_id)
+- "speak": add a new statement unprompted
+- "silent": nothing to add right now""")
     if co_eligible:
         co_hint = actor.role.co_strategy_hint()
-        lines.append(f"""
-Decide your next action. Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
-{{
-  "decision": "challenge" | "speak" | "silent" | "co",
-  "reply_to": <speech_id to challenge, or null>
-}}
-- "challenge": directly counter a specific speech (set reply_to to its speech_id)
-- "speak": add a new statement unprompted
-- "silent": nothing to add right now
-- "co": publicly declare your role (Coming-Out) in your next speech
-{co_hint}
-- The JSON must contain exactly these two fields and nothing else.
-Use {lang} only for internal reasoning if needed, but keep the JSON minimal.""")
-    else:
-        lines.append(f"""
-Decide your next action. Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
-{{
-  "decision": "challenge" | "speak" | "silent",
-  "reply_to": <speech_id to challenge, or null>
-}}
-- "challenge": directly counter a specific speech (set reply_to to its speech_id)
-- "speak": add a new statement unprompted
-- "silent": nothing to add right now
-- The JSON must contain exactly these two fields and nothing else.
+        lines.append(f'- "co": publicly declare your role (Coming-Out) in your next speech\n{co_hint}')
+    lines.append(f"""- The JSON must contain exactly these two fields and nothing else.
 Use {lang} only for internal reasoning if needed, but keep the JSON minimal.""")
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- `build_judgment_prompt` の2つのブランチに重複していたJSONフォーマット文字列を統合
- 共通部分は1つの `lines.append`、`co_eligible` 専用行のみ条件付きで挿入

## Test plan
- [x] `ruff check src/llm/prompt.py` パス
- [x] `pytest` 115件パス

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)