### PR TITLE
refactor: split actor profile and dynamic state

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -78,14 +78,14 @@ LLMの出力は自然文のパースに頼らず、常にPydanticモデルで検
 
 ### 3.2 Agent State（`src/agent/`）
 
-- エージェントの状態（役職・信念・記憶・人格パラメータ）を管理
+- エージェントの静的プロフィールと動的状態を管理
 - 状態は `state/agents/{name}.json` に永続化
-- Pydanticモデルは `src/domain/actor.py` で定義（`ActorState`, `Belief`, `Persona`）
-- ランタイムラッパー `Actor`（dataclass）は `state: ActorState` と `role: Role` を持つ。永続化対象は `ActorState` のみ
+- Pydanticモデルは `src/domain/actor.py` で定義（`ActorProfile`, `ActorState`, `Belief`, `Persona`）
+- ランタイムラッパー `Actor`（dataclass）は `profile: ActorProfile`, `state: ActorState`, `role: Role` を持つ
 
 #### Persona フィールド
 
-`Persona` モデルは以下のフィールドを持つ。
+`Persona` モデルは `ActorProfile.persona` に保持され、以下のフィールドを持つ。
 
 | フィールド | 型 | デフォルト | 説明 |
 |---|---|---|---|
@@ -104,9 +104,13 @@ LLMの出力は自然文のパースに頼らず、常にPydanticモデルで検
 
 | フィールド | 内容 |
 |---|---|
-| `role` | 真の役職文字列（システム管理。LLMには渡さない。ランタイムでは `Actor.role`（Role instance）を使う） |
+| `beliefs` | 他プレイヤーへの疑い・信頼・理由 |
+| `memory_summary` | 今回のゲームで蓄積された中期記憶 |
+| `is_alive` | 生存フラグ |
 | `claimed_role` | エージェントが公言した役職（CO済みなら設定。未COはNull） |
 | `intended_co` | 前夜ターンで「初日COする」と決めた場合 `True`（Day 1 OPENINGプロンプトに反映後は参照不要） |
+
+静的な `name`, `model`, `persona` は `ActorProfile` に分離される。真の役職は保存JSON上では `role` 文字列、ランタイムでは `Actor.role`（`Role` instance）として扱う。
 
 - `intent.co` がLLM出力に含まれたタイミングでGame Engineが `claimed_role` に保存
 - `claimed_role` は **Public情報** として全エージェントのプロンプトに渡す
@@ -150,7 +154,7 @@ Day 1 OPENINGで `intended_co=True` なのにLLMがCOを出力しなかった場
 | `call_judgment()` | 判断（DISCUSSION 並列） | 軽量（役職・性格・memory_summary・直近発言のみ） | `JudgmentOutput` |
 | `call_night_action()` | 夜行動 | 夜フェーズ専用 | `str`（ターゲット名） |
 | `call_pre_night_action()` | 前夜判断・単体呼び出し | 役職・性格・参加者情報 | `PreNightOutput` |
-| `call_pre_night_parallel()` | 前夜判断・並列呼び出し（`call_speech_parallel` と同パターン） | 同上 | `Iterator[tuple[AgentState, PreNightOutput]]` |
+| `call_pre_night_parallel()` | 前夜判断・並列呼び出し（`call_speech_parallel` と同パターン） | 同上 | `Iterator[tuple[Actor, PreNightOutput]]` |
 | `call_discussion_parallel()` | 昼DISCUSSION 判断→発言チェーンの並列実行 | — | `Iterator[tuple[Actor, JudgmentOutput, AgentOutput \| None, SpeechEntry \| None, bool]]` |
 
 #### 並列実行

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -46,7 +46,7 @@
 
 | モジュール | 責務 |
 |---|---|
-| `actor.py` | `ActorState`, `Belief`, `Persona` のPydanticモデル定義 + `Actor` dataclass（`state: ActorState`, `role: Role`） |
+| `actor.py` | `ActorProfile`, `ActorState`, `Belief`, `Persona` のPydanticモデル定義 + `Actor` dataclass（`profile: ActorProfile`, `state: ActorState`, `role: Role`） |
 | `event.py` | `EventType`, `LogEvent` のPydanticモデル定義 |
 | `role.py` | `Role` ABC + 具象クラス（Villager, Werewolf, Seer, Knight, Medium, Madman）+ `get_role()` ファクトリ。役職の定義を一箇所に集約する |
 | `schema.py` | `AgentOutput`, `SpeechEntry`, `JudgmentOutput` 等のPydanticモデル定義 |
@@ -90,13 +90,14 @@ def get_role(role: str) -> Role:
 | `belief.py` | 疑い・信頼スコアの更新（`memory_update` を受けて反映） |
 | `store.py` | JSONファイルへのread/write |
 
-### Actor と ActorState の分離
+### Actor / ActorProfile / ActorState の分離
 
 `Actor`（dataclass）はランタイムのみで使われる：
