### PR TITLE
refactor: add Role.__eq__ and simplify slide-CO comparison

### DIFF
--- a/src/domain/roles/role.py
+++ b/src/domain/roles/role.py
@@ -78,6 +78,12 @@ Rules:
 - Do NOT include your real role in speech unless you are doing a CO
 """
 
+    def __eq__(self, other: object) -> bool:
+        return type(self) is type(other)
+
+    def __hash__(self) -> int:
+        return hash(type(self))
+
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         return core_schema.is_instance_schema(cls)

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -162,9 +162,7 @@ class GameEngine:
 
         # Update claimed_role BEFORE emitting the speech so the CO speech itself
         # is rendered with the correct role color.
-        # Only emit CO_ANNOUNCEMENT when the claimed role actually changes
-        # (prevents duplicate announcements when LLM spontaneously repeats intent.co).
-        if output.intent.co and type(output.intent.co) is not type(actor.state.claimed_role):
+        if output.intent.co and actor.state.claimed_role != output.intent.co:
             actor.state.claimed_role = output.intent.co
             actor.state.intended_co = False  # clear once CO is made
             store.save(actor)


### PR DESCRIPTION
## Summary
- `Role` 基底クラスに `__eq__` / `__hash__` を追加（同クラスのインスタンスを等値とみなす）
- `game.py` のスライドCO条件を型比較から `!=` 演算子に簡略化

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` 115件パス

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)