### PR TITLE
chore: align Codex Windows setup with uv workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: pytest
+        entry: uv run pytest
         language: system
         pass_filenames: false
         always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Project Context
+
+- For project overview, architecture docs, and broader team conventions, refer to [CLAUDE.md](CLAUDE.md).
+- Key project docs listed in `CLAUDE.md` are the source of truth for product and design intent.
+
+## Repository Expectations
+
+- Use `uv` as the default local workflow tool.
+- Run project commands via `uv run ...`.
+- Before opening a PR, run `uv run ruff check .` and `uv run pytest`.
+- Pre-commit is configured to run tests via `uv run pytest`.
+
+## Windows / PowerShell Notes
+
+- If Japanese Markdown looks garbled in PowerShell, read files with `Get-Content -Encoding UTF8`.
+- If `git add` or `git commit` fails in sandbox with `.git\\index.lock` or branch lock permission errors, rerun with escalated permissions instead of working around it.
+
+## Working Conventions
+
+- Absolute imports only: `from src.xxx`, not relative imports.
+- When an external skill file is provided by path but is not registered as a session skill, state that briefly before reading it.
+- Put specialized instructions in files close to the relevant subtree if directory-specific overrides are needed later.
+
+## Known Environment Caveat
+
+- Some full-suite tests that rely on Windows temp directories may fail for environment-permission reasons unrelated to the current code change. When that happens, separate targeted test results from environment failures in the report.


### PR DESCRIPTION
## Summary
- add repository-level AGENTS.md so Codex can auto-load project instructions
- reference CLAUDE.md for broader project context and keep Codex-specific guidance concise
- switch the local pre-commit pytest hook to uv run pytest for Windows-friendly setup consistency

## Verification
- uv run pytest --version
- uv run pre-commit run pytest --all-files
- pre-commit on commit: pytest hook passed