-- `state: ActorState` — JSON 永続化される Pydantic モデル
-- `role: Role` — 役職 Strategy インスタンス（`make_actor(state, role_name)` で構築）
-- 便利 property: `name`（`state.name`）、`is_alive`（`state.is_alive`）
-- 永続化は `state` + `role.name`。`store.save(actor)` は `ActorState` フィールドに `role` を加えた JSON を書き出す
+- `profile: ActorProfile` — ゲーム中に不変なプロフィール（`name`, `model`, `persona`）
+- `state: ActorState` — ゲーム中に変化する状態（`beliefs`, `memory_summary`, `is_alive`, `claimed_role`, `intended_co`）
+- `role: Role` — 役職 Strategy インスタンス（`make_actor(profile, state, role_name)` で構築）
+- 便利 property: `name`（`profile.name`）、`model`（`profile.model`）、`persona`（`profile.persona`）、`is_alive`（`state.is_alive`）
+- 永続化は `profile` + `state` + `role.name`。`store.save(actor)` は分離JSONを書き出す
 
 `Actor.role` により `get_role(agent.role)` の繰り返し呼び出しが不要になる。
 
@@ -104,25 +105,32 @@ def get_role(role: str) -> Role:
 
 ```json
 {
-  "name": "Setsu",
+  "profile": {
+    "name": "Setsu",
+    "model": "claude-haiku-4-5-20251001",
+    "persona": {
+      "style": "logical, calm, empathic",
+      "lie_tendency": 0.1,
+      "aggression": 0.2,
+      "gender": "female",
+      "age": "adult",
+      "speech_style": "polite"
+    }
+  },
+  "state": {
+    "beliefs": {
+      "SQ": { "suspicion": 0.62, "trust": 0.18, "reason": ["Day2で票替え"] }
+    },
+    "memory_summary": ["Day1: SQはジナを擁護"],
+    "is_alive": true,
+    "claimed_role": null,
+    "intended_co": false
+  },
   "role": "Villager",
-  "persona": {
-    "style": "logical, calm, empathic",
-    "lie_tendency": 0.1,
-    "aggression": 0.2,
-    "gender": "female",
-    "age": "adult",
-    "speech_style": "polite"
-  },
-  "beliefs": {
-    "SQ": { "suspicion": 0.62, "trust": 0.18, "reason": ["Day2で票替え"] }
-  },
-  "claims": { "self_co": null, "others": {} },
-  "memory_summary": ["Day1: SQはジナを擁護"],
-  "goal": "survive and eliminate werewolves",
-  "last_action": { "type": "vote", "target": "SQ" }
 }
 ```
+
+`actor_from_dict()` は読込境界の adapter として機能し、新しい分離JSONを優先しつつ、過去アーカイブの旧フラットJSONも正規化して `Actor(profile, state, role)` に変換する。
 
 ---
 
@@ -146,7 +154,7 @@ class PublicContext:
     alive_players: list[str]
     dead_players: list[str]
     day: int
-    all_agents: list[AgentState] | None = None   # 役職分布・CO状況
+    all_agents: list[Actor] | None = None   # 役職分布・CO状況
     past_votes: list[PastVote] | None = None   # TypedDict: {day, votes}
     past_deaths: list[PastDeath] | None = None  # TypedDict: {day, name, cause}
 
