### PR TITLE
test: consolidate shared engine helpers into conftest

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,8 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#151 | tech-debt | 🟡 | 2 | Make LLMClient injectable into GameEngine via constructor argument | GameEngineのコンストラクタにllm_client引数を追加し、テストでpatch不要にする |
-| yukkie/AgentVillage#152 | tech-debt | 🟡 | 2 | Consolidate duplicate test helpers into tests/unit/conftest.py | _make_agent/_make_engineが5ファイルで重複。conftest.pyに集約（#151完了後にpatchも除去可能） |
 | yukkie/AgentVillage#97 | tech-debt | 🟡 | 3 | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | 3 | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.domain.actor import Actor, ActorState, Persona, make_actor
+from src.domain.event import LogEvent
+from src.engine.game import GameEngine
+from src.llm.client import LLMClient
+from src.logger.writer import LogWriter
+
+
+@pytest.fixture
+def make_test_actor():
+    def _make_test_actor(name: str, role: str = "Villager") -> Actor:
+        state = ActorState(
+            name=name,
+            persona=Persona(style="calm", lie_tendency=0.1, aggression=0.2),
+            beliefs={},
+            memory_summary=[],
+            is_alive=True,
+        )
+        return make_actor(state, role)
+
+    return _make_test_actor
+
+
+@pytest.fixture
+def make_test_engine():
+    def _make_test_engine(agents: list[Actor]) -> tuple[GameEngine, list[LogEvent]]:
+        events: list[LogEvent] = []
+        log_writer = MagicMock(spec=LogWriter)
+        log_writer.write.side_effect = lambda e: events.append(e)
+        llm_client = MagicMock(spec=LLMClient)
+        engine = GameEngine(
+            agents=agents,
+            log_writer=log_writer,
+            lang="English",
+            llm_client=llm_client,
+        )
+        return engine, events
+
+    return _make_test_engine

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -4,25 +4,13 @@ LLM呼び出し (LLMClient メソッド) はモック。
 """
 from unittest.mock import MagicMock, patch
 
-from src.domain.actor import ActorState, Actor, Persona, make_actor
 from src.engine.game import GameEngine
 from src.engine.phase import Phase
 from src.domain.schema import AgentOutput, Intent, JudgmentOutput
-from src.domain.event import EventType, LogEvent
+from src.domain.event import EventType
 from src.domain.roles import Seer
 from src.llm.client import LLMClient
 from src.logger.writer import LogWriter
-
-
-def _make_agent(name: str, role: str = "Villager") -> Actor:
-    state = ActorState(
-        name=name,
-        persona=Persona(style="calm", lie_tendency=0.1, aggression=0.2),
-        beliefs={},
-        memory_summary=[],
-        is_alive=True,
-    )
-    return make_actor(state, role)
 
 
 def _make_output(name: str, speech: str = "Hello.") -> AgentOutput:
@@ -35,23 +23,9 @@ def _make_output(name: str, speech: str = "Hello.") -> AgentOutput:
     )
 
 
-def _make_engine(agents: list[Actor]) -> tuple[GameEngine, list[LogEvent]]:
-    events: list[LogEvent] = []
-    log_writer = MagicMock(spec=LogWriter)
-    log_writer.write.side_effect = lambda e: events.append(e)
-    llm_client = MagicMock(spec=LLMClient)
-    engine = GameEngine(
-        agents=agents,
-        log_writer=log_writer,
-        lang="English",
-        llm_client=llm_client,
-    )
-    return engine, events
-
-
 class TestGameEngineLlmInjection:
-    def test_uses_injected_llm_client_without_factory_patch(self):
-        agents = [_make_agent("A")]
+    def test_uses_injected_llm_client_without_factory_patch(self, make_test_actor):
+        agents = [make_test_actor("A")]
         log_writer = MagicMock(spec=LogWriter)
         injected_llm = MagicMock(spec=LLMClient)
 
@@ -71,9 +45,9 @@ def _silent_discussion(actors, *_, **__):
 
 
 class TestRunDayPhaseOrder:
-    def test_opening_then_discussion_then_vote(self):
-        agents = [_make_agent("A"), _make_agent("B"), _make_agent("C", "Werewolf")]
-        engine, events = _make_engine(agents)
+    def test_opening_then_discussion_then_vote(self, make_test_actor, make_test_engine):
+        agents = [make_test_actor("A"), make_test_actor("B"), make_test_actor("C", "Werewolf")]
+        engine, events = make_test_engine(agents)
         engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
         engine._llm_client.call_discussion_parallel.side_effect = _silent_discussion
 
@@ -88,9 +62,9 @@ class TestRunDayPhaseOrder:
         assert phases.index(Phase.DAY_OPENING.value) < phases.index(Phase.DAY_DISCUSSION.value)
         assert phases.index(Phase.DAY_DISCUSSION.value) < phases.index(Phase.DAY_VOTE.value)
 
-    def test_speech_ids_are_sequential(self):
-        agents = [_make_agent("A"), _make_agent("B")]
-        engine, events = _make_engine(agents)
+    def test_speech_ids_are_sequential(self, make_test_actor, make_test_engine):
+        agents = [make_test_actor("A"), make_test_actor("B")]
+        engine, events = make_test_engine(agents)
         engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
         engine._llm_client.call_discussion_parallel.side_effect = _silent_discussion
 
@@ -105,9 +79,9 @@ class TestRunDayPhaseOrder:
         assert ids == sorted(ids)
         assert ids == list(range(1, len(ids) + 1))
 
-    def test_challenge_reply_to_recorded(self):
-        agents = [_make_agent("A"), _make_agent("B")]
-        engine, events = _make_engine(agents)
+    def test_challenge_reply_to_recorded(self, make_test_actor, make_test_engine):
+        agents = [make_test_actor("A"), make_test_actor("B")]
+        engine, events = make_test_engine(agents)
         engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
 
         # B challenges speech_id=1 (A's opening speech)
@@ -117,8 +91,8 @@ class TestRunDayPhaseOrder:
             # find speech_id=1 entry from today_log
             reply_to_entry = next((e for e in today_log if e.speech_id == 1), None)
             return iter([
-                (_make_agent("A"), JudgmentOutput(decision="silent"), None, None, False),
-                (_make_agent("B"), challenge, _make_output("B"), reply_to_entry, False),
+                (make_test_actor("A"), JudgmentOutput(decision="silent"), None, None, False),
+                (make_test_actor("B"), challenge, _make_output("B"), reply_to_entry, False),
             ])
 
         engine._llm_client.call_discussion_parallel.side_effect = discussion_with_challenge
@@ -133,9 +107,9 @@ class TestRunDayPhaseOrder:
         assert len(challenge_events) == 1
         assert all(e.reply_to == 1 for e in challenge_events)
 
-    def test_all_silent_does_not_raise(self):
-        agents = [_make_agent("A"), _make_agent("B", "Werewolf")]
-        engine, _ = _make_engine(agents)
+    def test_all_silent_does_not_raise(self, make_test_actor, make_test_engine):
+        agents = [make_test_actor("A"), make_test_actor("B", "Werewolf")]
+        engine, _ = make_test_engine(agents)
         engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
         engine._llm_client.call_discussion_parallel.side_effect = _silent_discussion
 
@@ -148,11 +122,11 @@ class TestRunDayPhaseOrder:
 class TestDiscussionCoDecision:
     """Tests for the "co" judgment option in discussion phase."""
 
-    def test_eligible_agent_co_sets_claimed_role(self):
+    def test_eligible_agent_co_sets_claimed_role(self, make_test_actor, make_test_engine):
         """Seer (unclaimed) chooses co → claimed_role is set after speaking."""
-        seer = _make_agent("Seer1", "Seer")
+        seer = make_test_actor("Seer1", "Seer")
         assert seer.state.claimed_role is None
-        engine, _ = _make_engine([seer])
+        engine, _ = make_test_engine([seer])
 
         co_output = AgentOutput(
             thought="I'll CO now.",
@@ -171,11 +145,11 @@ class TestDiscussionCoDecision:
 
         assert isinstance(seer.state.claimed_role, Seer)
 
-    def test_ineligible_agent_co_treated_as_speak(self):
+    def test_ineligible_agent_co_treated_as_speak(self, make_test_actor, make_test_engine):
         """Agent that already claimed a role cannot CO again — falls back to speak."""
-        seer = _make_agent("Seer1", "Seer")
+        seer = make_test_actor("Seer1", "Seer")
         seer.state.claimed_role = "Seer"  # already claimed
-        engine, _ = _make_engine([seer])
+        engine, _ = make_test_engine([seer])
 
         normal_output = _make_output("Seer1", "Just speaking.")
         engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
@@ -190,10 +164,10 @@ class TestDiscussionCoDecision:
         # co intent is None in normal_output → claimed_role unchanged
         assert seer.state.claimed_role is not None  # still the old value, not set again
 
-    def test_villager_co_treated_as_speak(self):
+    def test_villager_co_treated_as_speak(self, make_test_actor, make_test_engine):
         """Villager cannot CO — co judgment falls back to speak (force_co=False)."""
-        villager = _make_agent("V1", "Villager")
-        engine, _ = _make_engine([villager])
+        villager = make_test_actor("V1", "Villager")
+        engine, _ = make_test_engine([villager])
 
         normal_output = _make_output("V1", "Just talking.")
         engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])

--- a/tests/unit/test_judgment_prompt.py
+++ b/tests/unit/test_judgment_prompt.py
@@ -3,7 +3,7 @@ from src.llm.prompt import build_judgment_prompt
 from src.domain.schema import SpeechEntry
 
 
-def _make_agent(
+def _make_actor(
     name: str = "Setsu",
     role: str = "Villager",
     memory: list[str] | None = None,
@@ -26,67 +26,67 @@ def _make_log(*texts: str) -> list[SpeechEntry]:
 
 class TestBuildJudgmentPrompt:
     def test_contains_agent_name_and_role(self):
-        agent = _make_agent()
-        prompt = build_judgment_prompt(agent, [], ["Setsu", "SQ"], day=1)
+        actor = _make_actor()
+        prompt = build_judgment_prompt(actor, [], ["Setsu", "SQ"], day=1)
         assert "Setsu" in prompt
         assert "Villager" in prompt
 
     def test_contains_recent_speeches_with_ids(self):
-        agent = _make_agent()
+        actor = _make_actor()
         log = _make_log("Hello everyone.", "I suspect SQ.")
-        prompt = build_judgment_prompt(agent, log, ["Setsu", "SQ"], day=1)
+        prompt = build_judgment_prompt(actor, log, ["Setsu", "SQ"], day=1)
         assert "[1]" in prompt
         assert "[2]" in prompt
         assert "Hello everyone." in prompt
 
     def test_only_last_6_speeches_included(self):
-        agent = _make_agent()
+        actor = _make_actor()
         log = _make_log(*[f"speech {i}" for i in range(10)])
-        prompt = build_judgment_prompt(agent, log, ["Setsu"], day=2)
+        prompt = build_judgment_prompt(actor, log, ["Setsu"], day=2)
         # speech 0-3 should be excluded (only last 6: 4-9)
         assert "speech 0" not in prompt
         assert "speech 9" in prompt
 
     def test_memory_included(self):
-        agent = _make_agent(memory=["SQ changed vote on Day1"])
-        prompt = build_judgment_prompt(agent, [], ["Setsu", "SQ"], day=2)
+        actor = _make_actor(memory=["SQ changed vote on Day1"])
+        prompt = build_judgment_prompt(actor, [], ["Setsu", "SQ"], day=2)
         assert "SQ changed vote on Day1" in prompt
 
     def test_json_format_instruction_present(self):
-        agent = _make_agent()
-        prompt = build_judgment_prompt(agent, [], ["Setsu"], day=1)
+        actor = _make_actor()
+        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1)
         assert "challenge" in prompt
         assert "silent" in prompt
         assert "reply_to" in prompt
 
     def test_co_option_absent_for_villager(self):
-        agent = _make_agent(role="Villager")
-        prompt = build_judgment_prompt(agent, [], ["Setsu"], day=1, co_eligible=False)
+        actor = _make_actor(role="Villager")
+        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=False)
         assert '"co"' not in prompt
 
     def test_co_option_present_when_co_eligible(self):
-        agent = _make_agent(role="Seer")
-        prompt = build_judgment_prompt(agent, [], ["Setsu"], day=1, co_eligible=True)
+        actor = _make_actor(role="Seer")
+        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
         assert '"co"' in prompt
 
     def test_co_strategy_hint_seer(self):
-        agent = _make_agent(role="Seer")
-        prompt = build_judgment_prompt(agent, [], ["Setsu"], day=1, co_eligible=True)
+        actor = _make_actor(role="Seer")
+        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
         assert "Seer" in prompt
         assert "trust" in prompt.lower()
 
     def test_co_strategy_hint_werewolf(self):
-        agent = _make_agent(role="Werewolf")
-        prompt = build_judgment_prompt(agent, [], ["Setsu"], day=1, co_eligible=True)
+        actor = _make_actor(role="Werewolf")
+        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
         assert "fake" in prompt.lower() or "chaos" in prompt.lower()
 
     def test_co_strategy_hint_madman(self):
-        agent = _make_agent(role="Madman")
-        prompt = build_judgment_prompt(agent, [], ["Setsu"], day=1, co_eligible=True)
+        actor = _make_actor(role="Madman")
+        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
         assert "Madman" in prompt
 
     def test_co_not_in_format_when_not_eligible(self):
         """Ensure the 4th choice is absent when co_eligible=False (default)."""
-        agent = _make_agent(role="Seer")
-        prompt = build_judgment_prompt(agent, [], ["Setsu"], day=1)  # default co_eligible=False
+        actor = _make_actor(role="Seer")
+        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1)  # default co_eligible=False
         assert '"co"' not in prompt

--- a/tests/unit/test_pre_night.py
+++ b/tests/unit/test_pre_night.py
@@ -4,50 +4,20 @@
 - build_system_prompt の intended_co 反映
 - _run_pre_night のフロー（LLM・store.save をモック）
 """
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-
-from src.domain.actor import ActorState, Actor, Persona, make_actor
-from src.engine.game import GameEngine
 from src.engine.phase import Phase
