### PR TITLE
refactor: narrow _validate_action action param to ActionType (#163)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | 3 | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
-| yukkie/AgentVillage#163 | tech-debt | 🟡 | - | game.py: Narrow _validate_action action parameter from object to ActionType | `action: object` を Union 型に絞る |
 | yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#81 | tech-debt | 🟡 | 5 | Separate night action declaration and resolution phases | 夜フェーズの宣言・実行・公表を3段階に分離。seer_survived フラグ削除。キツネ等の複雑な相互作用に対応 |

--- a/src/action/resolver.py
+++ b/src/action/resolver.py
@@ -1,8 +1,6 @@
-from src.action.types import Vote, Inspect, Attack, CO
+from src.action.types import Attack, CO, Inspect, Vote
 from src.domain.actor import Actor
 from src.domain.roles import Werewolf
-
-ActionType = Vote | Inspect | Attack | CO
 
 
 def resolve_vote(action: Vote, agents: list[Actor]) -> str:

--- a/src/action/types.py
+++ b/src/action/types.py
@@ -19,3 +19,6 @@ class Attack:
 @dataclass
 class CO:
     role: str
+
+
+ActionType = Vote | Inspect | Attack | CO

--- a/src/action/validator.py
+++ b/src/action/validator.py
@@ -1,8 +1,6 @@
-from src.action.types import Vote, Inspect, Attack, CO
+from src.action.types import ActionType, Attack, CO, Inspect, Vote
 from src.domain.actor import Actor
 from src.domain.roles import Seer, Werewolf
-
-ActionType = Vote | Inspect | Attack | CO
 
 
 def validate(action: ActionType, actor: Actor, alive_players: list[str]) -> bool:

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -11,7 +11,7 @@ from src.llm import factory as llm_factory
 from src.llm.client import LLMClient
 from src.llm.prompt import PastDeath, PastVote, PublicContext, SpeechDirection, WolfSpecificContext
 from src.domain.schema import AgentOutput, SpeechEntry
-from src.action.types import Vote
+from src.action.types import ActionType, Vote
 from src.action.validator import validate
 from src.domain.event import LogEvent, EventType
 from src.domain.roles import Werewolf
@@ -109,7 +109,7 @@ class GameEngine:
     def _make_vote(self, target: str) -> Vote:
         return Vote(target=target)
 
-    def _validate_action(self, action: object, actor: Actor, alive_names: list[str]) -> bool:
+    def _validate_action(self, action: ActionType, actor: Actor, alive_names: list[str]) -> bool:
         return validate(action, actor, alive_names)
 
     def run(self) -> str:


### PR DESCRIPTION
## Summary
- Consolidate `ActionType = Vote | Inspect | Attack | CO` in [src/action/types.py](src/action/types.py)
- Remove duplicate `ActionType` definitions from [src/action/validator.py](src/action/validator.py) and [src/action/resolver.py](src/action/resolver.py) (the resolver.py one was unused)
- Narrow [src/engine/game.py:112](src/engine/game.py#L112) `_validate_action(action: object, ...)` to `action: ActionType` so passing unrelated values is caught by the type checker

## Test plan
- [x] \`ruff check .\` passes
- [x] \`pytest\` passes (143 passed)
- [x] Runtime behavior unchanged (type annotations only)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)