### PR TITLE
docs: remove issues #107 and #109 from Ideas.md (completed)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,8 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#107 | tech-debt | 🔴 | 2 | PR #106: _discussion_chain uses default-arg trick | snapshotをdefault引数で捕捉するスメルパターン |
-| yukkie/AgentVillage#109 | tech-debt | 🔴 | 1 | PR #106: local import of Villager moved deeper (#97のブロッカー) | ローカルインポートがさらに深いネストに埋没 |
 | yukkie/AgentVillage#111 | tech-debt | 🔴 | 2 | PR #106: test_challenge_reply_to_recorded mock is not round-aware | モックがラウンド区別不可でアサーションが緩められた |
 | yukkie/AgentVillage#93 | tech-debt | 🟡 | 3 | Module-level Anthropic client singleton makes testing difficult | _clientがモジュールロード時に生成されテスト時に差し替え不可 |
 | yukkie/AgentVillage#97 | tech-debt | 🟡 | 3 | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |


### PR DESCRIPTION
## Summary
- Issue #107、#109 はいずれも `_discussion_chain` 関連で #110 の実装により解消済みを確認
- Ideas.md から該当2行を削除

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)