### PR TITLE
refactor: reduce clone code in test mock setup

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#185 | tech-debt | 🔴 | 3 | Reduce clone code in repeated test mock setup | `test_game_day_loop.py` / `test_pre_night.py` / `test_client.py` などで重複している mock setup や side-effect scaffold を共通化して保守性を上げる |
 | yukkie/AgentVillage#184 | tech-debt | 🟡 | 3 | Add GameEngine tests for uncovered orchestration edge cases | `src/engine/game.py` の `run()` ループ、intended CO miss、memory update など未カバーの重要分岐を追加テストする |
 | yukkie/AgentVillage#183 | tech-debt | 🔴 | 2 | Add replay interaction tests for uncovered control paths | `src/ui/replay.py` のキー入力正規化、archive 選択、終端操作など replay の未カバー制御系をテストする |
 | yukkie/AgentVillage#182 | tech-debt | 🔴 | 3 | Add targeted tests for uncovered night phase branches | `src/engine/phase_night.py` の wolf chat、guard block、inspection 分岐など高リスクな未カバー経路をテストする |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
+import json
 from unittest.mock import MagicMock
 
+import anthropic
 import pytest
 
 from src.domain.actor import Actor, ActorProfile, ActorState, Persona, make_actor
 from src.domain.event import LogEvent
+from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput
 from src.engine.game import GameEngine
 from src.llm.client import LLMClient
 from src.logger.writer import LogWriter
@@ -65,3 +68,104 @@ def make_test_engine():
         return engine, events
 
     return _make_test_engine
+
+
+# ── Shared Mock Builders for LLM Client ──────────────────────────────────
+
+
+def make_llm_client_with_response(response_text: str) -> LLMClient:
+    """Build LLMClient mock that returns a specific response."""
+    msg = MagicMock()
+    msg.content = [MagicMock(text=response_text)]
+    anthropic_client = MagicMock(spec=anthropic.Anthropic)
+    anthropic_client.messages.create.return_value = msg
+    return LLMClient(anthropic_client)
+
+
+def make_failing_llm_client() -> LLMClient:
+    """Build LLMClient mock that raises RuntimeError on API call."""
+    anthropic_client = MagicMock(spec=anthropic.Anthropic)
+    anthropic_client.messages.create.side_effect = RuntimeError("API error")
+    return LLMClient(anthropic_client)
+
+
+# ── Shared Mock Builders for GameEngine ──────────────────────────────────
+
+
+def make_agent_output(name: str, speech: str = "Hello.") -> AgentOutput:
+    """Build AgentOutput with standard defaults for test side_effect."""
+    return AgentOutput(
+        thought="thinking",
+        speech=speech,
+        reasoning="reasoning",
+        intent=Intent(vote_candidates=[]),
+        memory_update=[],
+    )
+
+
+def make_speech_parallel_side_effect():
+    """Side effect for call_speech_parallel: each actor returns standard AgentOutput."""
+    def _side_effect(calls):
+        return iter([(a, make_agent_output(a.name)) for a, *_ in calls])
+    return _side_effect
+
+
+def make_silent_discussion_side_effect():
+    """Side effect for call_discussion_parallel: all actors respond with silent judgment."""
+    def _side_effect(actors, *_, **__):
+        return iter([(a, JudgmentOutput(decision="silent"), None, None) for a in actors])
+    return _side_effect
+
+
+def make_pre_night_parallel_side_effect(decision: str, claim_role: str | None = None):
+    """Side effect for call_pre_night_parallel: each actor returns PreNightOutput."""
+    def _side_effect(targets, *_, **__):
+        return iter([
+            (actor, PreNightOutput(
+                thought="thinking",
+                decision=decision,
+                claim_role=claim_role,
+                reasoning="reason",
+            )) for actor in targets
+        ])
+    return _side_effect
+
+
+# ── Shared JSON Constants for Client Tests ──────────────────────────────
+
+
+AGENT_OUTPUT_JSON = json.dumps({
+    "thought": "thinking",
+    "speech": "Hello village.",
+    "reasoning": "just a test",
+    "intent": {"vote_candidates": []},
+    "memory_update": [],
+})
+
+JUDGMENT_OUTPUT_JSON = json.dumps({"decision": "speak"})
+
+JUDGMENT_CO_OUTPUT_JSON = json.dumps({
+    "decision": "co",
+    "reply_to": None,
+    "claim_role": "Knight",
+})
+
+PRE_NIGHT_OUTPUT_JSON = json.dumps({
+    "thought": "thinking",
+    "decision": "wait",
+    "claim_role": None,
+    "reasoning": "not ready",
+})
+
+PRE_NIGHT_CO_OUTPUT_JSON = json.dumps({
+    "thought": "thinking",
+    "decision": "co",
+    "claim_role": "Medium",
+    "reasoning": "fake medium",
+})
+
+WOLF_CHAT_OUTPUT_JSON = json.dumps({
+    "thought": "thinking",
+    "speech": "Let's attack Alice.",
+    "vote_candidates": [{"target": "Alice", "score": 0.9}],
+})

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,65 +1,23 @@
 """Unit tests for src/llm/client.py — LLMClient with injected mock anthropic client."""