-from src.llm.client import LLMClient
 from src.llm.prompt import PublicContext, SpeechDirection, WolfSpecificContext, build_pre_night_prompt, build_system_prompt
 from src.domain.schema import PreNightOutput
-from src.domain.event import EventType, LogEvent
-from src.logger.writer import LogWriter
-
-
-def _make_agent(name: str, role: str) -> Actor:
-    state = ActorState(
-        name=name,
-        persona=Persona(style="calm", lie_tendency=0.1, aggression=0.2),
-        beliefs={},
-        memory_summary=[],
-        is_alive=True,
-    )
-    return make_actor(state, role)
-
-
-def _make_engine(agents: list[Actor]) -> tuple[GameEngine, list[LogEvent]]:
-    events: list[LogEvent] = []
-    log_writer = MagicMock(spec=LogWriter)
-    log_writer.write.side_effect = lambda e: events.append(e)
-    llm_client = MagicMock(spec=LLMClient)
-    engine = GameEngine(
-        agents=agents,
-        log_writer=log_writer,
-        lang="English",
-        llm_client=llm_client,
-    )
-    return engine, events
+from src.domain.event import EventType
 
 
 # ── build_pre_night_prompt ──────────────────────────────────────────────────
 
 
 class TestBuildPreNightPrompt:
