### PR TITLE
docs: add issue #138 to Ideas.md (複数LLM対応の設計検討)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -45,6 +45,7 @@
 | yukkie/AgentVillage#29 | enhancement | 🟢 | 8 | Persona community sharing | キャラテンプレートの共有 |
 | yukkie/AgentVillage#27 | enhancement | 🟢 | 13 | Web / mobile app | FastAPI + WebSocket + React |
 | yukkie/AgentVillage#30 | enhancement | 🟢 | 13 | State management DB migration | JSON → DB 移行 |
+| yukkie/AgentVillage#138 | enhancement | 🟢 | - | 複数LLM対応の設計検討 | 将来の複数LLMプロバイダー対応に向けた設計・ADRの検討 |
 
 ---
 


### PR DESCRIPTION
## Summary
- Ideas.md の GitHub Issues 一覧に #138（複数LLM対応の設計検討）を追加

## Test plan
- [ ] Ideas.md のテーブルに #138 が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)