-import json
-from unittest.mock import MagicMock
-
-import anthropic
-
 from src.domain.schema import AgentOutput, JudgmentOutput, PreNightOutput, WolfChatOutput
 from src.domain.roles import get_role
-from src.llm.client import LLMClient, resolve_claim_role
-
-
-def _make_llm_client(response_text: str) -> LLMClient:
-    msg = MagicMock()
-    msg.content = [MagicMock(text=response_text)]
-    anthropic_client = MagicMock(spec=anthropic.Anthropic)
-    anthropic_client.messages.create.return_value = msg
-    return LLMClient(anthropic_client)
-
-
-def _make_failing_llm_client() -> LLMClient:
-    anthropic_client = MagicMock(spec=anthropic.Anthropic)
-    anthropic_client.messages.create.side_effect = RuntimeError("API error")
-    return LLMClient(anthropic_client)
-
-
-_AGENT_OUTPUT_JSON = json.dumps({
-    "thought": "thinking",
-    "speech": "Hello village.",
-    "reasoning": "just a test",
-    "intent": {"vote_candidates": []},
-    "memory_update": [],
-})
-
-_JUDGMENT_OUTPUT_JSON = json.dumps({"decision": "speak"})
-
-_JUDGMENT_CO_OUTPUT_JSON = json.dumps({"decision": "co", "reply_to": None, "claim_role": "Knight"})
-
-_PRE_NIGHT_OUTPUT_JSON = json.dumps({
-    "thought": "thinking",
-    "decision": "wait",
-    "claim_role": None,
-    "reasoning": "not ready",
-})
-
-_PRE_NIGHT_CO_OUTPUT_JSON = json.dumps({
-    "thought": "thinking",
-    "decision": "co",
-    "claim_role": "Medium",
-    "reasoning": "fake medium",
-})
-
-_WOLF_CHAT_OUTPUT_JSON = json.dumps({
-    "thought": "thinking",
-    "speech": "Let's attack Alice.",
-    "vote_candidates": [{"target": "Alice", "score": 0.9}],
-})
+from src.llm.client import resolve_claim_role
+from tests.conftest import (
+    AGENT_OUTPUT_JSON,
+    JUDGMENT_CO_OUTPUT_JSON,
+    JUDGMENT_OUTPUT_JSON,
+    PRE_NIGHT_CO_OUTPUT_JSON,
+    PRE_NIGHT_OUTPUT_JSON,
+    WOLF_CHAT_OUTPUT_JSON,
+    make_failing_llm_client,
+    make_llm_client_with_response,
+)
 
 
 class TestCall:
     def test_returns_agent_output(self, make_test_actor):
         actor = make_test_actor("Alice")