-    def test_seer_prompt_contains_true_co_description(self):
-        agent = _make_agent("Gina", "Seer")
+    def test_seer_prompt_contains_true_co_description(self, make_test_actor):
+        agent = make_test_actor("Gina", "Seer")
         prompt = build_pre_night_prompt(agent, ["Gina", "SQ", "Raqio"])
         assert "Seer" in prompt
         assert "co" in prompt
@@ -55,8 +25,8 @@ class TestBuildPreNightPrompt:
         # Should NOT mention fake-CO language
         assert "fake" not in prompt.lower()
 
-    def test_werewolf_prompt_contains_fake_co_description(self):
-        agent = _make_agent("SQ", "Werewolf")
+    def test_werewolf_prompt_contains_fake_co_description(self, make_test_actor):
+        agent = make_test_actor("SQ", "Werewolf")
         prompt = build_pre_night_prompt(agent, ["Gina", "SQ", "Raqio"])
         assert "Seer" in prompt
         assert "co" in prompt
@@ -64,8 +34,8 @@ class TestBuildPreNightPrompt:
         # Should mention deception
         assert "fake" in prompt.lower() or "false" in prompt.lower() or "confuse" in prompt.lower()
 
-    def test_prompt_includes_all_players(self):
-        agent = _make_agent("Gina", "Seer")
+    def test_prompt_includes_all_players(self, make_test_actor):
+        agent = make_test_actor("Gina", "Seer")
         players = ["Gina", "SQ", "Raqio", "Zephyr", "Setsu"]
         prompt = build_pre_night_prompt(agent, players)
         for p in players:
@@ -76,14 +46,14 @@ class TestBuildPreNightPrompt:
 
 
 class TestBuildSystemPromptIntendedCo:
-    def test_no_intended_co_section_by_default(self):
-        agent = _make_agent("Gina", "Seer")
+    def test_no_intended_co_section_by_default(self, make_test_actor):
+        agent = make_test_actor("Gina", "Seer")
         ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
         prompt = build_system_prompt(agent, ctx, SpeechDirection())
         assert "CO DECISION" not in prompt
 
-    def test_seer_intended_co_adds_true_co_instruction(self):
-        agent = _make_agent("Gina", "Seer")
+    def test_seer_intended_co_adds_true_co_instruction(self, make_test_actor):
+        agent = make_test_actor("Gina", "Seer")
         ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
         prompt = build_system_prompt(agent, ctx, SpeechDirection(intended_co=True))
         assert "CO DECISION" in prompt
@@ -92,8 +62,8 @@ class TestBuildSystemPromptIntendedCo:
         # Must NOT instruct Seer to fake
         assert "fake" not in prompt.lower()
 
-    def test_werewolf_intended_co_adds_fake_co_instruction(self):
-        agent = _make_agent("SQ", "Werewolf")
+    def test_werewolf_intended_co_adds_fake_co_instruction(self, make_test_actor):
+        agent = make_test_actor("SQ", "Werewolf")
         ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
         role_ctx = WolfSpecificContext(wolf_partners=[])
         prompt = build_system_prompt(agent, ctx, SpeechDirection(intended_co=True), role_ctx)
