### PR TITLE
refactor: explicit tuple element types in phase_night helpers

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | 3 | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
-| yukkie/AgentVillage#161 | tech-debt | 🟡 | - | phase_night.py: Add explicit element types for tuple aliases | `tuple \| None` を `tuple[Actor, Inspect] \| None` に明示化 |
 | yukkie/AgentVillage#162 | tech-debt | 🟡 | - | game.py: Introduce TypedDict for _past_votes / _past_deaths entries | `list[dict]` の要素構造を TypedDict で型定義 |
 | yukkie/AgentVillage#163 | tech-debt | 🟡 | - | game.py: Narrow _validate_action action parameter from object to ActionType | `action: object` を Union 型に絞る |
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -76,9 +76,9 @@ def _resolve_fallback_attack(engine: GameEngine, alive_names: list[str]) -> str 
 
 def _declare_role_actions(
     engine: GameEngine, alive_names: list[str], night_context: str
-) -> tuple[str | None, tuple | None, Actor | None]:
+) -> tuple[str | None, tuple[Actor, Inspect] | None, Actor | None]:
     guard_target: str | None = None
-    seer_inspect: tuple | None = None
+    seer_inspect: tuple[Actor, Inspect] | None = None
     knight: Actor | None = None
 
     for actor in engine._alive_agents():
@@ -111,7 +111,7 @@ def _resolve_night_attack(
     attack_target: str,
     guard_target: str | None,
     knight: Actor | None,
-    seer_inspect: tuple | None,
+    seer_inspect: tuple[Actor, Inspect] | None,
 ) -> bool:
     if guard_target == attack_target:
         engine._emit(LogEvent.make(
@@ -141,7 +141,7 @@ def _resolve_night_attack(
     return seer_survived
 
 
-def _resolve_inspection(engine: GameEngine, seer_inspect: tuple) -> None:
+def _resolve_inspection(engine: GameEngine, seer_inspect: tuple[Actor, Inspect]) -> None:
     seer, inspect = seer_inspect
     name, result = resolve_inspect(inspect, engine.agents)
     if name not in seer.state.beliefs:


### PR DESCRIPTION
## Summary
- `_declare_role_actions` / `_resolve_night_attack` / `_resolve_inspection` の `tuple` 型注釈を `tuple[Actor, Inspect]` に置き換え、型チェッカが要素型を推論できるようにした
- ランタイム挙動には変更なし（型ヒントのみ）

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（143 tests）

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)