-        llm = _make_llm_client(_AGENT_OUTPUT_JSON)
+        llm = make_llm_client_with_response(AGENT_OUTPUT_JSON)
         from src.llm.prompt import PublicContext, SpeechDirection
         ctx = PublicContext(alive_players=["Alice"], dead_players=[], day=1, today_log=[])
         direction = SpeechDirection()
@@ -69,7 +27,7 @@ class TestCall:
 
     def test_returns_fallback_on_exception(self, make_test_actor):
         actor = make_test_actor("Alice")
-        llm = _make_failing_llm_client()
+        llm = make_failing_llm_client()
         from src.llm.prompt import PublicContext, SpeechDirection
         ctx = PublicContext(alive_players=["Alice"], dead_players=[], day=1, today_log=[])
         direction = SpeechDirection()
@@ -81,20 +39,20 @@ class TestCall:
 class TestCallJudgment:
     def test_returns_judgment_output(self, make_test_actor):
         actor = make_test_actor("Alice")
-        llm = _make_llm_client(_JUDGMENT_OUTPUT_JSON)
+        llm = make_llm_client_with_response(JUDGMENT_OUTPUT_JSON)
         result = llm.call_judgment(actor, [], ["Alice", "Bob"], day=1)
         assert isinstance(result, JudgmentOutput)
         assert result.decision == "speak"
 
     def test_returns_silent_on_exception(self, make_test_actor):
         actor = make_test_actor("Alice")
-        llm = _make_failing_llm_client()
+        llm = make_failing_llm_client()
         result = llm.call_judgment(actor, [], ["Alice", "Bob"], day=1)
         assert result.decision == "silent"
 
     def test_parses_claim_role_when_present(self, make_test_actor):
         actor = make_test_actor("Alice", "Werewolf")
-        llm = _make_llm_client(_JUDGMENT_CO_OUTPUT_JSON)
+        llm = make_llm_client_with_response(JUDGMENT_CO_OUTPUT_JSON)
         result = llm.call_judgment(actor, [], ["Alice", "Bob"], day=1)
         assert result.decision == "co"
         assert result.claim_role.name == "Knight"
@@ -103,20 +61,20 @@ class TestCallJudgment:
 class TestCallPreNightAction:
     def test_returns_pre_night_output(self, make_test_actor):
         actor = make_test_actor("Gina", "Seer")
-        llm = _make_llm_client(_PRE_NIGHT_OUTPUT_JSON)
+        llm = make_llm_client_with_response(PRE_NIGHT_OUTPUT_JSON)
         result = llm.call_pre_night_action(actor, ["Gina", "Bob"])
         assert isinstance(result, PreNightOutput)
         assert result.decision == "wait"
 
     def test_returns_wait_fallback_on_exception(self, make_test_actor):
         actor = make_test_actor("Gina", "Seer")
-        llm = _make_failing_llm_client()
+        llm = make_failing_llm_client()
         result = llm.call_pre_night_action(actor, ["Gina", "Bob"])
         assert result.decision == "wait"
 
     def test_parses_claim_role_when_present(self, make_test_actor):
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = _make_llm_client(_PRE_NIGHT_CO_OUTPUT_JSON)
+        llm = make_llm_client_with_response(PRE_NIGHT_CO_OUTPUT_JSON)
         result = llm.call_pre_night_action(actor, ["Wolf", "Bob"])
         assert result.decision == "co"
         assert result.claim_role.name == "Medium"
@@ -125,14 +83,14 @@ class TestCallPreNightAction:
 class TestCallWolfChat:
     def test_returns_wolf_chat_output(self, make_test_actor):
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = _make_llm_client(_WOLF_CHAT_OUTPUT_JSON)
+        llm = make_llm_client_with_response(WOLF_CHAT_OUTPUT_JSON)
         result = llm.call_wolf_chat(actor, ["OtherWolf"], ["Alice", "Wolf", "OtherWolf"], [])
         assert isinstance(result, WolfChatOutput)
         assert result.speech == "Let's attack Alice."
 
     def test_returns_empty_fallback_on_exception(self, make_test_actor):
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = _make_failing_llm_client()
+        llm = make_failing_llm_client()
         result = llm.call_wolf_chat(actor, ["OtherWolf"], ["Alice", "Wolf", "OtherWolf"], [])
         assert result.speech == "..."
 
