### PR TITLE
fix: error handling for log write, corrupt log lines, and replay crash (#103/#104/#105)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -17,9 +17,6 @@
 | yukkie/AgentVillage#93 | tech-debt | 🟡 | 3 | Module-level Anthropic client singleton makes testing difficult | _clientがモジュールロード時に生成されテスト時に差し替え不可 |
 | yukkie/AgentVillage#97 | tech-debt | 🟡 | 3 | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |
 | yukkie/AgentVillage#101 | tech-debt | 🟡 | 3 | check_victory() only supports two-faction win conditions | 二項対立のみ。第三陣営・Madman単独勝利に対応不可 |
-| yukkie/AgentVillage#103 | tech-debt | 🔴 | 1 | LogWriter.write() does not handle IOError — log failure crashes the game ⚠️unit test mandatory | ログ書き込み失敗でゲームが止まる |
-| yukkie/AgentVillage#104 | tech-debt | 🔴 | 1 | load_events() fails entirely if any log line is corrupted ⚠️unit test mandatory | 1行でも壊れると全ログが読めなくなる |
-| yukkie/AgentVillage#105 | tech-debt | 🔴 | 1 | ReplayPager crashes if archive agents/ dir is missing or has invalid JSON ⚠️unit test mandatory | アーカイブ破損時にリプレイ起動でクラッシュ |
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | 3 | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |

--- a/src/logger/reader.py
+++ b/src/logger/reader.py
@@ -1,5 +1,6 @@
 """JSONL log reading utilities shared across UI and future tooling."""
 import json
+import warnings
 from pathlib import Path
 
 from src.domain.event import LogEvent
@@ -13,8 +14,12 @@ def load_events(path: Path) -> list[LogEvent]:
     if not path.exists():
         return []
     events = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if line:
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
             events.append(LogEvent.model_validate(json.loads(line)))
+        except Exception as e:
+            warnings.warn(f"Skipping corrupted log line: {e}", stacklevel=2)
     return events

--- a/src/logger/writer.py
+++ b/src/logger/writer.py
@@ -1,4 +1,5 @@
 import shutil
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -29,10 +30,13 @@ class LogWriter:
 
     def write(self, event: LogEvent) -> None:
         line = event.model_dump_json() + "\n"
-        # Spectator log contains everything
-        with SPECTATOR_LOG.open("a", encoding="utf-8") as f:
-            f.write(line)
-        # Public log only contains public events
-        if event.is_public:
-            with PUBLIC_LOG.open("a", encoding="utf-8") as f:
+        try:
+            # Spectator log contains everything
+            with SPECTATOR_LOG.open("a", encoding="utf-8") as f:
                 f.write(line)
+            # Public log only contains public events
+            if event.is_public:
+                with PUBLIC_LOG.open("a", encoding="utf-8") as f:
+                    f.write(line)
+        except IOError as e:
+            print(f"[LogWriter] write failed: {e}", file=sys.stderr)

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -11,8 +11,9 @@ import readchar
 from rich.console import Console
 from rich.text import Text
 
-from src.agent import store
-from src.domain.actor import Actor, make_actor
+import json
+
+from src.domain.actor import Actor, ActorState, make_actor
 from src.domain.event import EventType, LogEvent
 from src.logger.reader import load_events
 from src.ui.renderer import render_event
@@ -101,7 +102,18 @@ class ReplayPager:
         self._lines = self._build_lines()
 
     def _load_agents(self) -> list[Actor]:
-        return store.load_all_from_dir(self._archive / "agents")
+        agents_dir = self._archive / "agents"
+        if not agents_dir.exists():
+            print(f"[ReplayPager] agents/ directory not found: {agents_dir}", file=sys.stderr)
+            return []
+        actors = []
+        for p in sorted(agents_dir.glob("*.json")):
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+                actors.append(make_actor(ActorState.model_validate(data), data["role"]))
+            except Exception as e:
+                print(f"[ReplayPager] skipping corrupt agent file {p.name}: {e}", file=sys.stderr)
+        return actors
 
     def _load_events(self) -> list[LogEvent]:
         log_file = "spectator_log.jsonl" if self._spectator else "public_log.jsonl"

--- a/tests/unit/test_logger_reader.py
+++ b/tests/unit/test_logger_reader.py
@@ -55,3 +55,37 @@ def test_load_events_skips_blank_lines(tmp_path: Path) -> None:
 
     result = load_events(p)
     assert len(result) == 1
+
+
+def test_load_events_skips_corrupted_lines_with_warning(tmp_path: Path) -> None:
+    """壊れた行はスキップされ、警告が出て、正常な行は読み込まれること。"""
+    good = _make_event(day=1)
+    p = tmp_path / "log.jsonl"
+    p.write_text(
+        good.model_dump_json() + "\n" + "NOT_JSON\n" + _make_event(day=2).model_dump_json() + "\n",
+        encoding="utf-8",
+    )
+
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = load_events(p)
+
+    assert len(result) == 2
+    assert any("corrupted" in str(w.message).lower() for w in caught)
+
+
+def test_load_events_skips_invalid_schema_with_warning(tmp_path: Path) -> None:
+    """JSON だがスキーマが壊れた行もスキップされること。"""
+    p = tmp_path / "log.jsonl"
+    p.write_text('{"invalid": true}\n', encoding="utf-8")
+
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = load_events(p)
+
+    assert result == []
+    assert len(caught) == 1

--- a/tests/unit/test_logger_writer.py
+++ b/tests/unit/test_logger_writer.py
@@ -1,0 +1,52 @@
+"""Unit tests for src/logger/writer.py — LogWriter.write()."""
+from pathlib import Path
+from unittest.mock import patch
+
+from src.domain.event import EventType, LogEvent
+
+
+def _make_event(is_public: bool = True) -> LogEvent:
+    return LogEvent.make(
+        day=1,
+        phase="day_opening",
+        event_type=EventType.SPEECH,
+        agent="Alice",
+        content="hello",
+        is_public=is_public,
+    )
+
+
+def test_write_creates_log_files(tmp_path: Path) -> None:
+    """正常系: ログファイルにイベントが書き込まれること。"""
+    with (
+        patch("src.logger.writer.LOG_DIR", tmp_path),
+        patch("src.logger.writer.PUBLIC_LOG", tmp_path / "public_log.jsonl"),
+        patch("src.logger.writer.SPECTATOR_LOG", tmp_path / "spectator_log.jsonl"),
+    ):
+        from src.logger.writer import LogWriter
+
+        writer = LogWriter()
+        writer.write(_make_event(is_public=True))
+
+        assert (tmp_path / "spectator_log.jsonl").read_text(encoding="utf-8").strip()
+        assert (tmp_path / "public_log.jsonl").read_text(encoding="utf-8").strip()
+
+
+def test_write_ioerror_prints_to_stderr_and_does_not_raise(tmp_path: Path) -> None:
+    """IOError 発生時にゲームが止まらず stderr に出力されること。"""
+    with (
+        patch("src.logger.writer.LOG_DIR", tmp_path),
+        patch("src.logger.writer.PUBLIC_LOG", tmp_path / "public_log.jsonl"),
+        patch("src.logger.writer.SPECTATOR_LOG", tmp_path / "spectator_log.jsonl"),
+    ):
+        from src.logger.writer import LogWriter
+
+        writer = LogWriter()
+
+        import io
+        fake_stderr = io.StringIO()
+        # Path.open を IOError に差し替え（LogWriter.__init__ 後なので write() だけに作用）
+        with patch("pathlib.Path.open", side_effect=IOError("disk full")):
+            with patch("src.logger.writer.sys.stderr", fake_stderr):
+                writer.write(_make_event())
+        assert "disk full" in fake_stderr.getvalue()

--- a/tests/unit/ui/test_replay.py
+++ b/tests/unit/ui/test_replay.py
@@ -126,3 +126,65 @@ def test_selector_returns_none_when_dir_missing(tmp_path: Path) -> None:
     selector = ArchiveSelector(tmp_path / "nonexistent")
     result = selector.select()
     assert result is None
+
+
+# ── ReplayPager エラーハンドリング (#105) ─────────────────────────────────────
+
+
+def test_pager_loads_empty_when_agents_dir_missing(tmp_path: Path) -> None:
+    """agents/ ディレクトリが存在しないとき空リストを返し、クラッシュしないこと。"""
+    archive = tmp_path / "20260101_000000"
+    archive.mkdir()
+    event = LogEvent.make(
+        day=1,
+        phase="day_opening",
+        event_type=EventType.SPEECH,
+        agent="Alice",
+        content="Hello.",
+        is_public=True,
+    )
+    (archive / "public_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
+    (archive / "spectator_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
+
+    import sys
+    from io import StringIO
+
+    captured = StringIO()
+    with patch.object(sys, "stderr", captured):
+        pager = ReplayPager(archive, spectator_mode=False)
+
+    assert pager._agents == []
+    assert "agents/ directory not found" in captured.getvalue()
+
+
+def test_pager_skips_corrupt_agent_file(tmp_path: Path) -> None:
+    """agents/ 内の壊れた JSON ファイルはスキップされ、正常ファイルは読み込まれること。"""
+    archive = tmp_path / "20260101_000000"
+    agents_dir = archive / "agents"
+    agents_dir.mkdir(parents=True)
+
+    good_data = _make_agent_json("Alice", "Villager")
+    (agents_dir / "alice.json").write_text(json.dumps(good_data), encoding="utf-8")
+    (agents_dir / "bob.json").write_text("NOT_JSON", encoding="utf-8")
+
+    event = LogEvent.make(
+        day=1,
+        phase="day_opening",
+        event_type=EventType.SPEECH,
+        agent="Alice",
+        content="Hello.",
+        is_public=True,
+    )
+    (archive / "public_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
+    (archive / "spectator_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
+
+    import sys
+    from io import StringIO
+
+    captured = StringIO()
+    with patch.object(sys, "stderr", captured):
+        pager = ReplayPager(archive, spectator_mode=False)
+
+    assert len(pager._agents) == 1
+    assert pager._agents[0].name == "Alice"
+    assert "bob.json" in captured.getvalue()


### PR DESCRIPTION
## Summary
- #103: `LogWriter.write()` の IOError をキャッチして stderr に出力。ゲームは続行
- #104: `load_events()` の壊れた行を `warnings.warn` でスキップ。正常行は読み込み継続
- #105: `ReplayPager._load_agents()` で `agents/` 不在・JSON破損を捕捉して明確なエラーを表示

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（121 tests）
- [ ] IOError 時に stderr 出力・クラッシュなし（`test_logger_writer.py`）
- [ ] 壊れたログ行がスキップされ警告が出る（`test_logger_reader.py`）
- [ ] `agents/` 不在・JSON破損時に空リスト+エラーメッセージ（`test_replay.py`）

Closes #103
Closes #104
Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)