@@ -111,14 +81,14 @@ class TestRunPreNight:
     def _make_output(self, decision: str) -> PreNightOutput:
         return PreNightOutput(thought="thinking", decision=decision, reasoning="reason")
 
-    def test_only_non_villager_agents_participate(self):
+    def test_only_non_villager_agents_participate(self, make_test_actor, make_test_engine):
         agents = [
-            _make_agent("A", "Villager"),
-            _make_agent("B", "Villager"),
-            _make_agent("C", "Seer"),
-            _make_agent("D", "Werewolf"),
+            make_test_actor("A", "Villager"),
+            make_test_actor("B", "Villager"),
+            make_test_actor("C", "Seer"),
+            make_test_actor("D", "Werewolf"),
         ]
-        engine, events = _make_engine(agents)
+        engine, events = make_test_engine(agents)
         engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
             [(actor, self._make_output("wait")) for actor in targets]
         )
@@ -132,9 +102,9 @@ class TestRunPreNight:
         agents_in_events = {e.agent for e in decision_events}
         assert agents_in_events == {"C", "D"}
 
-    def test_co_decision_sets_intended_co_true(self):
-        agents = [_make_agent("Gina", "Seer"), _make_agent("SQ", "Villager")]
-        engine, _ = _make_engine(agents)
+    def test_co_decision_sets_intended_co_true(self, make_test_actor, make_test_engine):
+        agents = [make_test_actor("Gina", "Seer"), make_test_actor("SQ", "Villager")]
+        engine, _ = make_test_engine(agents)
         engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
             [(actor, self._make_output("co")) for actor in targets]
         )