@@ -140,31 +98,31 @@ class TestCallWolfChat:
 class TestCallNightAction:
     def test_exact_match(self, make_test_actor):
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = _make_llm_client("Alice")
+        llm = make_llm_client_with_response("Alice")
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == "Alice"
 
     def test_partial_match(self, make_test_actor):
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = _make_llm_client("I think Alice is the target")
+        llm = make_llm_client_with_response("I think Alice is the target")
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == "Alice"
 
     def test_fallback_to_first_candidate_on_no_match(self, make_test_actor):
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = _make_llm_client("Nobody")
+        llm = make_llm_client_with_response("Nobody")
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == "Alice"
 
     def test_fallback_to_first_candidate_on_exception(self, make_test_actor):
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = _make_failing_llm_client()
+        llm = make_failing_llm_client()
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == "Alice"
 
     def test_returns_empty_string_when_no_prompt(self, make_test_actor):
         actor = make_test_actor("Alice", "Villager")
-        llm = _make_failing_llm_client()
+        llm = make_failing_llm_client()
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
         assert result == ""
         llm._client.messages.create.assert_not_called()

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -14,16 +14,11 @@ from src.domain.event import EventType
 from src.domain.roles import Seer
 from src.llm.client import LLMClient
 from src.logger.writer import LogWriter
-
-
-def _make_output(name: str, speech: str = "Hello.") -> AgentOutput:
-    return AgentOutput(
-        thought="thinking",
-        speech=speech,
-        reasoning="reasoning",
-        intent=Intent(vote_candidates=[]),
-        memory_update=[],
-    )
+from tests.conftest import (
+    make_agent_output,
+    make_silent_discussion_side_effect,
+    make_speech_parallel_side_effect,
+)
 
 
 class TestGameEngineLlmInjection:
@@ -47,17 +42,12 @@ class TestGameEngineLlmInjection:
         assert callable(run_night_phase)
 
 
-def _silent_discussion(actors, *_, **__):
-    """call_discussion_parallel stub: all actors silent."""
-    return iter([(a, JudgmentOutput(decision="silent"), None, None) for a in actors])
-
-
 class TestRunDayPhaseOrder:
     def test_opening_then_discussion_then_vote(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("A"), make_test_actor("B"), make_test_actor("C", "Werewolf")]
         engine, events = make_test_engine(agents)
-        engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
-        engine._llm_client.call_discussion_parallel.side_effect = _silent_discussion
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
+        engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
 
         with patch("src.agent.store.save"):
             engine._run_day()
@@ -73,8 +63,8 @@ class TestRunDayPhaseOrder:
     def test_speech_ids_are_sequential(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("A"), make_test_actor("B")]
         engine, events = make_test_engine(agents)
-        engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
-        engine._llm_client.call_discussion_parallel.side_effect = _silent_discussion
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
+        engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
 
         with patch("src.agent.store.save"):
             engine._run_day()
@@ -90,7 +80,7 @@ class TestRunDayPhaseOrder:
     def test_challenge_reply_to_recorded(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("A"), make_test_actor("B")]
         engine, events = make_test_engine(agents)
-        engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
 
         # B challenges speech_id=1 (A's opening speech)
         challenge = JudgmentOutput(decision="challenge", reply_to=1)
@@ -100,7 +90,7 @@ class TestRunDayPhaseOrder:
             reply_to_entry = next((e for e in today_log if e.speech_id == 1), None)
             return iter([
                 (make_test_actor("A"), JudgmentOutput(decision="silent"), None, None),
-                (make_test_actor("B"), challenge, _make_output("B"), reply_to_entry),
+                (make_test_actor("B"), challenge, make_agent_output("B"), reply_to_entry),
             ])
 
         engine._llm_client.call_discussion_parallel.side_effect = discussion_with_challenge
