### PR TITLE
refactor: introduce TypedDict for past_votes/past_deaths (#162)

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -147,8 +147,8 @@ class PublicContext:
     dead_players: list[str]
     day: int
     all_agents: list[AgentState] | None = None   # 役職分布・CO状況
-    past_votes: list[dict] | None = None
-    past_deaths: list[dict] | None = None
+    past_votes: list[PastVote] | None = None   # TypedDict: {day, votes}
+    past_deaths: list[PastDeath] | None = None  # TypedDict: {day, name, cause}
 
 @dataclass
 class SpeechDirection:

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | 3 | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
-| yukkie/AgentVillage#162 | tech-debt | 🟡 | - | game.py: Introduce TypedDict for _past_votes / _past_deaths entries | `list[dict]` の要素構造を TypedDict で型定義 |
 | yukkie/AgentVillage#163 | tech-debt | 🟡 | - | game.py: Narrow _validate_action action parameter from object to ActionType | `action: object` を Union 型に絞る |
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -9,7 +9,7 @@ from src.engine.phase_night import run_night_phase
 from src.engine.phase_pre_night import run_pre_night_phase
 from src.llm import factory as llm_factory
 from src.llm.client import LLMClient
-from src.llm.prompt import PublicContext, SpeechDirection, WolfSpecificContext
+from src.llm.prompt import PastDeath, PastVote, PublicContext, SpeechDirection, WolfSpecificContext
 from src.domain.schema import AgentOutput, SpeechEntry
 from src.action.types import Vote
 from src.action.validator import validate
@@ -39,8 +39,8 @@ class GameEngine:
         self._day_turn: int = 0
         self._day_outputs: dict[str, AgentOutput] = {}
         # Public history passed to agent prompts
-        self._past_votes: list[dict] = []   # [{"day": n, "votes": {"voter": "target"}}]
-        self._past_deaths: list[dict] = []  # [{"day": n, "name": str, "cause": "execution"|"attack"}]
+        self._past_votes: list[PastVote] = []
+        self._past_deaths: list[PastDeath] = []
         self._wolf_chat_rounds = WOLF_CHAT_ROUNDS
 
     def _emit(self, event: LogEvent) -> None:

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -1,9 +1,21 @@
 from collections import Counter
 from dataclasses import dataclass, field
+from typing import Literal, TypedDict
 
 from src.domain.actor import Actor
 from src.domain.roles import Role, Werewolf
 from src.domain.schema import SpeechEntry
+
+
+class PastVote(TypedDict):
+    day: int
+    votes: dict[str, str]
+
+
+class PastDeath(TypedDict):
+    day: int
+    name: str
+    cause: Literal["execution", "attack"]
 
 
 @dataclass
@@ -13,8 +25,8 @@ class PublicContext:
     dead_players: list[str]
     day: int
     all_agents: list[Actor] | None = None
-    past_votes: list[dict] | None = None
-    past_deaths: list[dict] | None = None
+    past_votes: list[PastVote] | None = None
+    past_deaths: list[PastDeath] | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Define `PastVote` / `PastDeath` TypedDict in [src/llm/prompt.py](src/llm/prompt.py)
- Narrow `cause` to `Literal[\"execution\", \"attack\"]` so typos are caught by the type checker
- Replace `list[dict]` annotations on `GameEngine._past_votes` / `_past_deaths` and `PublicContext.past_votes` / `past_deaths` with the new TypedDicts
- Update [doc/DetailDesign.md](doc/DetailDesign.md) to reflect the new types

## Test plan
- [x] \`ruff check .\` passes
- [x] \`pytest\` passes (143 passed)
- [x] Runtime behavior unchanged (type annotations only)

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)