### PR TITLE
refactor: move Counter import to module top level in prompt.py

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -17,8 +17,6 @@
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#81 | tech-debt | 🟡 | 5 | Separate night action declaration and resolution phases | 夜フェーズの宣言・実行・公表を3段階に分離。seer_survived フラグ削除。キツネ等の複雑な相互作用に対応 |
-| yukkie/AgentVillage#157 | tech-debt | 🟡 | 5 | Refactor phase_night.py into smaller functions | 夜フェーズを狼会話・宣言・解決などの読みやすい関数へ分割し、#81 の土台を作る |
-| yukkie/AgentVillage#158 | tech-debt | 🟡 | 3 | Refactor phase_day.py into smaller functions | 昼フェーズを opening / discussion / vote / post-vote に関数分割して見通しとテスト性を上げる |
 | yukkie/AgentVillage#33 | enhancement | 🟢 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#36 | enhancement | 🟢 | 5 | Belief updates from agent reasoning | suspicion/trust を推理結果から更新 |
 | yukkie/AgentVillage#47 | enhancement | 🟢 | 3 | Reasoning field for Vote/Guard/Divination/Judgment | 各アクションに reasoning を追加し spectator ログ・memory_update に記録 |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#97 | tech-debt | 🟡 | 3 | Move local imports to module top level in prompt.py and game.py | 関数内ローカルインポートがアーキテクチャ原則に違反 |
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | 3 | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -17,7 +17,6 @@
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#81 | tech-debt | 🟡 | 5 | Separate night action declaration and resolution phases | 夜フェーズの宣言・実行・公表を3段階に分離。seer_survived フラグ削除。キツネ等の複雑な相互作用に対応 |
-| yukkie/AgentVillage#58 | tech-debt | 🟡 | 8 | Split GameEngine phases into dedicated modules | game.py を前夜・昼・夜フェーズモジュールに分割 |
 | yukkie/AgentVillage#157 | tech-debt | 🟡 | 5 | Refactor phase_night.py into smaller functions | 夜フェーズを狼会話・宣言・解決などの読みやすい関数へ分割し、#81 の土台を作る |
 | yukkie/AgentVillage#158 | tech-debt | 🟡 | 3 | Refactor phase_day.py into smaller functions | 昼フェーズを opening / discussion / vote / post-vote に関数分割して見通しとテスト性を上げる |
 | yukkie/AgentVillage#33 | enhancement | 🟢 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |

--- a/src/engine/phase_day.py
+++ b/src/engine/phase_day.py
@@ -15,9 +15,7 @@ if TYPE_CHECKING:
     from src.engine.game import GameEngine
 
 
-def run_day_phase(engine: GameEngine) -> str | None:
-    engine._day_outputs = {}
-
+def _run_opening(engine: GameEngine) -> None:
     engine.phase = Phase.DAY_OPENING
     engine._phase_start(Phase.DAY_OPENING)
 
@@ -28,6 +26,8 @@ def run_day_phase(engine: GameEngine) -> str | None:
     for actor, output in engine._llm_client.call_speech_parallel(opening_calls):
         engine._apply_speech_output(actor, output, Phase.DAY_OPENING)
 
+
+def _run_discussion(engine: GameEngine) -> None:
     engine.phase = Phase.DAY_DISCUSSION
     for _round in range(DISCUSSION_ROUNDS):
         engine._phase_start(Phase.DAY_DISCUSSION)
@@ -61,6 +61,8 @@ def run_day_phase(engine: GameEngine) -> str | None:
         if not spoke_anyone:
             break
 
+
+def _run_vote(engine: GameEngine) -> str | None:
     engine.phase = Phase.DAY_VOTE
     engine._phase_start(Phase.DAY_VOTE)
 
@@ -100,28 +102,47 @@ def run_day_phase(engine: GameEngine) -> str | None:
                     is_public=True,
                 ))
 
-    if votes:
-        engine._past_votes.append({"day": engine.day, "votes": dict(votes)})
-        eliminated = tally_votes(votes)
-        engine._eliminate(eliminated, EventType.ELIMINATION, Phase.DAY_VOTE.value)
+    if not votes:
+        return None
 