@@ -118,8 +108,8 @@ class TestRunDayPhaseOrder:
     def test_all_silent_does_not_raise(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("A"), make_test_actor("B", "Werewolf")]
         engine, _ = make_test_engine(agents)
-        engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
-        engine._llm_client.call_discussion_parallel.side_effect = _silent_discussion
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
+        engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
 
         with patch("src.agent.store.save"):
             result = engine._run_day()
@@ -143,7 +133,7 @@ class TestDiscussionCoDecision:
             intent=Intent(vote_candidates=[], co="Seer"),
             memory_update=[],
         )
-        engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
             (seer, JudgmentOutput(decision="co"), co_output, None),
         ])
@@ -159,8 +149,8 @@ class TestDiscussionCoDecision:
         seer.state.claimed_role = "Seer"  # already claimed
         engine, _ = make_test_engine([seer])
 
-        normal_output = _make_output("Seer1", "Just speaking.")
-        engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
+        normal_output = make_agent_output("Seer1", "Just speaking.")
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
             (seer, JudgmentOutput(decision="co"), normal_output, None),
         ])
@@ -176,8 +166,8 @@ class TestDiscussionCoDecision:
         villager = make_test_actor("V1", "Villager")
         engine, _ = make_test_engine([villager])
 
-        normal_output = _make_output("V1", "Just talking.")
-        engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
+        normal_output = make_agent_output("V1", "Just talking.")
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
             (villager, JudgmentOutput(decision="co"), normal_output, None),
         ])
@@ -191,9 +181,9 @@ class TestDiscussionCoDecision:
     def test_failed_discussion_co_clears_intended_co(self, make_test_actor, make_test_engine):
         seer = make_test_actor("Seer1", "Seer")
         engine, _ = make_test_engine([seer])
-        normal_output = _make_output("Seer1", "I have something to say.")
+        normal_output = make_agent_output("Seer1", "I have something to say.")
 
-        engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
             (seer, JudgmentOutput(decision="co"), normal_output, None),
         ])
@@ -213,7 +203,7 @@ class TestDiscussionCoDecision:
             intent=Intent(vote_candidates=[], co="Medium"),
             memory_update=[],
         )
-        engine._llm_client.call_speech_parallel.side_effect = lambda calls: iter([(a, _make_output(a.name)) for a, *_ in calls])
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
             (wolf, JudgmentOutput(decision="co", claim_role="Medium"), co_output, None),
         ])

--- a/tests/unit/test_pre_night.py
+++ b/tests/unit/test_pre_night.py
@@ -9,8 +9,8 @@ from unittest.mock import patch
 from src.engine.phase import Phase
 from src.domain.roles import get_role
 from src.llm.prompt import PublicContext, SpeechDirection, WolfSpecificContext, build_pre_night_prompt, build_system_prompt
-from src.domain.schema import PreNightOutput
 from src.domain.event import EventType
+from tests.conftest import make_pre_night_parallel_side_effect
 
 
 # ── build_pre_night_prompt ──────────────────────────────────────────────────
@@ -80,14 +80,6 @@ class TestBuildSystemPromptIntendedCo:
 
 
 class TestRunPreNight:
-    def _make_output(self, decision: str, claim_role: str | None = None) -> PreNightOutput:
-        return PreNightOutput(
-            thought="thinking",
-            decision=decision,
-            claim_role=claim_role,
-            reasoning="reason",
-        )
-
     def test_only_non_villager_agents_participate(self, make_test_actor, make_test_engine):
         agents = [
             make_test_actor("A", "Villager"),
@@ -96,9 +88,7 @@ class TestRunPreNight:
             make_test_actor("D", "Werewolf"),
         ]
         engine, events = make_test_engine(agents)
-        engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
-            [(actor, self._make_output("wait")) for actor in targets]
-        )
+        engine._llm_client.call_pre_night_parallel.side_effect = make_pre_night_parallel_side_effect("wait")
 
         with patch("src.agent.store.save"):
             engine._run_pre_night()
