### PR TITLE
fix: error handling for store, setup, memory (#94 #99 #102)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,9 +21,6 @@
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#81 | tech-debt | 🟡 | 5 | Separate night action declaration and resolution phases | 夜フェーズの宣言・実行・公表を3段階に分離。seer_survived フラグ削除。キツネ等の複雑な相互作用に対応 |
 | yukkie/AgentVillage#58 | tech-debt | 🟡 | 8 | Split GameEngine phases into dedicated modules | game.py を前夜・昼・夜フェーズモジュールに分割 |
-| yukkie/AgentVillage#94 | tech-debt | 🟢 | 1 | store.load() does not handle FileNotFoundError ⚠️unit test mandatory | ファイル不在時に未ハンドルの例外が伝播する |
-| yukkie/AgentVillage#99 | tech-debt | 🟢 | 1 | setup.py silently ignores JSON parse errors in config files ⚠️unit test mandatory | config JSON破損時にトレースバックが素通りする |
-| yukkie/AgentVillage#102 | tech-debt | 🟢 | 1 | memory.update_memory() silently propagates IOError from store.save() ⚠️unit test mandatory | IOError無言伝播。呼び出し元で対処不可 |
 | yukkie/AgentVillage#33 | enhancement | 🟢 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#36 | enhancement | 🟢 | 5 | Belief updates from agent reasoning | suspicion/trust を推理結果から更新 |
 | yukkie/AgentVillage#47 | enhancement | 🟢 | 3 | Reasoning field for Vote/Guard/Divination/Judgment | 各アクションに reasoning を追加し spectator ログ・memory_update に記録 |

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -1,5 +1,9 @@
+import logging
+
 from src.domain.actor import Actor
 from src.agent import store
+
+logger = logging.getLogger(__name__)
 
 
 def update_memory(actor: Actor, memory_updates: list[str]) -> Actor:
@@ -7,5 +11,8 @@ def update_memory(actor: Actor, memory_updates: list[str]) -> Actor:
     for item in memory_updates:
         if item and item not in actor.state.memory_summary:
             actor.state.memory_summary.append(item)
-    store.save(actor)
+    try:
+        store.save(actor)
+    except OSError as e:
+        raise OSError(f"Failed to persist memory for {actor.name}: {e}") from e
     return actor

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -1,9 +1,5 @@
-import logging
-
 from src.domain.actor import Actor
 from src.agent import store
-
-logger = logging.getLogger(__name__)
 
 
 def update_memory(actor: Actor, memory_updates: list[str]) -> Actor:

--- a/src/agent/store.py
+++ b/src/agent/store.py
@@ -19,6 +19,8 @@ def save(actor: Actor) -> None:
 
 def load(name: str) -> Actor:
     path = STATE_DIR / f"{name.lower()}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Agent state file not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
     return make_actor(ActorState.model_validate(data), data["role"])
 

--- a/src/engine/setup.py
+++ b/src/engine/setup.py
@@ -13,8 +13,23 @@ def initialize_agents(num_players: int) -> list[Actor]:
     """Create and persist initial agent states with randomized roles."""
     STATE_DIR.mkdir(parents=True, exist_ok=True)
 
-    agent_configs = json.loads(Path("config/agents.json").read_text(encoding="utf-8"))
-    roles_config = json.loads(Path("config/roles.json").read_text(encoding="utf-8"))
+    try:
+        agent_configs = json.loads(Path("config/agents.json").read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print("Error: config/agents.json not found.")
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error: config/agents.json is not valid JSON: {e}")
+        sys.exit(1)
+
+    try:
+        roles_config = json.loads(Path("config/roles.json").read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print("Error: config/roles.json not found.")
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error: config/roles.json is not valid JSON: {e}")
+        sys.exit(1)
 
     key = str(num_players)
     if key not in roles_config:

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -1,0 +1,64 @@
+"""src/agent/memory.py のテスト。"""
+import pytest
+
+from src.domain.actor import Actor, ActorState, Persona
+from src.agent.memory import update_memory
+
+
+def _make_actor(name: str = "Alice") -> Actor:
+    from src.domain.actor import make_actor
+    state = ActorState(
+        name=name,
+        persona=Persona(style="calm"),
+        beliefs={},
+        memory_summary=[],
+        is_alive=True,
+    )
+    return make_actor(state, "Villager")
+
+
+def test_update_memory_appends_new_items(monkeypatch) -> None:
+    """
+    SUT: update_memory()
+    Mock: monkeypatch で store.save を no-op に差し替え
+    Level: unit
+    Objective: 新しい記憶が memory_summary に追記されること。
+    """
+    from src.agent import memory as mem_mod
+    monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
+    actor = _make_actor()
+    result = update_memory(actor, ["saw wolf", "suspect Bob"])
+    assert result.state.memory_summary == ["saw wolf", "suspect Bob"]
+
+
+def test_update_memory_skips_duplicates(monkeypatch) -> None:
+    """
+    SUT: update_memory()
+    Mock: monkeypatch で store.save を no-op に差し替え
+    Level: unit
+    Objective: 既存の記憶と重複するアイテムは追記されないこと。
+    """
+    from src.agent import memory as mem_mod
+    monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
+    actor = _make_actor()
+    actor.state.memory_summary.append("saw wolf")
+    update_memory(actor, ["saw wolf", "new info"])
+    assert actor.state.memory_summary == ["saw wolf", "new info"]
+
+
+def test_update_memory_raises_on_io_error(monkeypatch) -> None:
+    """
+    SUT: update_memory()
+    Mock: monkeypatch で store.save が OSError を送出するよう差し替え
+    Level: unit
+    Objective: store.save() が OSError を送出したとき、コンテキスト付きで OSError が re-raise されること。
+    """
+    from src.agent import memory as mem_mod
+
+    def failing_save(_):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mem_mod.store, "save", failing_save)
+    actor = _make_actor()
+    with pytest.raises(OSError, match="Failed to persist memory for Alice"):
+        update_memory(actor, ["some update"])

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -49,3 +49,42 @@ def test_initialize_agents_invalid_player_count():
     """存在しないプレイヤー数を指定したとき sys.exit が呼ばれること。"""
     with pytest.raises(SystemExit):
         initialize_agents(99)
+
+
+def test_initialize_agents_corrupt_agents_json(monkeypatch):
+    """
+    SUT: initialize_agents()
+    Mock: monkeypatch で Path.read_text を差し替え、agents.json 読み込み時に不正JSONを返す
+    Level: unit
+    Objective: agents.json が不正な JSON のとき sys.exit(1) が呼ばれること。
+    """
+    original_read = Path.read_text
+
+    def fake_read(self, **kwargs):
+        if self.name == "agents.json":
+            return "{not valid json"
+        return original_read(self, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read)
+    with pytest.raises(SystemExit):
+        initialize_agents(5)
+
+
+def test_initialize_agents_corrupt_roles_json(monkeypatch):
+    """
+    SUT: initialize_agents()
+    Mock: monkeypatch で Path.read_text を差し替え、roles.json 読み込み時に不正JSONを返す
+    Level: unit
+    Objective: roles.json が不正な JSON のとき sys.exit(1) が呼ばれること。
+    """
+    original_read = Path.read_text
+
+    def fake_read(self, **kwargs):
+        if self.name == "roles.json":
+            return "{not valid json"
+        return original_read(self, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read)
+    with patch("src.agent.store.save"):
+        with pytest.raises(SystemExit):
+            initialize_agents(5)

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -48,6 +48,18 @@ def test_load_all_from_dir_empty(tmp_path: Path) -> None:
     assert store.load_all_from_dir(empty_dir) == []
 
 
+def test_load_missing_file_raises(tmp_path: Path, monkeypatch) -> None:
+    """
+    SUT: load()
+    Mock: monkeypatch で STATE_DIR を tmp_path に差し替え
+    Level: unit
+    Objective: 存在しないエージェントファイルを load() したとき FileNotFoundError が送出されること。
+    """
+    monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+    with pytest.raises(FileNotFoundError, match="Agent state file not found"):
+        store.load("ghost")
+
+
 def test_load_all_delegates_to_load_all_from_dir(agents_dir: Path, monkeypatch) -> None:
     """load_all() が load_all_from_dir(STATE_DIR) に委譲していること。"""
     called_with: list[Path] = []


### PR DESCRIPTION
## Summary
- `store.load()`: ファイル不在時に明確な `FileNotFoundError` を送出（パス付きメッセージ）
- `setup.initialize_agents()`: `agents.json` / `roles.json` の `JSONDecodeError` をキャッチして `sys.exit(1)` + 明確なエラーメッセージ
- `memory.update_memory()`: `store.save()` の `OSError` をコンテキスト付きで re-raise

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス (127 passed)
- [ ] `test_store.py`: `load()` missing file → `FileNotFoundError`
- [ ] `test_setup.py`: corrupt `agents.json` / `roles.json` → `SystemExit`
- [ ] `test_memory.py`: `store.save()` `OSError` → `OSError` with context

Closes #94
Closes #99
Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)