-        medium = next((a for a in engine._alive_agents() if isinstance(a.role, Medium)), None)
-        if medium:
-            executed_actor = engine._get_agent(eliminated)
-            if executed_actor:
-                result = "Werewolf" if isinstance(executed_actor.role, Werewolf) else "Not Werewolf"
-                memory_mod.update_memory(
-                    medium,
-                    [f"Day {engine.day}: {eliminated} was executed, they were {result}"],
-                )
-                engine._emit(LogEvent.make(
-                    day=engine.day,
-                    phase=Phase.DAY_VOTE.value,
-                    event_type=EventType.MEDIUM_RESULT,
-                    agent=medium.name,
-                    target=eliminated,
-                    content=f"{medium.name} senses: {eliminated} was {result}",
-                    is_public=False,
-                ))
+    engine._past_votes.append({"day": engine.day, "votes": dict(votes)})
+    eliminated = tally_votes(votes)
+    engine._eliminate(eliminated, EventType.ELIMINATION, Phase.DAY_VOTE.value)
+    return eliminated
+
+
+def _resolve_post_vote(engine: GameEngine, eliminated: str) -> None:
+    medium = next((a for a in engine._alive_agents() if isinstance(a.role, Medium)), None)
+    if not medium:
+        return
+
+    executed_actor = engine._get_agent(eliminated)
+    if not executed_actor:
+        return
+
+    result = "Werewolf" if isinstance(executed_actor.role, Werewolf) else "Not Werewolf"
+    memory_mod.update_memory(
+        medium,
+        [f"Day {engine.day}: {eliminated} was executed, they were {result}"],
+    )
+    engine._emit(LogEvent.make(
+        day=engine.day,
+        phase=Phase.DAY_VOTE.value,
+        event_type=EventType.MEDIUM_RESULT,
+        agent=medium.name,
+        target=eliminated,
+        content=f"{medium.name} senses: {eliminated} was {result}",
+        is_public=False,
+    ))
+
+
+def run_day_phase(engine: GameEngine) -> str | None:
+    engine._day_outputs = {}
+
+    _run_opening(engine)
+    _run_discussion(engine)
+    eliminated = _run_vote(engine)
+    if eliminated:
+        _resolve_post_vote(engine, eliminated)
 
     return check_victory(engine.agents)

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING
 from src.agent import memory as memory_mod, store
 from src.action.resolver import resolve_attack, resolve_inspect
 from src.action.types import Attack, Inspect
-from src.domain.actor import Belief
+from src.domain.actor import Actor, Belief
 from src.domain.event import EventType, LogEvent
 from src.domain.roles import Knight, Seer, Werewolf
-from src.domain.schema import SpeechEntry
+from src.domain.schema import SpeechEntry, WolfChatOutput
 from src.engine.phase import Phase
 from src.engine.victory import check_victory
 
@@ -16,81 +16,71 @@ if TYPE_CHECKING:
     from src.engine.game import GameEngine
 
 
-def run_night_phase(engine: GameEngine) -> str | None:
-    engine.phase = Phase.NIGHT
-    engine._phase_start(Phase.NIGHT)
-    engine.today_log = []
+def _run_wolf_chat(engine: GameEngine) -> str | None:
+    wolves = [a for a in engine._alive_agents() if isinstance(a.role, Werewolf)]
+    if len(wolves) < 2:
+        return None
+
+    engine.phase = Phase.NIGHT_WOLF_CHAT
+    engine._phase_start(Phase.NIGHT_WOLF_CHAT)
+    wolf_chat_log: list[SpeechEntry] = []
+    wolf_names = [w.name for w in wolves]
+    last_wolf_outputs: dict[str, WolfChatOutput | None] = {w.name: None for w in wolves}
+
+    for _round in range(engine._wolf_chat_rounds):
+        for wolf in wolves:
+            partners = [n for n in wolf_names if n != wolf.name]
+            output = engine._llm_client.call_wolf_chat(
+                wolf, partners, engine._alive_names(), wolf_chat_log, engine.lang
+            )
+            last_wolf_outputs[wolf.name] = output
+            entry = SpeechEntry(
+                speech_id=engine._next_speech_id(),
+                agent=wolf.name,
+                text=output.speech,
+            )
+            wolf_chat_log.append(entry)
+            engine._emit(LogEvent.make(
+                day=engine.day,
+                phase=Phase.NIGHT_WOLF_CHAT.value,
+                event_type=EventType.WOLF_CHAT,
+                agent=wolf.name,
+                content=f"{wolf.name}: {output.speech}",
+                is_public=False,
+            ))
 
     alive_names = engine._alive_names()