@@ -145,9 +115,9 @@ class TestRunPreNight:
         seer = next(a for a in agents if a.name == "Gina")
         assert seer.state.intended_co is True
 
-    def test_wait_decision_sets_intended_co_false(self):
-        agents = [_make_agent("Gina", "Seer"), _make_agent("SQ", "Villager")]
-        engine, _ = _make_engine(agents)
+    def test_wait_decision_sets_intended_co_false(self, make_test_actor, make_test_engine):
+        agents = [make_test_actor("Gina", "Seer"), make_test_actor("SQ", "Villager")]
+        engine, _ = make_test_engine(agents)
         engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
             [(actor, self._make_output("wait")) for actor in targets]
         )
@@ -158,9 +128,9 @@ class TestRunPreNight:
         seer = next(a for a in agents if a.name == "Gina")
         assert seer.state.intended_co is False
 
-    def test_decision_events_are_spectator_only(self):
-        agents = [_make_agent("Gina", "Seer"), _make_agent("SQ", "Villager")]
-        engine, events = _make_engine(agents)
+    def test_decision_events_are_spectator_only(self, make_test_actor, make_test_engine):
+        agents = [make_test_actor("Gina", "Seer"), make_test_actor("SQ", "Villager")]
+        engine, events = make_test_engine(agents)
         engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
             [(actor, self._make_output("co")) for actor in targets]
         )
@@ -171,9 +141,9 @@ class TestRunPreNight:
         decision_events = [e for e in events if e.event_type == EventType.PRE_NIGHT_DECISION]
         assert all(not e.is_public for e in decision_events)
 
-    def test_phase_start_event_is_spectator_only(self):
-        agents = [_make_agent("Gina", "Seer"), _make_agent("SQ", "Villager")]
-        engine, events = _make_engine(agents)
+    def test_phase_start_event_is_spectator_only(self, make_test_actor, make_test_engine):
+        agents = [make_test_actor("Gina", "Seer"), make_test_actor("SQ", "Villager")]
+        engine, events = make_test_engine(agents)
         engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
             [(actor, self._make_output("wait")) for actor in targets]
         )
@@ -188,9 +158,9 @@ class TestRunPreNight:
         assert len(phase_starts) == 1
         assert not phase_starts[0].is_public
 
-    def test_no_villagers_only_skips_phase(self):
-        agents = [_make_agent("A", "Villager"), _make_agent("B", "Villager")]
-        engine, events = _make_engine(agents)
+    def test_no_villagers_only_skips_phase(self, make_test_actor, make_test_engine):
+        agents = [make_test_actor("A", "Villager"), make_test_actor("B", "Villager")]
+        engine, events = make_test_engine(agents)
 
         engine._run_pre_night()
 


### PR DESCRIPTION
## Summary
- move shared test actor and engine setup into tests/unit/conftest.py fixtures
- update day loop and pre-night tests to use the shared fixtures instead of local duplicate helpers
- align judgment prompt helper naming from _make_agent to _make_actor and use actor as the local variable name

## Test plan
- [x] .\\.venv\\Scripts\\python.exe -m pytest tests/unit/test_game_day_loop.py tests/unit/test_pre_night.py
- [x] .\\.venv\\Scripts\\python.exe -m pytest tests/unit/test_judgment_prompt.py
- [x] pre-commit ruff and pytest during git commit

## Notes
- Running tests/unit end-to-end in this environment still hits unrelated Windows tmp directory permission errors in tmp_path-based tests.

Closes #152