### PR TITLE
test: add replay interaction tests (#183)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#184 | tech-debt | 🟡 | 3 | Add GameEngine tests for uncovered orchestration edge cases | `src/engine/game.py` の `run()` ループ、intended CO miss、memory update など未カバーの重要分岐を追加テストする |
-| yukkie/AgentVillage#183 | tech-debt | 🔴 | 2 | Add replay interaction tests for uncovered control paths | `src/ui/replay.py` のキー入力正規化、archive 選択、終端操作など replay の未カバー制御系をテストする |
 | yukkie/AgentVillage#182 | tech-debt | 🔴 | 3 | Add targeted tests for uncovered night phase branches | `src/engine/phase_night.py` の wolf chat、guard block、inspection 分岐など高リスクな未カバー経路をテストする |
 | yukkie/AgentVillage#179 | tech-debt | 🔴 | 3 | Structure inspection event results for renderer-safe logging | inspection 系のログ結果を構造化し、renderer/replay で安全に扱いつつ旧ログとの互換も保つ |
 | yukkie/AgentVillage#178 | tech-debt | 🔴 | 2 | Classify LLM fallback errors through a client helper | `client.py` の helper で LLM fallback のエラー種別を分類し、挙動を変えずに観測性を上げる（⚠️unit test mandatory） |

--- a/tests/unit/ui/test_replay.py
+++ b/tests/unit/ui/test_replay.py
@@ -7,7 +7,7 @@
 """
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -199,3 +199,203 @@ def test_pager_loads_legacy_agent_json_without_profile(tmp_path: Path) -> None:
 
     assert len(pager._agents) == 1
     assert pager._agents[0].name == "Alice"
+
+
+# ── _getch() key normalization (#183) ────────────────────────────────────────
+
+
+def test_getch_normalizes_arrow_keys() -> None:
+    """
+    SUT: _getch()
+    Mock: readchar.readkey — arrow key raw bytes を返すように差し替え
+    Level: unit
+    Objective: UP/DOWN/LEFT/RIGHT の raw bytes が対応する文字列にマップされること。
+    """
+    import readchar as rc
+
+    from src.ui.replay import _getch
+
+    arrow_cases = [
+        (rc.key.UP, "UP"),
+        (rc.key.DOWN, "DOWN"),
+        (rc.key.LEFT, "LEFT"),
+        (rc.key.RIGHT, "RIGHT"),
+    ]
+    for raw_key, expected in arrow_cases:
+        with patch("readchar.readkey", return_value=raw_key):
+            assert _getch() == expected, f"expected {expected!r} for raw {raw_key!r}"
+
+
+def test_getch_passes_through_unmapped_key() -> None:
+    """
+    SUT: _getch()
+    Mock: readchar.readkey — マッピング外のキー 'q' を返すように差し替え
+    Level: unit
+    Objective: マッピングに存在しないキーはそのまま返ること。
+    """
+    from src.ui.replay import _getch
+
+    with patch("readchar.readkey", return_value="q"):
+        assert _getch() == "q"
+
+
+# ── ArchiveSelector navigation (#183) ────────────────────────────────────────
+
+
+@pytest.fixture()
+def tmp_archive_dir(tmp_path: Path) -> Path:
+    """Archive directory with 3 sub-archives for selector navigation tests."""
+    arch_dir = tmp_path / "state_archive"
+    for name in ["20260101_000000", "20260102_000000", "20260103_000000"]:
+        (arch_dir / name).mkdir(parents=True)
+    return arch_dir
+
+
+def test_selector_navigates_and_selects(tmp_archive_dir: Path) -> None:
+    """
+    SUT: ArchiveSelector.select()
+    Mock: _getch (side_effect キューで操作シーケンスを再現), _clear (stdout汚染回避)
+    Level: unit
+    Objective: DOWN→DOWN→UP→Enter のキー操作でカーソルが1番目のアーカイブを選択して返ること。
+    """
+    keys = iter(["DOWN", "DOWN", "UP", "\r"])
+    selector = ArchiveSelector(tmp_archive_dir)
+    with patch("src.ui.replay._getch", side_effect=keys), patch("src.ui.replay._clear"):
+        result = selector.select()
+
+    archives = sorted(
+        [p for p in tmp_archive_dir.iterdir() if p.is_dir()], reverse=True
+    )
+    assert result == archives[1]
+
+
+def test_selector_returns_none_on_quit_with_archives(tmp_archive_dir: Path) -> None:
+    """
+    SUT: ArchiveSelector.select()
+    Mock: _getch (即座に 'q' を返す), _clear (stdout汚染回避)
+    Level: unit
+    Objective: アーカイブが存在する状態で 'q' を押すと None が返ること。
+    """
+    selector = ArchiveSelector(tmp_archive_dir)
+    with patch("src.ui.replay._getch", return_value="q"), patch("src.ui.replay._clear"):
+        result = selector.select()
+
+    assert result is None
+
+
+# ── ReplayPager end-of-replay controls (#183) ────────────────────────────────
+
+
+def test_pager_end_of_replay_q_quits(tmp_archive: Path) -> None:
+    """
+    SUT: ReplayPager.run()
+    Mock: _getch (即 'q'), _clear, shutil.get_terminal_size (十分な高さを返す)
+    Level: unit
+    Objective: 末尾表示中に 'q' を押すとページャーが終了すること。
+    """
+    pager = ReplayPager(tmp_archive, spectator_mode=False)
+    large_size = MagicMock()
+    large_size.lines = len(pager._lines) + 10
+    large_size.columns = 80
+
+    with (
+        patch("src.ui.replay._getch", return_value="q"),
+        patch("src.ui.replay._clear"),
+        patch("shutil.get_terminal_size", return_value=large_size),
+    ):
+        pager.run()
+
+
+def test_pager_end_of_replay_k_scrolls_up(tmp_archive: Path) -> None:
+    """
+    SUT: ReplayPager.run()
+    Mock: _getch (side_effect: 'k' then 'q'), _clear, shutil.get_terminal_size
+    Level: unit
+    Objective: 末尾表示中に 'k' を押すと1行戻り、その後 'q' で終了できること。
+    """
+    pager = ReplayPager(tmp_archive, spectator_mode=False)
+    large_size = MagicMock()
+    large_size.lines = len(pager._lines) + 10
+    large_size.columns = 80
+
+    keys = iter(["k", "q"])
+    with (
+        patch("src.ui.replay._getch", side_effect=keys),
+        patch("src.ui.replay._clear"),
+        patch("shutil.get_terminal_size", return_value=large_size),
+    ):
+        pager.run()
+
+
+def test_pager_end_of_replay_b_scrolls_page_up(tmp_archive: Path) -> None:
+    """
+    SUT: ReplayPager.run()
+    Mock: _getch (side_effect: 'b' then 'q'), _clear, shutil.get_terminal_size
+    Level: unit
+    Objective: 末尾表示中に 'b' を押すとpage_size分戻り、その後 'q' で終了できること。
+    """
+    pager = ReplayPager(tmp_archive, spectator_mode=False)
+    large_size = MagicMock()
+    large_size.lines = len(pager._lines) + 10
+    large_size.columns = 80
+
+    keys = iter(["b", "q"])
+    with (
+        patch("src.ui.replay._getch", side_effect=keys),
+        patch("src.ui.replay._clear"),
+        patch("shutil.get_terminal_size", return_value=large_size),
+    ):
+        pager.run()
+
+
+def test_pager_end_of_replay_g_goes_to_top(tmp_archive: Path) -> None:
+    """
+    SUT: ReplayPager.run()
+    Mock: _getch (side_effect: 'g' then 'q'), _clear, shutil.get_terminal_size
+    Level: unit
+    Objective: 末尾表示中に 'g' を押すとトップに戻り、その後 'q' で終了できること。
+    """
+    pager = ReplayPager(tmp_archive, spectator_mode=False)
+    large_size = MagicMock()
+    large_size.lines = len(pager._lines) + 10
+    large_size.columns = 80
+
+    keys = iter(["g", "q"])
+    with (
+        patch("src.ui.replay._getch", side_effect=keys),
+        patch("src.ui.replay._clear"),
+        patch("shutil.get_terminal_size", return_value=large_size),
+    ):
+        pager.run()
+
+
+# ── run_replay() entry paths (#183) ──────────────────────────────────────────
+
+
+def test_run_replay_calls_archive_selector_when_no_archive(tmp_path: Path) -> None:
+    """
+    SUT: run_replay()
+    Mock: ArchiveSelector.select (None を返す)
+    Level: unit
+    Objective: archive_path=None のとき ArchiveSelector.select() が呼ばれること。
+    """
+    with patch("src.ui.replay.ArchiveSelector") as mock_selector_cls:
+        mock_selector_cls.return_value.select.return_value = None
+        run_replay(spectator_mode=False, archive_path=None)
+        mock_selector_cls.return_value.select.assert_called_once()
+
+
+def test_run_replay_does_not_create_pager_when_selector_returns_none(tmp_path: Path) -> None:
+    """
+    SUT: run_replay()
+    Mock: ArchiveSelector.select (None を返す), ReplayPager (呼ばれないことを確認)
+    Level: unit
+    Objective: ArchiveSelector が None を返したとき ReplayPager が生成されないこと。
+    """
+    with (
+        patch("src.ui.replay.ArchiveSelector") as mock_selector_cls,
+        patch("src.ui.replay.ReplayPager") as mock_pager_cls,
+    ):
+        mock_selector_cls.return_value.select.return_value = None
+        run_replay(spectator_mode=False, archive_path=None)
+        mock_pager_cls.assert_not_called()


### PR DESCRIPTION
## Summary
- `_getch()` のキー正規化（UP/DOWN/LEFT/RIGHT → 文字列マッピング、未マップキーのパススルー）をカバー
- `ArchiveSelector` のナビゲーション操作（DOWN/UP/Enter で選択、q で中断）をカバー
- `ReplayPager.run()` の末尾到達後のコントロール（q/k/b/g）をカバー
- `run_replay()` の archive 未指定パスで `ArchiveSelector` が呼ばれること、None 返時に `ReplayPager` が生成されないことをカバー

## Test plan
- [x] \`ruff check .\` パス
- [x] \`pytest\` 全184件パス（新規10件追加）

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)