+    score_totals: dict[str, float] = {}
+    for wolf in wolves:
+        out = last_wolf_outputs[wolf.name]
+        if out and out.vote_candidates:
+            for vc in out.vote_candidates:
+                if vc.target in alive_names and vc.target not in wolf_names:
+                    score_totals[vc.target] = score_totals.get(vc.target, 0.0) + vc.score
+    if score_totals:
+        return max(score_totals, key=lambda t: score_totals[t])
+    return None
+
+
+def _resolve_fallback_attack(engine: GameEngine, alive_names: list[str]) -> str | None:
     night_context = f"Day {engine.day} night. Alive: {', '.join(alive_names)}"
+    for actor in engine._alive_agents():
+        if not isinstance(actor.role, Werewolf):
+            continue
+        target_name = engine._llm_client.call_night_action(actor, night_context, alive_names)
+        attack = Attack(target=target_name)
+        if engine._validate_action(attack, actor, alive_names):
+            return resolve_attack(attack, engine.agents)
+    return None
 
-    attack_target: str | None = None
+
+def _declare_role_actions(
+    engine: GameEngine, alive_names: list[str], night_context: str
+) -> tuple[str | None, tuple | None, Actor | None]:
     guard_target: str | None = None
+    seer_inspect: tuple | None = None
+    knight: Actor | None = None
 
-    wolves = [a for a in engine._alive_agents() if isinstance(a.role, Werewolf)]
-    if len(wolves) >= 2:
-        engine.phase = Phase.NIGHT_WOLF_CHAT
-        engine._phase_start(Phase.NIGHT_WOLF_CHAT)
-        wolf_chat_log: list[SpeechEntry] = []
-        wolf_names = [w.name for w in wolves]
-        last_wolf_outputs = {w.name: None for w in wolves}
-
-        for _round in range(engine._wolf_chat_rounds):
-            for wolf in wolves:
-                partners = [n for n in wolf_names if n != wolf.name]
-                output = engine._llm_client.call_wolf_chat(
-                    wolf, partners, alive_names, wolf_chat_log, engine.lang
-                )
-                last_wolf_outputs[wolf.name] = output
-                entry = SpeechEntry(
-                    speech_id=engine._next_speech_id(),
-                    agent=wolf.name,
-                    text=output.speech,
-                )
-                wolf_chat_log.append(entry)
-                engine._emit(LogEvent.make(
-                    day=engine.day,
-                    phase=Phase.NIGHT_WOLF_CHAT.value,
-                    event_type=EventType.WOLF_CHAT,
-                    agent=wolf.name,
-                    content=f"{wolf.name}: {output.speech}",
-                    is_public=False,
-                ))
-
-        score_totals: dict[str, float] = {}
-        for wolf in wolves:
-            out = last_wolf_outputs[wolf.name]
-            if out and out.vote_candidates:
-                for vc in out.vote_candidates:
-                    if vc.target in alive_names and vc.target not in wolf_names:
-                        score_totals[vc.target] = score_totals.get(vc.target, 0.0) + vc.score
-        if score_totals:
-            attack_target = max(score_totals, key=lambda t: score_totals[t])
-
-    if attack_target is None:
-        for actor in engine._alive_agents():
-            if not isinstance(actor.role, Werewolf):
-                continue
-            target_name = engine._llm_client.call_night_action(actor, night_context, alive_names)
-            attack = Attack(target=target_name)
-            if engine._validate_action(attack, actor, alive_names):
-                attack_target = resolve_attack(attack, engine.agents)
-                break
-
-    if attack_target:
-        engine._emit(LogEvent.make(
-            day=engine.day,
-            phase=Phase.NIGHT.value,
-            event_type=EventType.NIGHT_ATTACK,
-            agent=wolves[0].name if wolves else None,
-            target=attack_target,
-            content=f"Werewolves attack {attack_target}",
-            is_public=False,
-        ))
-
-    seer_inspect: tuple[object, Inspect] | None = None
-
-    knight = None
     for actor in engine._alive_agents():
         if isinstance(actor.role, Knight):
             knight = actor