@@ -112,9 +102,7 @@ class TestRunPreNight:
     def test_co_decision_sets_intended_co_true(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("Gina", "Seer"), make_test_actor("SQ", "Villager")]
         engine, _ = make_test_engine(agents)
-        engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
-            [(actor, self._make_output("co")) for actor in targets]
-        )
+        engine._llm_client.call_pre_night_parallel.side_effect = make_pre_night_parallel_side_effect("co")
 
         with patch("src.agent.store.save"):
             engine._run_pre_night()
@@ -125,9 +113,7 @@ class TestRunPreNight:
     def test_fake_co_claim_role_is_used_when_explicitly_selected(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("Wolf", "Werewolf"), make_test_actor("SQ", "Villager")]
         engine, _ = make_test_engine(agents)
-        engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
-            [(actor, self._make_output("co", "Medium")) for actor in targets]
-        )
+        engine._llm_client.call_pre_night_parallel.side_effect = make_pre_night_parallel_side_effect("co", "Medium")
 
         with patch("src.agent.store.save"):
             engine._run_pre_night()
@@ -138,9 +124,7 @@ class TestRunPreNight:
     def test_fake_co_uses_default_when_claim_role_is_omitted(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("Wolf", "Werewolf"), make_test_actor("SQ", "Villager")]
         engine, _ = make_test_engine(agents)
-        engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
-            [(actor, self._make_output("co")) for actor in targets]
-        )
+        engine._llm_client.call_pre_night_parallel.side_effect = make_pre_night_parallel_side_effect("co")
 
         with patch("src.agent.store.save"):
             engine._run_pre_night()
@@ -151,9 +135,7 @@ class TestRunPreNight:
     def test_wait_decision_sets_intended_co_false(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("Gina", "Seer"), make_test_actor("SQ", "Villager")]
         engine, _ = make_test_engine(agents)
-        engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
-            [(actor, self._make_output("wait")) for actor in targets]
-        )
+        engine._llm_client.call_pre_night_parallel.side_effect = make_pre_night_parallel_side_effect("wait")
 
         with patch("src.agent.store.save"):
             engine._run_pre_night()
@@ -164,9 +146,7 @@ class TestRunPreNight:
     def test_decision_events_are_spectator_only(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("Gina", "Seer"), make_test_actor("SQ", "Villager")]
         engine, events = make_test_engine(agents)
-        engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
-            [(actor, self._make_output("co")) for actor in targets]
-        )
+        engine._llm_client.call_pre_night_parallel.side_effect = make_pre_night_parallel_side_effect("co")
 
         with patch("src.agent.store.save"):
             engine._run_pre_night()
@@ -177,9 +157,7 @@ class TestRunPreNight:
     def test_phase_start_event_is_spectator_only(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("Gina", "Seer"), make_test_actor("SQ", "Villager")]
         engine, events = make_test_engine(agents)
-        engine._llm_client.call_pre_night_parallel.side_effect = lambda targets, *a, **kw: iter(
-            [(actor, self._make_output("wait")) for actor in targets]
-        )
+        engine._llm_client.call_pre_night_parallel.side_effect = make_pre_night_parallel_side_effect("wait")
 
         with patch("src.agent.store.save"):
             engine._run_pre_night()


### PR DESCRIPTION
## Summary
- Extracted shared mock builders (`make_speech_parallel_side_effect()`, `make_silent_discussion_side_effect()`, `make_pre_night_parallel_side_effect()`) to conftest.py
- Moved repeated helper functions and JSON constants to conftest for reuse across test files
- Updated test_game_day_loop.py, test_pre_night.py, test_client.py to use shared builders
- Test intent and assertions remain unchanged; all 45 tests pass

## Test plan
- [x] `ruff check .` passes
- [x] `pytest tests/unit/test_game_day_loop.py tests/unit/test_pre_night.py tests/unit/test_client.py` passes (45 tests)
- [x] Readability verified: test assertions unchanged, mock setup simplified

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)