### PR TITLE
docs: backlog refinement #5

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,16 +13,16 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#185 | tech-debt | 🔴 | - | Reduce clone code in repeated test mock setup | `test_game_day_loop.py` / `test_pre_night.py` / `test_client.py` などで重複している mock setup や side-effect scaffold を共通化して保守性を上げる |
-| yukkie/AgentVillage#184 | tech-debt | 🟢 | - | Add GameEngine tests for uncovered orchestration edge cases | `src/engine/game.py` の `run()` ループ、intended CO miss、memory update など未カバーの重要分岐を追加テストする |
-| yukkie/AgentVillage#183 | tech-debt | 🟡 | - | Add replay interaction tests for uncovered control paths | `src/ui/replay.py` のキー入力正規化、archive 選択、終端操作など replay の未カバー制御系をテストする |
-| yukkie/AgentVillage#182 | tech-debt | 🔴 | - | Add targeted tests for uncovered night phase branches | `src/engine/phase_night.py` の wolf chat、guard block、inspection 分岐など高リスクな未カバー経路をテストする |
-| yukkie/AgentVillage#181 | tech-debt | 🟡 | - | Split test strategy from test status and define sync workflow | `tests/TestStrategy.md` の戦略とステータスを分離し、更新タイミングをプロセスで定義して docs と実態のズレを防ぐ |
-| yukkie/AgentVillage#180 | tech-debt | 🟡 | - | Strengthen contract tests where heavy mocking hides interface regressions | mock が強すぎて境界契約を守れていないテストを見直し、契約テストを追加して見かけの coverage と実効的な保証のズレを減らす |
-| yukkie/AgentVillage#179 | tech-debt | 🟢 | - | Centralize legacy compatibility normalization for logs and actor state | ログ・actor state の旧形式互換処理を 1 箇所に集約し、互換責務の分散を減らす |
-| yukkie/AgentVillage#178 | tech-debt | 🟡 | - | Classify LLM fallback errors through a client helper | `client.py` の helper で LLM fallback のエラー種別を分類し、挙動を変えずに観測性を上げる |
-| yukkie/AgentVillage#177 | tech-debt | 🔴 | - | Structure inspection event results for renderer-safe logging | inspection 系のログ結果を構造化し、renderer/replay で安全に扱いつつ旧ログとの互換も保つ |
-| yukkie/AgentVillage#176 | bug | - | - | Fix replay log role rendering regression | INSPECT などのログで role object の repr が出るデグレを修正し、過去ログ互換を保ったまま人間向けの役職名を表示する |
+| yukkie/AgentVillage#185 | tech-debt | 🔴 | 3 | Reduce clone code in repeated test mock setup | `test_game_day_loop.py` / `test_pre_night.py` / `test_client.py` などで重複している mock setup や side-effect scaffold を共通化して保守性を上げる |
+| yukkie/AgentVillage#184 | tech-debt | 🟡 | 3 | Add GameEngine tests for uncovered orchestration edge cases | `src/engine/game.py` の `run()` ループ、intended CO miss、memory update など未カバーの重要分岐を追加テストする |
+| yukkie/AgentVillage#183 | tech-debt | 🔴 | 2 | Add replay interaction tests for uncovered control paths | `src/ui/replay.py` のキー入力正規化、archive 選択、終端操作など replay の未カバー制御系をテストする |
+| yukkie/AgentVillage#182 | tech-debt | 🔴 | 3 | Add targeted tests for uncovered night phase branches | `src/engine/phase_night.py` の wolf chat、guard block、inspection 分岐など高リスクな未カバー経路をテストする |
+| yukkie/AgentVillage#181 | tech-debt | 🔴 | 2 | Split test strategy from test status and define sync workflow | `tests/TestStrategy.md` の戦略とステータスを分離し、更新タイミングをプロセスで定義して docs と実態のズレを防ぐ |
+| yukkie/AgentVillage#180 | tech-debt | 🔴 | 5 | Strengthen contract tests where heavy mocking hides interface regressions | mock が強すぎて境界契約を守れていないテストを見直し、契約テストを追加して見かけの coverage と実効的な保証のズレを減らす |
+| yukkie/AgentVillage#179 | tech-debt | 🔴 | 3 | Structure inspection event results for renderer-safe logging | inspection 系のログ結果を構造化し、renderer/replay で安全に扱いつつ旧ログとの互換も保つ |
+| yukkie/AgentVillage#178 | tech-debt | 🔴 | 2 | Classify LLM fallback errors through a client helper | `client.py` の helper で LLM fallback のエラー種別を分類し、挙動を変えずに観測性を上げる（⚠️unit test mandatory） |
+| yukkie/AgentVillage#177 | tech-debt | 🟢 | 5 | Centralize legacy compatibility normalization for logs and actor state | ログ・actor state の旧形式互換処理を 1 箇所に集約し、互換責務の分散を減らす |
+| yukkie/AgentVillage#176 | bug | 🟢 | 2 | Fix replay log role rendering regression | INSPECT などのログで role object の repr が出るデグレを修正し、過去ログ互換を保ったまま人間向けの役職名を表示する |
 | yukkie/AgentVillage#33 | enhancement | 🟢 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#36 | enhancement | 🟢 | 5 | Belief updates from agent reasoning | suspicion/trust を推理結果から更新 |
 | yukkie/AgentVillage#47 | enhancement | 🟢 | 3 | Reasoning field for Vote/Guard/Divination/Judgment | 各アクションに reasoning を追加し spectator ログ・memory_update に記録 |


### PR DESCRIPTION
## Summary

Backlog refinement session #5 — Sprint Goal「技術的負債の完済」に沿って tech-debt 系 Issue の SP / 優先度を整理。

### SP 見積もり (10件)

| SP | Issues |
|---|---|
| sp:2 | #176, #178, #181, #183 |
| sp:3 | #179, #182, #184, #185 |
| sp:5 | #177, #180 |

### 優先度更新 (6件)

- #176 (bug): → 🟢 low（実害は読みづらさ程度）
- #178 (tech-debt): 🟡 medium → 🔴 high（低工数 tech-debt は即着手 + 本文に `⚠️unit test mandatory` 追記）
- #180 (tech-debt): 🟡 medium → 🔴 high（契約テスト方針確立、Sprint Goal に直結）
- #181 (tech-debt): 🟡 medium → 🔴 high（低工数 tech-debt、即着手対象）
- #183 (tech-debt): 🟡 medium → 🔴 high（低工数 tech-debt、replay 周辺）
- #184 (tech-debt): 🟢 low → 🟡 medium（coverage 系を low に留める理由は薄い）

### Ideas.md 修正

- #177 / #179 のタイトルが GitHub 実態と入れ替わっていたため修正

## Test plan

- [x] ドキュメント変更のみ（コード影響なし）
- [x] pre-commit (ruff, pytest) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)