### PR TITLE
docs: remove issue #108 from Ideas.md (completed)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#107 | tech-debt | 🔴 | 2 | PR #106: _discussion_chain uses default-arg trick | snapshotをdefault引数で捕捉するスメルパターン |
-| yukkie/AgentVillage#108 | tech-debt | 🔴 | 1 | PR #106: _discussion_chain nested inside _run_day() (#58のブロッカー) | ネスト関数が#58の分割を難しくしている |
 | yukkie/AgentVillage#109 | tech-debt | 🔴 | 1 | PR #106: local import of Villager moved deeper (#97のブロッカー) | ローカルインポートがさらに深いネストに埋没 |
 | yukkie/AgentVillage#111 | tech-debt | 🔴 | 2 | PR #106: test_challenge_reply_to_recorded mock is not round-aware | モックがラウンド区別不可でアサーションが緩められた |
 | yukkie/AgentVillage#93 | tech-debt | 🟡 | 3 | Module-level Anthropic client singleton makes testing difficult | _clientがモジュールロード時に生成されテスト時に差し替え不可 |


### PR DESCRIPTION
## Summary
- Issue #108 (`_discussion_chain` nested inside `_run_day()`) は #110 の実装ですでに解消済みであることを確認
- `_discussion_chain` はコードベースから除去されており AC を満たしている
- Ideas.md から #108 の行を削除

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)