### PR TITLE
docs: add self-reflection review issues to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,6 +14,9 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | 3 | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
+| yukkie/AgentVillage#161 | tech-debt | 🟡 | - | phase_night.py: Add explicit element types for tuple aliases | `tuple \| None` を `tuple[Actor, Inspect] \| None` に明示化 |
+| yukkie/AgentVillage#162 | tech-debt | 🟡 | - | game.py: Introduce TypedDict for _past_votes / _past_deaths entries | `list[dict]` の要素構造を TypedDict で型定義 |
+| yukkie/AgentVillage#163 | tech-debt | 🟡 | - | game.py: Narrow _validate_action action parameter from object to ActionType | `action: object` を Union 型に絞る |
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#81 | tech-debt | 🟡 | 5 | Separate night action declaration and resolution phases | 夜フェーズの宣言・実行・公表を3段階に分離。seer_survived フラグ削除。キツネ等の複雑な相互作用に対応 |


### PR DESCRIPTION
## Summary
型明示に関する self-reflection review で洗い出した 3 件の Issue を Ideas.md に追記

- #161: phase_night.py の `tuple` に要素型を明示
- #162: `_past_votes` / `_past_deaths` を TypedDict 化
- #163: `_validate_action(action: object)` を `ActionType` に絞る

## Test plan
- [x] Ideas.md 追記のみ、コード変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)