@@ -276,7 +284,7 @@ class ReplayPager:
 ```
 
 **初期化:**
-1. `archive_path/agents/*.json` を `AgentState` としてロード（`src.agent.state` の Pydantic モデルを直接使用）
+1. `archive_path/agents/*.json` を `actor_from_dict()` 経由で `Actor` としてロード
 2. `spectator_mode` に応じて `spectator_log.jsonl` または `public_log.jsonl` を読み込み
 3. 各 `LogEvent` を `Renderer.on_event()` で描画し、`list[str]`（ANSI 文字列）としてバッファに積む
 
@@ -285,6 +293,8 @@ class ReplayPager:
 これを防ぐため、`_build_lines()` ではエージェントのコピーを作り `claimed_role` を全員 `None` にリセットした上で、
 イベントを順に処理しながら `CO_ANNOUNCEMENT` が来たタイミングで `claimed_role` を更新する。
 spectatorモードは `agent.role`（変化しない真の役職）を使うため影響なし。
+
+旧アーカイブ互換のため、`profile` が存在しない旧JSONは `name` / `model` / `persona` をトップレベルから読み取り、必要に応じて `config/agents.json` のカタログで補完する。
 
 **ページャーループ:**
 - `shutil.get_terminal_size().lines` でターミナル高さを取得

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#119 | tech-debt | 🟡 | 3 | Unify co-intent flags: rename force_co and type intended_co as Role \| None | force_coとintended_coの二重フラグを統合。Step1:force_co削除、Step2:bool→Role\|None型変更（2段階） |
-| yukkie/AgentVillage#74 | tech-debt | 🟡 | 5 | Split ActorState into ActorProfile (static) and ActorState (dynamic) | name/role/model/persona を ActorProfile に分離。ActorState は動的フィールドのみ |
 | yukkie/AgentVillage#81 | tech-debt | 🟡 | 5 | Separate night action declaration and resolution phases | 夜フェーズの宣言・実行・公表を3段階に分離。seer_survived フラグ削除。キツネ等の複雑な相互作用に対応 |
 | yukkie/AgentVillage#33 | enhancement | 🟢 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#36 | enhancement | 🟢 | 5 | Belief updates from agent reasoning | suspicion/trust を推理結果から更新 |

--- a/src/agent/store.py
+++ b/src/agent/store.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 from src.config import STATE_DIR
-from src.domain.actor import Actor, ActorState, make_actor
+from src.domain.actor import Actor, actor_from_dict, actor_to_dict
 
 
 def _ensure_dir() -> None:
@@ -12,8 +12,7 @@ def _ensure_dir() -> None:
 def save(actor: Actor) -> None:
     _ensure_dir()
     path = STATE_DIR / f"{actor.name.lower()}.json"
-    data = json.loads(actor.state.model_dump_json())
-    data["role"] = actor.role.name
+    data = actor_to_dict(actor)
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
@@ -22,14 +21,14 @@ def load(name: str) -> Actor:
     if not path.exists():
         raise FileNotFoundError(f"Agent state file not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
-    return make_actor(ActorState.model_validate(data), data["role"])
+    return actor_from_dict(data)
 
 
 def load_all_from_dir(path: Path) -> list[Actor]:
     actors = []
     for p in sorted(path.glob("*.json")):
         data = json.loads(p.read_text(encoding="utf-8"))
-        actors.append(make_actor(ActorState.model_validate(data), data["role"]))
+        actors.append(actor_from_dict(data))
     return actors
 
 

--- a/src/domain/actor.py
+++ b/src/domain/actor.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from pathlib import Path
+import json
 
 from pydantic import BaseModel
 
@@ -21,10 +23,13 @@ class Belief(BaseModel):
     reason: list[str] = []
 
 
-class ActorState(BaseModel):
+class ActorProfile(BaseModel):
     name: str
     model: str = "claude-haiku-4-5-20251001"
     persona: Persona
+
+
+class ActorState(BaseModel):
     beliefs: dict[str, Belief] = {}
     memory_summary: list[str] = []
     is_alive: bool = True
@@ -34,17 +39,87 @@ class ActorState(BaseModel):
 
 @dataclass
 class Actor:
+    profile: ActorProfile
     state: ActorState
     role: Role
 
     @property
     def name(self) -> str:
-        return self.state.name
+        return self.profile.name
+
+    @property
+    def model(self) -> str:
+        return self.profile.model
+
+    @property
+    def persona(self) -> Persona:
+        return self.profile.persona
 
     @property
     def is_alive(self) -> bool:
         return self.state.is_alive
 
 
-def make_actor(state: ActorState, role_name: str) -> Actor:
-    return Actor(state=state, role=get_role(role_name))
+def make_actor(profile: ActorProfile, state: ActorState, role_name: str) -> Actor:
+    return Actor(profile=profile, state=state, role=get_role(role_name))
+
+
+def load_agent_catalog(path: Path = Path("config/agents.json")) -> dict[str, ActorProfile]:
+    configs = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        config["name"]: ActorProfile(
+            name=config["name"],
+            model=config.get("model", ActorProfile.model_fields["model"].default),
+            persona=Persona.model_validate(config),
+        )
+        for config in configs
+    }
+
+
+def actor_to_dict(actor: Actor) -> dict:
+    return {
+        "profile": actor.profile.model_dump(mode="json"),
+        "state": actor.state.model_dump(mode="json"),
+        "role": actor.role.name,
+    }
+
+
+def actor_from_dict(data: dict, agent_catalog: dict[str, ActorProfile] | None = None) -> Actor:
+    role_name = data["role"]
+
+    # Preferred on-disk format: keep static profile and dynamic state separate.
+    if "profile" in data and "state" in data:
+        profile = ActorProfile.model_validate(data["profile"])
+        state = ActorState.model_validate(data["state"])
+        return make_actor(profile, state, role_name)
+
+    # Backward-compatibility path for archived/top-level JSON. Normalize the
+    # legacy flat shape into the new ActorProfile + ActorState structure here
+    # so the rest of the codebase only deals with the new model.
+    fallback_name = data.get("name")
+    if fallback_name and agent_catalog and fallback_name in agent_catalog:
+        profile = agent_catalog[fallback_name]
+        profile_data = {
+            "name": data.get("name", profile.name),
+            "model": data.get("model", profile.model),
+            "persona": data.get("persona", profile.persona.model_dump(mode="json")),
+        }
+    else:
+        profile_data = {
+            "name": data["name"],
+            "model": data.get("model", ActorProfile.model_fields["model"].default),
+            "persona": data["persona"],
+        }
+
+    state_data = {
+        "beliefs": data.get("beliefs", {}),
+        "memory_summary": data.get("memory_summary", []),
+        "is_alive": data.get("is_alive", True),
+        "claimed_role": data.get("claimed_role"),
+        "intended_co": data.get("intended_co", False),
+    }
+    return make_actor(
+        ActorProfile.model_validate(profile_data),
+        ActorState.model_validate(state_data),
+        role_name,
+    )

--- a/src/engine/setup.py
+++ b/src/engine/setup.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 from src.config import STATE_DIR
-from src.domain.actor import Actor, ActorState, Belief, Persona, make_actor
+from src.domain.actor import Actor, ActorProfile, ActorState, Belief, Persona, make_actor
 from src.agent import store
 
 
@@ -54,14 +54,17 @@ def initialize_agents(num_players: int) -> list[Actor]:
             for other in selected_configs
             if other["name"] != name
         }
-        state = ActorState(
+        profile = ActorProfile(
             name=name,
+            model=config.get("model", ActorProfile.model_fields["model"].default),
             persona=Persona.model_validate(config),
+        )
+        state = ActorState(
             beliefs=beliefs,
             memory_summary=[],
             is_alive=True,
         )
-        actor = make_actor(state, role)
+        actor = make_actor(profile, state, role)
         store.save(actor)
         actors.append(actor)
 

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -72,7 +72,7 @@ class LLMClient:
         raw = ""
         try:
             message = self._client.messages.create(
-                model=actor.state.model,
+                model=actor.model,
                 max_tokens=2048,
                 system=system_prompt,
                 messages=[
@@ -102,7 +102,7 @@ class LLMClient:
         raw = ""
         try:
             message = self._client.messages.create(
-                model=actor.state.model,
+                model=actor.model,
                 max_tokens=1024,
                 messages=[{"role": "user", "content": prompt}],
             )
@@ -137,7 +137,7 @@ class LLMClient:
         raw = ""
         try:
             message = self._client.messages.create(
-                model=actor.state.model,
+                model=actor.model,
                 max_tokens=1024,
                 messages=[{"role": "user", "content": prompt}],
             )
@@ -212,7 +212,7 @@ class LLMClient:
         raw = ""
         try:
             message = self._client.messages.create(
-                model=actor.state.model,
+                model=actor.model,
                 max_tokens=2048,
                 messages=[{"role": "user", "content": prompt}],
             )
@@ -237,7 +237,7 @@ class LLMClient:
         raw = ""
         try:
             message = self._client.messages.create(
-                model=actor.state.model,
+                model=actor.model,
                 max_tokens=64,
                 messages=[
                     {

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -65,15 +65,15 @@ _SPEECH_STYLE_PROMPTS: dict[str, str] = {
 
 def build_persona_prompt(actor: Actor) -> str:
     """Generate personality prompt from actor persona."""
-    style = actor.state.persona.style
-    lie = actor.state.persona.lie_tendency
-    agg = actor.state.persona.aggression
+    style = actor.persona.style
+    lie = actor.persona.lie_tendency
+    agg = actor.persona.aggression
 
     identity_parts = [actor.name]
-    if actor.state.persona.age is not None:
-        identity_parts.append(f"age {actor.state.persona.age}")
-    if actor.state.persona.gender is not None:
-        identity_parts.append(actor.state.persona.gender)
+    if actor.persona.age is not None:
+        identity_parts.append(f"age {actor.persona.age}")
+    if actor.persona.gender is not None:
+        identity_parts.append(actor.persona.gender)
     identity = ", ".join(identity_parts)
 
     lines = [
@@ -81,11 +81,11 @@ def build_persona_prompt(actor: Actor) -> str:
         f"Your personality style: {style}.",
     ]
 
-    speech_prompt = _SPEECH_STYLE_PROMPTS.get(actor.state.persona.speech_style)
+    speech_prompt = _SPEECH_STYLE_PROMPTS.get(actor.persona.speech_style)
     if speech_prompt:
         lines.append(speech_prompt)
-    elif actor.state.persona.speech_style != "casual":
-        lines.append(f"Your speaking style: {actor.state.persona.speech_style}.")
+    elif actor.persona.speech_style != "casual":
+        lines.append(f"Your speaking style: {actor.persona.speech_style}.")
 
     if lie > 0.5:
         lines.append("You are comfortable bending the truth when it serves your survival.")
@@ -224,7 +224,7 @@ def build_pre_night_prompt(
 
     lines = [
         f"You are {actor.name}, a player in a social deduction game (Werewolf/Mafia).",
-        f"Your personality style: {actor.state.persona.style}.",
+        f"Your personality style: {actor.persona.style}.",
         "",
         f"Your secret role is: {actor.role.name}",
         f"Players in this game: {', '.join(alive_players)}",

--- a/src/ui/cli.py
+++ b/src/ui/cli.py
@@ -57,5 +57,5 @@ class CLI:
         console.print("\n[bold cyan]Agent Roster:[/bold cyan]")
         for actor in self.agents:
             role_style = actor.role.color
-            console.print(f"  [{role_style}]{actor.name}[/{role_style}] — {actor.role.name} ({actor.state.persona.style})")
+            console.print(f"  [{role_style}]{actor.name}[/{role_style}] — {actor.role.name} ({actor.persona.style})")
         console.print()

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -13,7 +13,7 @@ from rich.text import Text
 
 import json
 
-from src.domain.actor import Actor, ActorState, make_actor
+from src.domain.actor import Actor, actor_from_dict, load_agent_catalog, make_actor
 from src.domain.event import EventType, LogEvent
 from src.logger.reader import load_events
 from src.ui.renderer import Renderer
@@ -106,11 +106,12 @@ class ReplayPager:
         if not agents_dir.exists():
             print(f"[ReplayPager] agents/ directory not found: {agents_dir}", file=sys.stderr)
             return []
+        agent_catalog = load_agent_catalog()
         actors = []
         for p in sorted(agents_dir.glob("*.json")):
             try:
                 data = json.loads(p.read_text(encoding="utf-8"))
-                actors.append(make_actor(ActorState.model_validate(data), data["role"]))
+                actors.append(actor_from_dict(data, agent_catalog))
             except Exception as e:
                 print(f"[ReplayPager] skipping corrupt agent file {p.name}: {e}", file=sys.stderr)
         return actors
@@ -126,7 +127,7 @@ class ReplayPager:
         # Reset claimed_role to None so public-mode colors reflect what was
         # publicly known at each moment, not the end-of-game state.
         dynamic_actors: dict[str, Actor] = {
-            a.name: make_actor(a.state.model_copy(), a.role.name)
+            a.name: make_actor(a.profile.model_copy(), a.state.model_copy(), a.role.name)
             for a in self._agents
         }
         for a in dynamic_actors.values():

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,24 +2,49 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from src.domain.actor import Actor, ActorState, Persona, make_actor
+from src.domain.actor import Actor, ActorProfile, ActorState, Persona, make_actor
 from src.domain.event import LogEvent
 from src.engine.game import GameEngine
 from src.llm.client import LLMClient
 from src.logger.writer import LogWriter
 
 
+def make_legacy_agent_json(name: str, role: str) -> dict:
+    return {
+        "name": name,
+        "persona": Persona(style="calm").model_dump(mode="json"),
+        "beliefs": {},
+        "memory_summary": [],
+        "is_alive": True,
+        "role": role,
+    }
+
+
+def make_split_agent_json(name: str, role: str) -> dict:
+    return {
+        "profile": ActorProfile(name=name, persona=Persona(style="calm")).model_dump(mode="json"),
+        "state": ActorState(
+            beliefs={},
+            memory_summary=[],
+            is_alive=True,
+        ).model_dump(mode="json"),
+        "role": role,
+    }
+
+
 @pytest.fixture
 def make_test_actor():
     def _make_test_actor(name: str, role: str = "Villager") -> Actor:
-        state = ActorState(
+        profile = ActorProfile(
             name=name,
             persona=Persona(style="calm", lie_tendency=0.1, aggression=0.2),
+        )
+        state = ActorState(
             beliefs={},
             memory_summary=[],
             is_alive=True,
         )
-        return make_actor(state, role)
+        return make_actor(profile, state, role)
 
     return _make_test_actor
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4,20 +4,8 @@ from unittest.mock import MagicMock
 
 import anthropic
 
-from src.domain.actor import Actor, ActorState, Persona, make_actor
 from src.domain.schema import AgentOutput, JudgmentOutput, PreNightOutput, WolfChatOutput
 from src.llm.client import LLMClient
-
-
-def _make_actor(name: str = "Alice", role: str = "Villager") -> Actor:
-    state = ActorState(
-        name=name,
-        persona=Persona(style="calm", lie_tendency=0.1, aggression=0.2),
-        beliefs={},
-        memory_summary=[],
-        is_alive=True,
-    )
-    return make_actor(state, role)
 
 
 def _make_llm_client(response_text: str) -> LLMClient:
@@ -58,8 +46,8 @@ _WOLF_CHAT_OUTPUT_JSON = json.dumps({
 
 
 class TestCall:
-    def test_returns_agent_output(self):
-        actor = _make_actor()
+    def test_returns_agent_output(self, make_test_actor):
+        actor = make_test_actor("Alice")
         llm = _make_llm_client(_AGENT_OUTPUT_JSON)
         from src.llm.prompt import PublicContext, SpeechDirection
         ctx = PublicContext(alive_players=["Alice"], dead_players=[], day=1, today_log=[])
@@ -68,8 +56,8 @@ class TestCall:
         assert isinstance(result, AgentOutput)
         assert result.speech == "Hello village."
 
-    def test_returns_fallback_on_exception(self):
-        actor = _make_actor()
+    def test_returns_fallback_on_exception(self, make_test_actor):
+        actor = make_test_actor("Alice")
         llm = _make_failing_llm_client()
         from src.llm.prompt import PublicContext, SpeechDirection
         ctx = PublicContext(alive_players=["Alice"], dead_players=[], day=1, today_log=[])
@@ -80,77 +68,77 @@ class TestCall:
 
 
 class TestCallJudgment:
-    def test_returns_judgment_output(self):
-        actor = _make_actor()
+    def test_returns_judgment_output(self, make_test_actor):
+        actor = make_test_actor("Alice")
         llm = _make_llm_client(_JUDGMENT_OUTPUT_JSON)
         result = llm.call_judgment(actor, [], ["Alice", "Bob"], day=1)
         assert isinstance(result, JudgmentOutput)
         assert result.decision == "speak"
 
-    def test_returns_silent_on_exception(self):
-        actor = _make_actor()
+    def test_returns_silent_on_exception(self, make_test_actor):
+        actor = make_test_actor("Alice")
         llm = _make_failing_llm_client()
         result = llm.call_judgment(actor, [], ["Alice", "Bob"], day=1)
         assert result.decision == "silent"
 
 
 class TestCallPreNightAction:
-    def test_returns_pre_night_output(self):
-        actor = _make_actor("Gina", "Seer")
+    def test_returns_pre_night_output(self, make_test_actor):
+        actor = make_test_actor("Gina", "Seer")
         llm = _make_llm_client(_PRE_NIGHT_OUTPUT_JSON)
         result = llm.call_pre_night_action(actor, ["Gina", "Bob"])
         assert isinstance(result, PreNightOutput)
         assert result.decision == "wait"
 
-    def test_returns_wait_fallback_on_exception(self):
-        actor = _make_actor("Gina", "Seer")
+    def test_returns_wait_fallback_on_exception(self, make_test_actor):
+        actor = make_test_actor("Gina", "Seer")
         llm = _make_failing_llm_client()
         result = llm.call_pre_night_action(actor, ["Gina", "Bob"])
         assert result.decision == "wait"
 
 
 class TestCallWolfChat:
-    def test_returns_wolf_chat_output(self):
-        actor = _make_actor("Wolf", "Werewolf")
+    def test_returns_wolf_chat_output(self, make_test_actor):
+        actor = make_test_actor("Wolf", "Werewolf")
         llm = _make_llm_client(_WOLF_CHAT_OUTPUT_JSON)
         result = llm.call_wolf_chat(actor, ["OtherWolf"], ["Alice", "Wolf", "OtherWolf"], [])
         assert isinstance(result, WolfChatOutput)
         assert result.speech == "Let's attack Alice."
 
-    def test_returns_empty_fallback_on_exception(self):
-        actor = _make_actor("Wolf", "Werewolf")
+    def test_returns_empty_fallback_on_exception(self, make_test_actor):
+        actor = make_test_actor("Wolf", "Werewolf")
         llm = _make_failing_llm_client()
         result = llm.call_wolf_chat(actor, ["OtherWolf"], ["Alice", "Wolf", "OtherWolf"], [])
         assert result.speech == "..."
 
 
 class TestCallNightAction:
-    def test_exact_match(self):
-        actor = _make_actor("Wolf", "Werewolf")
+    def test_exact_match(self, make_test_actor):
+        actor = make_test_actor("Wolf", "Werewolf")
         llm = _make_llm_client("Alice")
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == "Alice"
 
-    def test_partial_match(self):
-        actor = _make_actor("Wolf", "Werewolf")
+    def test_partial_match(self, make_test_actor):
+        actor = make_test_actor("Wolf", "Werewolf")
         llm = _make_llm_client("I think Alice is the target")
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == "Alice"
 
-    def test_fallback_to_first_candidate_on_no_match(self):
-        actor = _make_actor("Wolf", "Werewolf")
+    def test_fallback_to_first_candidate_on_no_match(self, make_test_actor):
+        actor = make_test_actor("Wolf", "Werewolf")
         llm = _make_llm_client("Nobody")
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == "Alice"
 
-    def test_fallback_to_first_candidate_on_exception(self):
-        actor = _make_actor("Wolf", "Werewolf")
+    def test_fallback_to_first_candidate_on_exception(self, make_test_actor):
+        actor = make_test_actor("Wolf", "Werewolf")
         llm = _make_failing_llm_client()
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == "Alice"
 
-    def test_returns_empty_string_when_no_prompt(self):
-        actor = _make_actor("Alice", "Villager")
+    def test_returns_empty_string_when_no_prompt(self, make_test_actor):
+        actor = make_test_actor("Alice", "Villager")
         llm = _make_failing_llm_client()
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == ""

--- a/tests/unit/test_judgment_prompt.py
+++ b/tests/unit/test_judgment_prompt.py
@@ -1,23 +1,6 @@
-from src.domain.actor import ActorState, Actor, Persona, Belief, make_actor
+from src.domain.actor import Belief
 from src.llm.prompt import build_judgment_prompt
 from src.domain.schema import SpeechEntry
-
-
-def _make_actor(
-    name: str = "Setsu",
-    role: str = "Villager",
-    memory: list[str] | None = None,
-    claimed_role: str | None = None,
-) -> Actor:
-    state = ActorState(
-        name=name,
-        persona=Persona(style="calm", lie_tendency=0.1, aggression=0.2),
-        beliefs={"SQ": Belief()},
-        memory_summary=memory or [],
-        is_alive=True,
-        claimed_role=claimed_role,
-    )
-    return make_actor(state, role)
 
 
 def _make_log(*texts: str) -> list[SpeechEntry]:
@@ -25,68 +8,80 @@ def _make_log(*texts: str) -> list[SpeechEntry]:
 
 
 class TestBuildJudgmentPrompt:
-    def test_contains_agent_name_and_role(self):
-        actor = _make_actor()
+    def test_contains_agent_name_and_role(self, make_test_actor):
+        actor = make_test_actor("Setsu")
+        actor.state.beliefs = {"SQ": Belief()}
         prompt = build_judgment_prompt(actor, [], ["Setsu", "SQ"], day=1)
         assert "Setsu" in prompt
         assert "Villager" in prompt
 
-    def test_contains_recent_speeches_with_ids(self):
-        actor = _make_actor()
+    def test_contains_recent_speeches_with_ids(self, make_test_actor):
+        actor = make_test_actor("Setsu")
+        actor.state.beliefs = {"SQ": Belief()}
         log = _make_log("Hello everyone.", "I suspect SQ.")
         prompt = build_judgment_prompt(actor, log, ["Setsu", "SQ"], day=1)
         assert "[1]" in prompt
         assert "[2]" in prompt
         assert "Hello everyone." in prompt
 
-    def test_only_last_6_speeches_included(self):
-        actor = _make_actor()
+    def test_only_last_6_speeches_included(self, make_test_actor):
+        actor = make_test_actor("Setsu")
+        actor.state.beliefs = {"SQ": Belief()}
         log = _make_log(*[f"speech {i}" for i in range(10)])
         prompt = build_judgment_prompt(actor, log, ["Setsu"], day=2)
         # speech 0-3 should be excluded (only last 6: 4-9)
         assert "speech 0" not in prompt
         assert "speech 9" in prompt
 
-    def test_memory_included(self):
-        actor = _make_actor(memory=["SQ changed vote on Day1"])
+    def test_memory_included(self, make_test_actor):
+        actor = make_test_actor("Setsu")
+        actor.state.beliefs = {"SQ": Belief()}
+        actor.state.memory_summary = ["SQ changed vote on Day1"]
         prompt = build_judgment_prompt(actor, [], ["Setsu", "SQ"], day=2)
         assert "SQ changed vote on Day1" in prompt
 
-    def test_json_format_instruction_present(self):
-        actor = _make_actor()
+    def test_json_format_instruction_present(self, make_test_actor):
+        actor = make_test_actor("Setsu")
+        actor.state.beliefs = {"SQ": Belief()}
         prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1)
         assert "challenge" in prompt
         assert "silent" in prompt
         assert "reply_to" in prompt
 
-    def test_co_option_absent_for_villager(self):
-        actor = _make_actor(role="Villager")
+    def test_co_option_absent_for_villager(self, make_test_actor):
+        actor = make_test_actor("Setsu", "Villager")
+        actor.state.beliefs = {"SQ": Belief()}
         prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=False)
         assert '"co"' not in prompt
 
-    def test_co_option_present_when_co_eligible(self):
-        actor = _make_actor(role="Seer")
+    def test_co_option_present_when_co_eligible(self, make_test_actor):
+        actor = make_test_actor("Setsu", "Seer")
+        actor.state.beliefs = {"SQ": Belief()}
         prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
         assert '"co"' in prompt
 
-    def test_co_strategy_hint_seer(self):
-        actor = _make_actor(role="Seer")
+    def test_co_strategy_hint_seer(self, make_test_actor):
+        actor = make_test_actor("Setsu", "Seer")
+        actor.state.beliefs = {"SQ": Belief()}
         prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
         assert "Seer" in prompt
         assert "trust" in prompt.lower()
 
-    def test_co_strategy_hint_werewolf(self):
-        actor = _make_actor(role="Werewolf")
+    def test_co_strategy_hint_werewolf(self, make_test_actor):
+        actor = make_test_actor("Setsu", "Werewolf")
+        actor.state.beliefs = {"SQ": Belief()}
         prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
         assert "fake" in prompt.lower() or "chaos" in prompt.lower()
 
-    def test_co_strategy_hint_madman(self):
-        actor = _make_actor(role="Madman")
+    def test_co_strategy_hint_madman(self, make_test_actor):
+        actor = make_test_actor("Setsu", "Madman")
+        actor.state.beliefs = {"SQ": Belief()}
         prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
         assert "Madman" in prompt
 
-    def test_co_not_in_format_when_not_eligible(self):
+    def test_co_not_in_format_when_not_eligible(self, make_test_actor):
         """Ensure the 4th choice is absent when co_eligible=False (default)."""
-        actor = _make_actor(role="Seer")
+        actor = make_test_actor("Setsu", "Seer")
+        actor.state.beliefs = {"SQ": Belief()}
         prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1)  # default co_eligible=False
         assert '"co"' not in prompt

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -1,23 +1,9 @@
 """src/agent/memory.py のテスト。"""
 import pytest
 
-from src.domain.actor import Actor, ActorState, Persona
 from src.agent.memory import update_memory
 
-
-def _make_actor(name: str = "Alice") -> Actor:
-    from src.domain.actor import make_actor
-    state = ActorState(
-        name=name,
-        persona=Persona(style="calm"),
-        beliefs={},
-        memory_summary=[],
-        is_alive=True,
-    )
-    return make_actor(state, "Villager")
-
-
-def test_update_memory_appends_new_items(monkeypatch) -> None:
+def test_update_memory_appends_new_items(monkeypatch, make_test_actor) -> None:
     """
     SUT: update_memory()
     Mock: monkeypatch で store.save を no-op に差し替え
@@ -26,12 +12,12 @@ def test_update_memory_appends_new_items(monkeypatch) -> None:
     """
     from src.agent import memory as mem_mod
     monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
-    actor = _make_actor()
+    actor = make_test_actor("Alice")
     result = update_memory(actor, ["saw wolf", "suspect Bob"])
     assert result.state.memory_summary == ["saw wolf", "suspect Bob"]
 
 
-def test_update_memory_skips_duplicates(monkeypatch) -> None:
+def test_update_memory_skips_duplicates(monkeypatch, make_test_actor) -> None:
     """
     SUT: update_memory()
     Mock: monkeypatch で store.save を no-op に差し替え
@@ -40,13 +26,13 @@ def test_update_memory_skips_duplicates(monkeypatch) -> None:
     """
     from src.agent import memory as mem_mod
     monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
-    actor = _make_actor()
+    actor = make_test_actor("Alice")
     actor.state.memory_summary.append("saw wolf")
     update_memory(actor, ["saw wolf", "new info"])
     assert actor.state.memory_summary == ["saw wolf", "new info"]
 
 
-def test_update_memory_raises_on_io_error(monkeypatch) -> None:
+def test_update_memory_raises_on_io_error(monkeypatch, make_test_actor) -> None:
     """
     SUT: update_memory()
     Mock: monkeypatch で store.save が OSError を送出するよう差し替え
@@ -59,6 +45,6 @@ def test_update_memory_raises_on_io_error(monkeypatch) -> None:
         raise OSError("disk full")
 
     monkeypatch.setattr(mem_mod.store, "save", failing_save)
-    actor = _make_actor()
+    actor = make_test_actor("Alice")
     with pytest.raises(OSError, match="Failed to persist memory for Alice"):
         update_memory(actor, ["some update"])

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -4,20 +4,10 @@ from pathlib import Path
 
 import pytest
 
-from src.domain.actor import Actor, ActorState, Persona
+from src.domain.actor import Actor, ActorProfile, ActorState, Persona
+from src.domain.roles import get_role
 from src.agent import store
-
-
-def _make_agent_json(name: str, role: str) -> dict:
-    data = ActorState(
-        name=name,
-        persona=Persona(style="calm"),
-        beliefs={},
-        memory_summary=[],
-        is_alive=True,
-    ).model_dump()
-    data["role"] = role
-    return data
+from tests.unit.conftest import make_legacy_agent_json, make_split_agent_json
 
 
 @pytest.fixture()
@@ -25,10 +15,10 @@ def agents_dir(tmp_path: Path) -> Path:
     d = tmp_path / "agents"
     d.mkdir()
     (d / "alice.json").write_text(
-        json.dumps(_make_agent_json("Alice", "Villager")), encoding="utf-8"
+        json.dumps(make_legacy_agent_json("Alice", "Villager")), encoding="utf-8"
     )
     (d / "bob.json").write_text(
-        json.dumps(_make_agent_json("Bob", "Werewolf")), encoding="utf-8"
+        json.dumps(make_split_agent_json("Bob", "Werewolf")), encoding="utf-8"
     )
     return d
 
@@ -75,3 +65,18 @@ def test_load_all_delegates_to_load_all_from_dir(agents_dir: Path, monkeypatch) 
 
     store.load_all()
     assert called_with == [agents_dir]
+
+
+def test_save_writes_split_json(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+    actor = Actor(
+        profile=ActorProfile(name="Alice", persona=Persona(style="calm")),
+        state=ActorState(beliefs={}, memory_summary=[], is_alive=True),
+        role=get_role("Villager"),
+    )
+    store.save(actor)
+
+    written = json.loads((tmp_path / "alice.json").read_text(encoding="utf-8"))
+    assert "profile" in written
+    assert "state" in written
+    assert written["role"] == "Villager"

--- a/tests/unit/ui/test_replay.py
+++ b/tests/unit/ui/test_replay.py
@@ -11,24 +11,9 @@ from unittest.mock import patch
 
 import pytest
 
-from src.domain.actor import ActorState, Persona
 from src.domain.event import EventType, LogEvent
 from src.ui.replay import ArchiveSelector, ReplayPager, run_replay
-
-
-# ── helpers ─────────────────────────────────────────────────────────────────
-
-
-def _make_agent_json(name: str, role: str) -> dict:
-    data = ActorState(
-        name=name,
-        persona=Persona(style="calm"),
-        beliefs={},
-        memory_summary=[],
-        is_alive=True,
-    ).model_dump()
-    data["role"] = role
-    return data
+from tests.unit.conftest import make_legacy_agent_json, make_split_agent_json
 
 
 def _make_event_jsonl(*events: LogEvent) -> str:
@@ -43,10 +28,10 @@ def tmp_archive(tmp_path: Path) -> Path:
     agents_dir.mkdir(parents=True)
 
     (agents_dir / "alice.json").write_text(
-        json.dumps(_make_agent_json("Alice", "Villager")), encoding="utf-8"
+        json.dumps(make_legacy_agent_json("Alice", "Villager")), encoding="utf-8"
     )
     (agents_dir / "bob.json").write_text(
-        json.dumps(_make_agent_json("Bob", "Werewolf")), encoding="utf-8"
+        json.dumps(make_split_agent_json("Bob", "Werewolf")), encoding="utf-8"
     )
 
     event = LogEvent.make(
@@ -163,7 +148,7 @@ def test_pager_skips_corrupt_agent_file(tmp_path: Path) -> None:
     agents_dir = archive / "agents"
     agents_dir.mkdir(parents=True)
 
-    good_data = _make_agent_json("Alice", "Villager")
+    good_data = make_split_agent_json("Alice", "Villager")
     (agents_dir / "alice.json").write_text(json.dumps(good_data), encoding="utf-8")
     (agents_dir / "bob.json").write_text("NOT_JSON", encoding="utf-8")
 
@@ -188,3 +173,29 @@ def test_pager_skips_corrupt_agent_file(tmp_path: Path) -> None:
     assert len(pager._agents) == 1
     assert pager._agents[0].name == "Alice"
     assert "bob.json" in captured.getvalue()
+
+
+def test_pager_loads_legacy_agent_json_without_profile(tmp_path: Path) -> None:
+    archive = tmp_path / "20260101_000000"
+    agents_dir = archive / "agents"
+    agents_dir.mkdir(parents=True)
+
+    (agents_dir / "alice.json").write_text(
+        json.dumps(make_legacy_agent_json("Alice", "Villager")),
+        encoding="utf-8",
+    )
+    event = LogEvent.make(
+        day=1,
+        phase="day_opening",
+        event_type=EventType.SPEECH,
+        agent="Alice",
+        content="Hello.",
+        is_public=True,
+    )
+    (archive / "public_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
+    (archive / "spectator_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
+
+    pager = ReplayPager(archive, spectator_mode=False)
+
+    assert len(pager._agents) == 1
+    assert pager._agents[0].name == "Alice"


### PR DESCRIPTION
## Summary
- split actor data into ActorProfile (static) and ActorState (dynamic)
- switch persistence to a split JSON format and add an adapter for legacy replay/archive loading
- update tests and design docs, and remove issue #74 from Ideas.md

## Test plan
- [x] uv run ruff check .
- [x] uv run pytest
- [x] replay still loads both split JSON and legacy archived actor JSON

Closes #74