### PR TITLE
refactor: Renderer class with GUI migration hint (closes #76)

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -246,7 +246,7 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 | モジュール | 責務 |
 |---|---|
 | `cli.py` | Richを使ったCLI表示。フェーズ区切り・発言・死亡通知を色付きで出力 |
-| `renderer.py` | イベントを受け取って表示文字列に変換（cliから切り離して将来のWeb対応を容易に） |
+| `renderer.py` | `Renderer` クラス（`on_event()`）でイベントを Rich `Text` に変換。将来的に EventPresenter（中立の `DisplayEvent`）→ `ConsoleRenderer` / `WebRenderer` へ分割する前提のシーム |
 | `replay.py` | アーカイブ選択UI + ページャー。LLMを一切呼ばずにJSONLログを再生する |
 
 ### replay.py — クラス構成
@@ -278,7 +278,7 @@ class ReplayPager:
 **初期化:**
 1. `archive_path/agents/*.json` を `AgentState` としてロード（`src.agent.state` の Pydantic モデルを直接使用）
 2. `spectator_mode` に応じて `spectator_log.jsonl` または `public_log.jsonl` を読み込み
-3. 各 `LogEvent` を `renderer.render_event()` で描画し、`list[str]`（ANSI 文字列）としてバッファに積む
+3. 各 `LogEvent` を `Renderer.on_event()` で描画し、`list[str]`（ANSI 文字列）としてバッファに積む
 
 **`_build_lines()` の claimed_role 動的追跡:**
 アーカイブの agent JSON は end-of-game 状態（CO済み）を持つ。そのまま使うと、CO前の発言もCO後の色で表示されてしまう。

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | 3 | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
-| yukkie/AgentVillage#76 | tech-debt | 🟡 | 3 | Refactor renderer.py into Renderer class with GUI migration hint | Renderer クラス化・イベントスタイルを整理・GUI化時の EventPresenter 設計ヒントをコメントで残す |
 | yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#81 | tech-debt | 🟡 | 5 | Separate night action declaration and resolution phases | 夜フェーズの宣言・実行・公表を3段階に分離。seer_survived フラグ削除。キツネ等の複雑な相互作用に対応 |
 | yukkie/AgentVillage#33 | enhancement | 🟢 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |

--- a/src/ui/cli.py
+++ b/src/ui/cli.py
@@ -3,7 +3,7 @@ from rich.panel import Panel
 
 from src.domain.event import LogEvent
 from src.domain.actor import Actor
-from src.ui.renderer import render_event
+from src.ui.renderer import Renderer
 
 console = Console()
 
@@ -12,10 +12,11 @@ class CLI:
     def __init__(self, agents: list[Actor], spectator_mode: bool = False):
         self.agents = agents
         self.spectator_mode = spectator_mode
+        self._renderer = Renderer(agents, spectator_mode)
 
     def on_event(self, event: LogEvent) -> None:
         """Callback for the game engine to call when an event occurs."""
-        text = render_event(event, self.agents, self.spectator_mode)
+        text = self._renderer.on_event(event)
         if text is not None:
             console.print(text)
 

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -1,122 +1,127 @@
+"""Event-to-display conversion layer.
+
+Future GUI/web migration plan:
+    EventPresenter (produces a neutral ``DisplayEvent`` — pure data: text,
+    semantic style tokens, visibility) → {ConsoleRenderer, WebRenderer, ...}
+    (each binds the neutral event to its own output medium).
+
+Today, ``Renderer`` collapses both steps: it filters by spectator visibility
+and emits Rich ``Text`` directly. Splitting it is deferred until a second
+frontend (web) is actually needed.
+"""
+
 from rich.text import Text
-from rich.console import Console
 
 from src.domain.event import LogEvent, EventType
 from src.domain.actor import Actor
 
-console = Console()
 
+class Renderer:
+    """Convert ``LogEvent`` instances into Rich ``Text`` for console output."""
 
-def _get_agent(agent_name: str | None, agents: list[Actor]) -> Actor | None:
-    if agent_name is None:
-        return None
-    return next((a for a in agents if a.name == agent_name), None)
+    # Simple events where the output is ``[PREFIX] {content}`` in a fixed style.
+    # Events needing dynamic style or extra fields (SPEECH, VOTE, PHASE_START,
+    # PRE_NIGHT_DECISION, GAME_OVER) are handled separately in ``on_event``.
+    _SIMPLE_EVENT_STYLES: dict[EventType, tuple[str, str]] = {
+        EventType.NIGHT_ATTACK: ("[NIGHT] ", "red"),
+        EventType.INSPECTION: ("[INSPECT] ", "cyan"),
+        EventType.WOLF_CHAT: ("[WOLF] ", "red"),
+        EventType.GUARD: ("[GUARD] ", "bright_green"),
+        EventType.GUARD_BLOCK: ("[GUARD BLOCK] ", "bold bright_green"),
+        EventType.CO_ANNOUNCEMENT: ("[CO] ", "bold white"),
+        EventType.MEDIUM_RESULT: ("[MEDIUM] ", "cyan"),
+    }
 
+    def __init__(self, agents: list[Actor], spectator_mode: bool = False):
+        self.agents = agents
+        self.spectator_mode = spectator_mode
 
-def _speech_style(agent_name: str | None, agents: list[Actor], spectator_mode: bool) -> str:
-    """Return Rich color style for a speech event.
+    def on_event(self, event: LogEvent) -> Text | None:
+        """Convert a LogEvent to a Rich Text object for display.
 
-    Spectator mode: color by true role.
-    Public mode: color by claimed role (CO'd role only), default white.
-    """
-    actor = _get_agent(agent_name, agents)
-    if actor is None:
-        return "white"
-    if spectator_mode:
-        return actor.role.color
-    # public mode: only color if the agent has CO'd
-    if actor.state.claimed_role:
-        return actor.state.claimed_role.color
-    return "white"
+        Returns None if the event should not be displayed in the current mode.
+        """
+        if not event.is_public and not self.spectator_mode:
+            return None
 
+        text = Text()
 
-def render_event(
-    event: LogEvent,
-    agents: list[Actor],
-    spectator_mode: bool = False,
-) -> Text | None:
-    """
-    Convert a LogEvent to a Rich Text object for display.
-    Returns None if the event should not be displayed in the current mode.
-    """
-    # Skip non-public events in non-spectator mode
-    if not event.is_public and not spectator_mode:
-        return None
+        if event.event_type == EventType.PHASE_START:
+            text.append(f"\n{event.content}\n", style="bold yellow")
 
-    text = Text()
+        elif event.event_type == EventType.SPEECH:
+            self._render_speech(event, text)
 
-    if event.event_type == EventType.PHASE_START:
-        text.append(f"\n{event.content}\n", style="bold yellow")
+        elif event.event_type == EventType.REASONING:
+            text.append(f"[REASON] {event.agent}: ", style="bold magenta")
+            text.append(event.content, style="magenta")
 
-    elif event.event_type == EventType.SPEECH:
+        elif event.event_type == EventType.VOTE:
+            text.append(f"[VOTE] {event.agent} → {event.target}", style="white")
+
+        elif event.event_type == EventType.ELIMINATION:
+            text.append(f"\n{event.content}\n", style="bold red")
+
+        elif event.event_type == EventType.NIGHT_ATTACK:
+            # Spectator only — render attacker/target explicitly when available.
+            if event.agent and event.target:
+                text.append(
+                    f"[NIGHT] {event.agent} attacks {event.target}",
+                    style="red",
+                )
+            else:
+                text.append(f"[NIGHT] {event.content}", style="red")
+
+        elif event.event_type == EventType.PRE_NIGHT_DECISION:
+            # Spectator only — color by the speaker's true role.
+            actor = self._get_agent(event.agent)
+            style = actor.role.color if actor else "cyan"
+            text.append(f"[PRE-NIGHT] {event.content}", style=style)
+
+        elif event.event_type == EventType.GAME_OVER:
+            text.append(f"\n{'=' * 50}\n", style="bold yellow")
+            text.append(event.content, style="bold green")
+            text.append(f"\n{'=' * 50}\n", style="bold yellow")
+
+        elif event.event_type in self._SIMPLE_EVENT_STYLES:
+            prefix, style = self._SIMPLE_EVENT_STYLES[event.event_type]
+            text.append(f"{prefix}{event.content}", style=style)
+
+        else:
+            text.append(event.content)
+
+        return text if len(text) > 0 else None
+
+    def _render_speech(self, event: LogEvent, text: Text) -> None:
         if event.content.startswith("[THINK]"):
-            # Thought log — spectator only (already filtered above)
+            # Thought log — spectator only (already filtered in on_event).
             thought_content = event.content[len("[THINK] "):]
             text.append(f"  [THINK] {event.agent}: ", style="dim white")
             text.append(thought_content, style="dim white")
-        else:
-            style = _speech_style(event.agent, agents, spectator_mode)
-            prefix = f"[{event.speech_id}] " if event.speech_id is not None else ""
-            reply = f" (→[{event.reply_to}])" if event.reply_to is not None else ""
-            text.append(f"{prefix}{event.agent}{reply}: ", style=f"bold {style}")
-            text.append(event.content, style=style)
+            return
 
-    elif event.event_type == EventType.REASONING:
-        text.append(f"[REASON] {event.agent}: ", style="bold magenta")
-        text.append(event.content, style="magenta")
+        style = self._speech_style(event.agent)
+        prefix = f"[{event.speech_id}] " if event.speech_id is not None else ""
+        reply = f" (→[{event.reply_to}])" if event.reply_to is not None else ""
+        text.append(f"{prefix}{event.agent}{reply}: ", style=f"bold {style}")
+        text.append(event.content, style=style)
 
-    elif event.event_type == EventType.VOTE:
-        text.append(f"[VOTE] {event.agent} → {event.target}", style="white")
+    def _get_agent(self, agent_name: str | None) -> Actor | None:
+        if agent_name is None:
+            return None
+        return next((a for a in self.agents if a.name == agent_name), None)
 
-    elif event.event_type == EventType.ELIMINATION:
-        text.append(f"\n{event.content}\n", style="bold red")
+    def _speech_style(self, agent_name: str | None) -> str:
+        """Return Rich color style for a speech event.
 
-    elif event.event_type == EventType.NIGHT_ATTACK:
-        # Spectator only — red
-        if event.agent and event.target:
-            text.append(
-                f"[NIGHT] {event.agent} attacks {event.target}",
-                style="red",
-            )
-        else:
-            text.append(f"[NIGHT] {event.content}", style="red")
-
-    elif event.event_type == EventType.INSPECTION:
-        # Spectator only — cyan
-        text.append(f"[INSPECT] {event.content}", style="cyan")
-
-    elif event.event_type == EventType.PRE_NIGHT_DECISION:
-        # Spectator only — role color
-        actor = _get_agent(event.agent, agents)
-        style = actor.role.color if actor else "cyan"
-        text.append(f"[PRE-NIGHT] {event.content}", style=style)
-
-    elif event.event_type == EventType.WOLF_CHAT:
-        # Spectator only — red
-        text.append(f"[WOLF] {event.content}", style="red")
-
-    elif event.event_type == EventType.GUARD:
-        # Spectator only — bright_green (Knight role color)
-        text.append(f"[GUARD] {event.content}", style="bright_green")
-
-    elif event.event_type == EventType.GUARD_BLOCK:
-        # Spectator only — bold bright_green (Knight role color)
-        text.append(f"[GUARD BLOCK] {event.content}", style="bold bright_green")
-
-    elif event.event_type == EventType.CO_ANNOUNCEMENT:
-        # Public CO declaration — bold white so it stands out
-        text.append(f"[CO] {event.content}", style="bold white")
-
-    elif event.event_type == EventType.MEDIUM_RESULT:
-        # Spectator only — cyan (Medium's role color)
-        text.append(f"[MEDIUM] {event.content}", style="cyan")
-
-    elif event.event_type == EventType.GAME_OVER:
-        text.append(f"\n{'=' * 50}\n", style="bold yellow")
-        text.append(event.content, style="bold green")
-        text.append(f"\n{'=' * 50}\n", style="bold yellow")
-
-    else:
-        text.append(event.content)
-
-    return text if len(text) > 0 else None
+        Spectator mode: color by true role.
+        Public mode: color by claimed role (CO'd role only), default white.
+        """
+        actor = self._get_agent(agent_name)
+        if actor is None:
+            return "white"
+        if self.spectator_mode:
+            return actor.role.color
+        if actor.state.claimed_role:
+            return actor.state.claimed_role.color
+        return "white"

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -16,7 +16,7 @@ import json
 from src.domain.actor import Actor, ActorState, make_actor
 from src.domain.event import EventType, LogEvent
 from src.logger.reader import load_events
-from src.ui.renderer import render_event
+from src.ui.renderer import Renderer
 
 ARCHIVE_DIR = Path("state_archive")
 
@@ -132,6 +132,7 @@ class ReplayPager:
         for a in dynamic_actors.values():
             a.state.claimed_role = None
 
+        renderer = Renderer(list(dynamic_actors.values()), self._spectator)
         all_lines: list[str] = []
         for event in events:
             # Use event.claimed_role (structured field) rather than parsing content text.
@@ -139,7 +140,7 @@ class ReplayPager:
                 if event.agent in dynamic_actors:
                     dynamic_actors[event.agent].state.claimed_role = event.claimed_role
 
-            rich_text = render_event(event, list(dynamic_actors.values()), self._spectator)
+            rich_text = renderer.on_event(event)
             if rich_text is None:
                 continue
             rendered = _render_rich_to_lines(rich_text, width)

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -1,0 +1,134 @@
+"""Renderer のイベント描画テスト。
+
+- 公開／観戦モードの可視性フィルタ
+- 主要な EventType ごとのスタイル・本文
+- CO 済み時の発言色
+"""
+from rich.text import Text
+
+from src.domain.event import EventType, LogEvent
+from src.ui.renderer import Renderer
+
+
+def _make_event(event_type: EventType, **kwargs) -> LogEvent:
+    return LogEvent.make(day=1, phase="day", event_type=event_type, **kwargs)
+
+
+# ── 可視性フィルタ ────────────────────────────────────────────────────────────
+
+
+def test_non_public_event_hidden_in_public_mode(make_test_actor) -> None:
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=False)
+    event = _make_event(
+        EventType.NIGHT_ATTACK, agent="Wolf", target="Alice", is_public=False
+    )
+
+    assert renderer.on_event(event) is None
+
+
+def test_non_public_event_visible_in_spectator_mode(make_test_actor) -> None:
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=True)
+    event = _make_event(
+        EventType.NIGHT_ATTACK, agent="Wolf", target="Alice", is_public=False
+    )
+
+    result = renderer.on_event(event)
+
+    assert isinstance(result, Text)
+    assert "Wolf attacks Alice" in result.plain
+
+
+# ── 代表的な EventType の描画 ────────────────────────────────────────────────
+
+
+def test_speech_uses_white_without_co(make_test_actor) -> None:
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=False)
+    event = _make_event(
+        EventType.SPEECH, agent="Alice", content="Hello.", speech_id=1
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "[1] Alice: Hello." in result.plain
+    # First span carries the name prefix; style should be bold white.
+    assert "white" in str(result.spans[0].style)
+
+
+def test_speech_uses_true_role_color_in_spectator_mode(make_test_actor) -> None:
+    actor = make_test_actor("Wolf", "Werewolf")
+    renderer = Renderer([actor], spectator_mode=True)
+    event = _make_event(EventType.SPEECH, agent="Wolf", content="Hi.")
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert actor.role.color in str(result.spans[0].style)
+
+
+def test_think_prefix_renders_as_dim_spectator_line(make_test_actor) -> None:
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=True)
+    event = _make_event(
+        EventType.SPEECH, agent="Alice", content="[THINK] they look nervous", is_public=False
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "[THINK] Alice: they look nervous" in result.plain
+
+
+def test_vote_renders_agent_and_target(make_test_actor) -> None:
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=False)
+    event = _make_event(EventType.VOTE, agent="Alice", target="Bob")
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert result.plain == "[VOTE] Alice → Bob"
+
+
+def test_simple_event_uses_mapping_prefix(make_test_actor) -> None:
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(EventType.INSPECTION, content="Seer saw Bob is Werewolf", is_public=False)
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert result.plain == "[INSPECT] Seer saw Bob is Werewolf"
+
+
+def test_night_attack_without_agent_falls_back_to_content(make_test_actor) -> None:
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(EventType.NIGHT_ATTACK, content="No one was attacked", is_public=False)
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert result.plain == "[NIGHT] No one was attacked"
+
+
+def test_phase_start_wraps_with_newlines(make_test_actor) -> None:
+    renderer = Renderer([], spectator_mode=False)
+    event = _make_event(EventType.PHASE_START, content="=== Day 1 ===")
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert result.plain == "\n=== Day 1 ===\n"
+
+
+def test_game_over_has_header_and_footer(make_test_actor) -> None:
+    renderer = Renderer([], spectator_mode=False)
+    event = _make_event(EventType.GAME_OVER, content="Village wins!")
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "Village wins!" in result.plain
+    assert result.plain.count("=" * 50) == 2


### PR DESCRIPTION
## Summary
- Wrap `render_event()` into a `Renderer` class holding `agents` and `spectator_mode`
- Consolidate simple event-style mappings into `_SIMPLE_EVENT_STYLES` class constant
- Add module-level comment outlining future EventPresenter → ConsoleRenderer/WebRenderer split
- Update `cli.py` and `replay.py` to use `Renderer` instances instead of the bare function
- Add unit tests covering visibility filter and representative event types

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス (153 passed)
- [x] Visibility filter: non-public event hidden in public mode, visible in spectator
- [x] Speech style: white default, true-role color in spectator mode
- [x] Simple events render with mapped prefix/style

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)