### PR TITLE
refactor: inject llm client into game engine

### DIFF
--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -8,6 +8,7 @@ from src.engine.phase import Phase
 from src.engine.vote import tally_votes
 from src.engine.victory import check_victory
 from src.llm import factory as llm_factory
+from src.llm.client import LLMClient
 from src.llm.prompt import PublicContext, SpeechDirection, WolfSpecificContext
 from src.domain.schema import AgentOutput, SpeechEntry
 from src.action.types import Vote, Inspect, Attack
@@ -25,12 +26,13 @@ class GameEngine:
         log_writer: LogWriter,
         event_callback: Callable[[LogEvent], None] | None = None,
         lang: str = "English",
+        llm_client: LLMClient | None = None,
     ):
         self.agents = agents
         self.log_writer = log_writer
         self.event_callback = event_callback or (lambda e: None)
         self.lang = lang
-        self._llm_client = llm_factory.create_client()
+        self._llm_client = llm_client or llm_factory.create_client()
         self.day = 1
         self.phase = Phase.DAY_OPENING
         self.today_log: list[SpeechEntry] = []

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -10,6 +10,7 @@ from src.engine.phase import Phase
 from src.domain.schema import AgentOutput, Intent, JudgmentOutput
 from src.domain.event import EventType, LogEvent
 from src.domain.roles import Seer
+from src.llm.client import LLMClient
 from src.logger.writer import LogWriter
 
 
@@ -38,9 +39,30 @@ def _make_engine(agents: list[Actor]) -> tuple[GameEngine, list[LogEvent]]:
     events: list[LogEvent] = []
     log_writer = MagicMock(spec=LogWriter)
     log_writer.write.side_effect = lambda e: events.append(e)
-    with patch("src.engine.game.llm_factory.create_client", return_value=MagicMock()):
-        engine = GameEngine(agents=agents, log_writer=log_writer, lang="English")
+    llm_client = MagicMock(spec=LLMClient)
+    engine = GameEngine(
+        agents=agents,
+        log_writer=log_writer,
+        lang="English",
+        llm_client=llm_client,
+    )
     return engine, events
+
+
+class TestGameEngineLlmInjection:
+    def test_uses_injected_llm_client_without_factory_patch(self):
+        agents = [_make_agent("A")]
+        log_writer = MagicMock(spec=LogWriter)
+        injected_llm = MagicMock(spec=LLMClient)
+
+        engine = GameEngine(
+            agents=agents,
+            log_writer=log_writer,
+            lang="English",
+            llm_client=injected_llm,
+        )
+
+        assert engine._llm_client is injected_llm
 
 
 def _silent_discussion(actors, *_, **__):

--- a/tests/unit/test_pre_night.py
+++ b/tests/unit/test_pre_night.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from src.domain.actor import ActorState, Actor, Persona, make_actor
 from src.engine.game import GameEngine
 from src.engine.phase import Phase
+from src.llm.client import LLMClient
 from src.llm.prompt import PublicContext, SpeechDirection, WolfSpecificContext, build_pre_night_prompt, build_system_prompt
 from src.domain.schema import PreNightOutput
 from src.domain.event import EventType, LogEvent
@@ -31,8 +32,13 @@ def _make_engine(agents: list[Actor]) -> tuple[GameEngine, list[LogEvent]]:
     events: list[LogEvent] = []
     log_writer = MagicMock(spec=LogWriter)
     log_writer.write.side_effect = lambda e: events.append(e)
-    with patch("src.engine.game.llm_factory.create_client", return_value=MagicMock()):
-        engine = GameEngine(agents=agents, log_writer=log_writer, lang="English")
+    llm_client = MagicMock(spec=LLMClient)
+    engine = GameEngine(
+        agents=agents,
+        log_writer=log_writer,
+        lang="English",
+        llm_client=llm_client,
+    )
     return engine, events
 
 


### PR DESCRIPTION
## Summary
- add optional llm_client injection to GameEngine while preserving the default factory path
- update unit tests to pass MagicMock(spec=LLMClient) directly instead of patching the factory
- add a regression test confirming the injected client is used

## Test plan
- [x] .\\.venv\\Scripts\\python.exe -m pytest tests/unit/test_game_day_loop.py tests/unit/test_pre_night.py
- [x] pre-commit pytest hook during git commit

Closes #151