### PR TITLE
refactor: make test_challenge_reply_to_recorded round-aware

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,6 +13,7 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
+| yukkie/AgentVillage#143 | tech-debt | 🟡 | - | Revise TestStrategy.md: define DUT-first test design principles | DUT定義・Mock隔離原則・テストレベル分類（pytest markers + docstring規約）の整備 |
 | yukkie/AgentVillage#93 | tech-debt | 🟡 | 3 | Module-level Anthropic client singleton makes testing difficult | _clientがモジュールロード時に生成されテスト時に差し替え不可 |
 | yukkie/AgentVillage#97 | tech-debt | 🟡 | 3 | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |
 | yukkie/AgentVillage#101 | tech-debt | 🟡 | 3 | check_victory() only supports two-faction win conditions | 二項対立のみ。第三陣営・Madman単独勝利に対応不可 |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#111 | tech-debt | 🔴 | 2 | PR #106: test_challenge_reply_to_recorded mock is not round-aware | モックがラウンド区別不可でアサーションが緩められた |
 | yukkie/AgentVillage#93 | tech-debt | 🟡 | 3 | Module-level Anthropic client singleton makes testing difficult | _clientがモジュールロード時に生成されテスト時に差し替え不可 |
 | yukkie/AgentVillage#97 | tech-debt | 🟡 | 3 | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |
 | yukkie/AgentVillage#101 | tech-debt | 🟡 | 3 | check_victory() only supports two-faction win conditions | 二項対立のみ。第三陣営・Madman単独勝利に対応不可 |

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -96,6 +96,7 @@ class TestRunDayPhaseOrder:
             return challenge if actor.name == "B" else silent
 
         with (
+            patch("src.engine.game.DISCUSSION_ROUNDS", 1),
             patch("src.engine.game.llm_client.call_speech_parallel", side_effect=lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])),
             patch("src.engine.game.llm_client.call", side_effect=lambda ag, *a, **kw: _make_output(ag.name)),
             patch("src.engine.game.llm_client.call_judgment", side_effect=judgment_side_effect),
@@ -104,7 +105,7 @@ class TestRunDayPhaseOrder:
             engine._run_day()
 
         challenge_events = [e for e in events if e.reply_to is not None and e.is_public]
-        assert len(challenge_events) >= 1
+        assert len(challenge_events) == 1
         assert all(e.reply_to == 1 for e in challenge_events)
 
     def test_all_silent_does_not_raise(self):


### PR DESCRIPTION
## Summary
- `test_challenge_reply_to_recorded` に `patch("src.engine.game.DISCUSSION_ROUNDS", 1)` を追加し、テスト内でディスカッションを1ラウンドに限定
- `assert len(challenge_events) >= 1` を `== 1` に戻し、意図したシナリオ（Bがラウンド1で1回だけチャレンジ）を明示的に検証

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)