@@ -107,63 +97,107 @@ def run_night_phase(engine: GameEngine) -> str | None:
                     content=f"{actor.name} guards {guard_target}",
                     is_public=False,
                 ))
-
         elif isinstance(actor.role, Seer):
             target_name = engine._llm_client.call_night_action(actor, night_context, alive_names)
             inspect = Inspect(target=target_name)
             if engine._validate_action(inspect, actor, alive_names):
                 seer_inspect = (actor, inspect)
 
-    seer_survived = True
-    if attack_target:
-        if guard_target == attack_target:
-            engine._emit(LogEvent.make(
-                day=engine.day,
-                phase=Phase.NIGHT.value,
-                event_type=EventType.GUARD_BLOCK,
-                target=attack_target,
-                content=f"{attack_target} was protected by the Knight! The attack was blocked.",
-                is_public=False,
-            ))
-            engine._emit(LogEvent.make(
-                day=engine.day,
-                phase=Phase.NIGHT.value,
-                event_type=EventType.GUARD_BLOCK,
-                content="The village woke up to find everyone safe. The werewolves' attack seems to have failed.",
-                is_public=True,
-            ))
-            if knight:
-                memory_mod.update_memory(
-                    knight,
-                    [f"Day {engine.day}: successfully guarded {guard_target} from werewolf attack"],
-                )
-        else:
-            if seer_inspect and seer_inspect[0].name == attack_target:
-                seer_survived = False
-            engine._eliminate(attack_target, EventType.NIGHT_ATTACK, Phase.NIGHT.value)
+    return guard_target, seer_inspect, knight
 
-    if seer_inspect and seer_survived:
-        seer, inspect = seer_inspect
-        name, result = resolve_inspect(inspect, engine.agents)
-        if name not in seer.state.beliefs:
-            seer.state.beliefs[name] = Belief()
-        if isinstance(result, Werewolf):
-            seer.state.beliefs[name].suspicion = 1.0
-            seer.state.beliefs[name].trust = 0.0
-            seer.state.beliefs[name].reason.append(f"Day {engine.day}: inspected as Werewolf")
-        else:
-            seer.state.beliefs[name].suspicion = 0.0
-            seer.state.beliefs[name].trust = 1.0
-            seer.state.beliefs[name].reason.append(f"Day {engine.day}: inspected as Not Werewolf")
-        store.save(seer)
+
+def _resolve_night_attack(
+    engine: GameEngine,
+    attack_target: str,
+    guard_target: str | None,
+    knight: Actor | None,
+    seer_inspect: tuple | None,
+) -> bool:
+    if guard_target == attack_target:
         engine._emit(LogEvent.make(
             day=engine.day,
             phase=Phase.NIGHT.value,
-            event_type=EventType.INSPECTION,
-            agent=seer.name,
-            target=name,
-            content=f"{seer.name} inspects {name}: {result}",
+            event_type=EventType.GUARD_BLOCK,
+            target=attack_target,
+            content=f"{attack_target} was protected by the Knight! The attack was blocked.",
             is_public=False,
         ))
