### PR TITLE
docs: revise TestStrategy.md with SUT-first test design principles

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#143 | tech-debt | 🔴 | 2 | Revise TestStrategy.md: define DUT-first test design principles | DUT定義・Mock隔離原則・テストレベル分類（pytest markers + docstring規約）の整備 |
 | yukkie/AgentVillage#93 | tech-debt | 🟡 | 3 | Module-level Anthropic client singleton makes testing difficult | _clientがモジュールロード時に生成されテスト時に差し替え不可 |
 | yukkie/AgentVillage#97 | tech-debt | 🟡 | 3 | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |
 | yukkie/AgentVillage#101 | tech-debt | 🟡 | 3 | check_victory() only supports two-faction win conditions | 二項対立のみ。第三陣営・Madman単独勝利に対応不可 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,9 @@ dev = [
     "ruff>=0.4.0",
     "pre-commit>=4.0.0",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "unit: unit tests (no I/O, no network)",
+    "integration: integration tests (real I/O or multi-module)",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,5 @@ dev = [
 markers = [
     "unit: unit tests (no I/O, no network)",
     "integration: integration tests (real I/O or multi-module)",
+    "e2e: end-to-end tests covering full game flow (may call real LLM API; skipped in CI by default)",
 ]

--- a/tests/TestStrategy.md
+++ b/tests/TestStrategy.md
@@ -1,42 +1,132 @@
-# {ProjectName} Test Strategy
+# AgentVillage Test Strategy
 
-本ドキュメントでは、テスト戦略（何を単体テストし、何をE2E/統合テストでカバーするのか）をモジュールごとに定義します。
-
-## 1. テスト方針の基本原則
-
-- **Unit Test (単体テスト)**: 外部ネットワーク (HTTP) やデータベースに依存しない、副作用のない「純粋なロジック」や「データ変換処理」を対象とします。境界値やエッジケースの検証を高速に行うことを目的とします。
-- **E2E / Integration Test (統合テスト)**: モジュール間の連携、外部APIの呼び出しからDB保存まで、一連のパイプライン全体が正しく動作することをモックとテストデータを使って確認します。
+本ドキュメントは、テスト設計の原則・テストレベルの定義・規約を定める。
 
 ---
 
-## 2. モジュールごとのテストスコープ
+## 1. SUT-first テスト設計原則
 
-### `src/{module}.py`
-- **役割**: <!-- モジュールの責務 -->
-- **Unit Test**:
-  - **対象**: <!-- テスト対象のロジック・関数 -->
-  - **検証項目**: <!-- 何を検証するか -->
+テストを書く前に **SUT（System Under Test）** — つまり「何をテストするか」を先に定義する。
 
-### `src/{module}.py`
-- **役割**: <!-- モジュールの責務 -->
-- **Unit Test**: **対象外**
-  - **理由**: <!-- なぜ単体テストしないか -->
-- **E2E Test**: <!-- どのE2Eテストでカバーするか -->
+### 原則
+
+1. **SUTを先に宣言する** — テストファイル冒頭のdocstringにSUTを明記してから書き始める
+2. **MockはSUTを隔離するための手段** — Mockは「SUTの依存を取り除くため」に使う。Mockが多いほどテストの価値は下がる
+3. **1テスト = 1つのSUT観点** — 複数のロジックを1つのテストで検証しない
+
+### アンチパターン
+
+| アンチパターン | 問題 |
+|---|---|
+| Mockを先に決めてからテストを書く | テスト対象が曖昧になり、実装詳細に密結合する |
+| 定数パッチで副作用を迂回する | SUTの本来の振る舞いではなく副作用の回避をテストしている |
+| Unit/Integrationの境界が曖昧 | テストが遅くなり、失敗原因の特定が難しくなる |
 
 ---
 
-## 3. 現在のテスト戦略でカバーされていない領域（未テスト領域）
+## 2. テストレベル定義
 
-費用対効果や現在のプロジェクトフェーズを考慮し、以下の領域は意図的に**テスト自動化の対象外**としています。
+### Unit Test (`@pytest.mark.unit`)
 
-1. **外部APIの実接続テスト (Live Integration)**
-   - **内容**: <!-- 何のテストか -->
-   - **理由**: 外部サービスへの負荷・Flaky Test のリスクを避けるため。
+- **対象**: 単一の関数・クラスの純粋なロジック
+- **条件**: ファイルI/O・ネットワーク・外部プロセスに依存しない（`tmp_path` は可）
+- **速度**: ミリ秒単位で完了すること
 
-2. **実DBへの統合テスト (DB Integration)**
-   - **内容**: <!-- 何のテストか -->
-   - **理由**: 検証用DBインスタンスの用意とCI連携コストが高いため。
+### Integration Test (`@pytest.mark.integration`)
 
-3. **UI のブラウザ操作テスト (Visual Regression)**
-   - **内容**: <!-- 何のテストか -->
-   - **理由**: 保守コストが高いため、目視確認（手動検証）に留める。
+- **対象**: 複数モジュールの連携、または実際のファイルI/Oを伴う動作
+- **条件**: 実LLM API呼び出しは含まない（コストとFlakyリスクのため）
+- **速度**: 秒単位まで許容
+
+マーカーを省略した場合は `unit` として扱う（CI設定に準じる）。
+
+---
+
+## 3. docstring 規約
+
+各テスト関数には以下の3要素をdocstringで明示する:
+
+```python
+def test_load_events_skips_blank_lines(tmp_path: Path) -> None:
+    """
+    SUT: load_events()
+    Mock: なし（tmp_path で実ファイルI/Oを使用）
+    Level: unit
+    空行を含むJSONLファイルから、空行をスキップしてイベントを読み込めること。
+    """
+```
+
+既存テストで1行docstringのみの場合は、新規追加・修正時に合わせて補完する。
+
+---
+
+## 4. モジュールごとのテストスコープ
+
+### `src/agent/store.py`
+
+- **SUT**: `load_all_from_dir()`, `load_all()`, `save()`
+- **Unit Test**: `tests/unit/test_store.py`
+  - `load_all_from_dir` が正常系・空ディレクトリを正しく処理すること
+  - `load_all` が `load_all_from_dir(STATE_DIR)` に委譲していること
+- **Mock**: `monkeypatch` で `STATE_DIR` を差し替え
+
+### `src/logger/reader.py`
+
+- **SUT**: `load_events()`
+- **Unit Test**: `tests/unit/test_logger_reader.py`
+  - 正常系・空ファイル・存在しないファイル・空行スキップ
+- **Mock**: なし（`tmp_path` で実ファイルI/O）
+
+### `src/logger/writer.py`
+
+- **SUT**: `LogWriter.write()`
+- **Unit Test**: 未実装（Issue #103 参照）
+  - IOError 時にゲームがクラッシュしないこと
+
+### `src/llm/prompt.py`
+
+- **SUT**: `build_system_prompt()`, `build_pre_night_prompt()`, `build_judgment_prompt()` 等
+- **Unit Test**: `tests/unit/test_prompt.py`, `tests/unit/test_judgment_prompt.py`, `tests/unit/test_pre_night.py`
+  - 各種フラグ・ロール・フェーズに応じたプロンプト文字列の内容検証
+- **Mock**: `Actor`, `GameEngine` を `MagicMock` で構築
+
+### `src/llm/extract.py`
+
+- **SUT**: JSONパース・スキーマバリデーション関数
+- **Unit Test**: `tests/unit/test_extract_json.py`
+- **Mock**: なし（純粋な文字列→オブジェクト変換）
+
+### `src/domain/schema.py`
+
+- **SUT**: Pydanticスキーマのバリデーション
+- **Unit Test**: `tests/unit/test_judgment_schema.py`
+- **Mock**: なし
+
+### `src/agent/setup.py`
+
+- **SUT**: `initialize_agents()`
+- **Unit Test**: `tests/unit/test_setup.py`
+- **Mock**: ファイルI/Oを `tmp_path` または `monkeypatch` で差し替え
+
+### `src/engine/game.py` (`GameEngine`)
+
+- **SUT**: 昼・夜・勝利判定フェーズの制御フロー
+- **Unit Test**: `tests/unit/test_game_day_loop.py`, `tests/unit/test_pre_night.py`
+  - LLM呼び出しを `MagicMock` で差し替えてフロー分岐を検証
+- **Mock**: `LLMClient`, `LogWriter`, `store.save`
+
+### `main.py`
+
+- **SUT**: `main()` のCLI引数解釈とモジュール呼び出し順
+- **Unit Test**: `tests/unit/test_main.py`
+- **Mock**: `GameEngine`, `CLI`, `LogWriter`, `initialize_agents`, `archive_state`
+
+---
+
+## 5. 意図的未カバー領域
+
+| 領域 | 理由 |
+|---|---|
+| 実LLM API呼び出し（Live Integration） | APIコスト・Flakyリスクを避けるため。`MagicMock` で代替 |
+| LLM出力の品質・整合性検証 | Issue #45（promptfoo導入）で別途対応予定 |
+| UIのターミナル描画（Visual Regression） | 保守コストが高いため目視確認に留める |

--- a/tests/TestStrategy.md
+++ b/tests/TestStrategy.md
@@ -38,13 +38,19 @@
 - **条件**: 実LLM API呼び出しは含まない（コストとFlakyリスクのため）
 - **速度**: 秒単位まで許容
 
+### E2E Test (`@pytest.mark.e2e`)
+
+- **対象**: ゲーム開始から終了までの一連のフロー全体
+- **条件**: 実LLM API呼び出しを含む場合がある。CI では原則スキップ（手動実行）
+- **速度**: 分単位まで許容
+
 マーカーを省略した場合は `unit` として扱う（CI設定に準じる）。
 
 ---
 
 ## 3. docstring 規約
 
-各テスト関数には以下の3要素をdocstringで明示する:
+各テスト関数には以下の4要素をdocstringで明示する:
 
 ```python
 def test_load_events_skips_blank_lines(tmp_path: Path) -> None:
@@ -52,11 +58,19 @@ def test_load_events_skips_blank_lines(tmp_path: Path) -> None:
     SUT: load_events()
     Mock: なし（tmp_path で実ファイルI/Oを使用）
     Level: unit
-    空行を含むJSONLファイルから、空行をスキップしてイベントを読み込めること。
+    Objective: 空行を含むJSONLファイルから、空行をスキップしてイベントを読み込めること。
     """
 ```
 
-既存テストで1行docstringのみの場合は、新規追加・修正時に合わせて補完する。
+- **SUT**: テスト対象の関数・クラス・メソッド名
+- **Mock**: 使用するMock/monkeypatchとその目的。なければ「なし」と明記
+- **Level**: `unit` / `integration` / `e2e` のいずれか
+- **Objective**: このテストが何を検証するかを1文で記述する
+
+### クリーンアップ規約
+
+既存テストを変更する場合は、変更対象のテスト関数のdocstringを本規約に沿って修正する。
+新規追加のテストは最初から本規約に従うこと。
 
 ---
 


### PR DESCRIPTION
## Summary
- TestStrategy.md を全面改訂。SUT-first 原則・テストレベル定義・docstring規約を整備
- テストレベルに E2E (`@pytest.mark.e2e`) を追加
- docstring 規約に SUT / Mock / Level / Objective の4要素を定義
- 既存テスト変更時のクリーンアップ規約を追加
- pyproject.toml に pytest markers (unit / integration / e2e) を追加

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（115 passed）

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)