+        engine._emit(LogEvent.make(
+            day=engine.day,
+            phase=Phase.NIGHT.value,
+            event_type=EventType.GUARD_BLOCK,
+            content="The village woke up to find everyone safe. The werewolves' attack seems to have failed.",
+            is_public=True,
+        ))
+        if knight:
+            memory_mod.update_memory(
+                knight,
+                [f"Day {engine.day}: successfully guarded {guard_target} from werewolf attack"],
+            )
+        return True  # seer survived
+
+    seer_survived = not (seer_inspect and seer_inspect[0].name == attack_target)
+    engine._eliminate(attack_target, EventType.NIGHT_ATTACK, Phase.NIGHT.value)
+    return seer_survived
+
+
+def _resolve_inspection(engine: GameEngine, seer_inspect: tuple) -> None:
+    seer, inspect = seer_inspect
+    name, result = resolve_inspect(inspect, engine.agents)
+    if name not in seer.state.beliefs:
+        seer.state.beliefs[name] = Belief()
+    if isinstance(result, Werewolf):
+        seer.state.beliefs[name].suspicion = 1.0
+        seer.state.beliefs[name].trust = 0.0
+        seer.state.beliefs[name].reason.append(f"Day {engine.day}: inspected as Werewolf")
+    else:
+        seer.state.beliefs[name].suspicion = 0.0
+        seer.state.beliefs[name].trust = 1.0
+        seer.state.beliefs[name].reason.append(f"Day {engine.day}: inspected as Not Werewolf")
+    store.save(seer)
+    engine._emit(LogEvent.make(
+        day=engine.day,
+        phase=Phase.NIGHT.value,
+        event_type=EventType.INSPECTION,
+        agent=seer.name,
+        target=name,
+        content=f"{seer.name} inspects {name}: {result}",
+        is_public=False,
+    ))
+
+
+def run_night_phase(engine: GameEngine) -> str | None:
+    engine.phase = Phase.NIGHT
+    engine._phase_start(Phase.NIGHT)
+    engine.today_log = []
+
+    alive_names = engine._alive_names()
+    night_context = f"Day {engine.day} night. Alive: {', '.join(alive_names)}"
+
+    attack_target = _run_wolf_chat(engine)
+
+    if attack_target is None:
+        attack_target = _resolve_fallback_attack(engine, alive_names)
+
+    if attack_target:
+        wolves = [a for a in engine._alive_agents() if isinstance(a.role, Werewolf)]
+        engine._emit(LogEvent.make(
+            day=engine.day,
+            phase=Phase.NIGHT.value,
+            event_type=EventType.NIGHT_ATTACK,
+            agent=wolves[0].name if wolves else None,
+            target=attack_target,
+            content=f"Werewolves attack {attack_target}",
+            is_public=False,
+        ))
+
+    guard_target, seer_inspect, knight = _declare_role_actions(engine, alive_names, night_context)
+
+    seer_survived = True
+    if attack_target:
+        seer_survived = _resolve_night_attack(engine, attack_target, guard_target, knight, seer_inspect)
+
+    if seer_inspect and seer_survived:
+        _resolve_inspection(engine, seer_inspect)
 
     return check_victory(engine.agents)

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from dataclasses import dataclass, field
 
 from src.domain.actor import Actor
@@ -101,7 +102,6 @@ def build_role_prompt(role: Role, wolf_partners: list[str] | None = None) -> str
 
 def build_public_info_prompt(ctx: PublicContext) -> str:
     """Build prompt section with public game information."""
-    from collections import Counter
     lines = [f"\n--- PUBLIC INFORMATION (Day {ctx.day}) ---"]
 
     if ctx.all_agents:
@@ -219,7 +219,6 @@ def build_pre_night_prompt(
     ]
 
     if all_agents:
-        from collections import Counter
         role_counts = Counter(a.role.name for a in all_agents)
         role_summary = ", ".join(f"{count} {role}" for role, count in sorted(role_counts.items()))
         lines.append(f"Role distribution in this game: {role_summary}")


### PR DESCRIPTION
## Summary

### Closes #97: Move Counter import to module top level
- `from collections import Counter` が `src/llm/prompt.py` の2つの関数内にローカルインポートとして存在していた
- モジュール先頭に移動し、プロジェクトの絶対インポート規約に準拠させた
- `game.py` に記載されていた `Villager` のローカルインポートは調査の結果すでに存在せず、変更不要

### Closes #157 & #158: Split phase_night and phase_day into smaller functions
- `run_night_phase()` を5つのヘルパー関数に分割（wolf chat、fallback attack、role action宣言、攻撃解決、占い解決）
- `run_day_phase()` を4つのヘルパー関数に分割（opening、discussion、vote、post-vote）
- 各ヘルパーは `_` プレフィックスのモジュールプライベート関数
- 外部インターフェース・動作は変更なし
- `WolfChatOutput`・`Actor` の型を明示してインポート追加

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（143 tests）

Closes #97
Closes #157
Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)