### PR TITLE
refactor: structure inspection event results for renderer-safe logging

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -278,6 +278,10 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 `content` の文字列フォーマット（`"{name} claims to be {role}"`）に依存せず、型安全に公言役職名を参照できる。
 既存アーカイブとの後方互換は `default=None` で対応する。
 
+`INSPECTION` イベントには `inspection_role: str | None` フィールドを使う。
+占い師が確認した役職名（`"Werewolf"` または `"Villager"`）を格納し、レンダラーが文字列パースなしに役職情報を参照できる。
+既存アーカイブとの後方互換は `default=None` で対応し、`None` の場合は `content` フォールバックで表示する。
+
 ---
 
 ## src/ui/ — UIレイヤー

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#184 | tech-debt | 🟡 | 3 | Add GameEngine tests for uncovered orchestration edge cases | `src/engine/game.py` の `run()` ループ、intended CO miss、memory update など未カバーの重要分岐を追加テストする |
-| yukkie/AgentVillage#179 | tech-debt | 🔴 | 3 | Structure inspection event results for renderer-safe logging | inspection 系のログ結果を構造化し、renderer/replay で安全に扱いつつ旧ログとの互換も保つ |
 | yukkie/AgentVillage#178 | tech-debt | 🔴 | 2 | Classify LLM fallback errors through a client helper | `client.py` の helper で LLM fallback のエラー種別を分類し、挙動を変えずに観測性を上げる（⚠️unit test mandatory） |
 | yukkie/AgentVillage#177 | tech-debt | 🟢 | 5 | Centralize legacy compatibility normalization for logs and actor state | ログ・actor state の旧形式互換処理を 1 箇所に集約し、互換責務の分散を減らす |
 | yukkie/AgentVillage#176 | bug | 🟢 | 2 | Fix replay log role rendering regression | INSPECT などのログで role object の repr が出るデグレを修正し、過去ログ互換を保ったまま人間向けの役職名を表示する |

--- a/src/domain/event.py
+++ b/src/domain/event.py
@@ -46,6 +46,7 @@ class LogEvent(BaseModel):
     speech_id: int | None = None
     reply_to: int | None = None
     claimed_role: RoleField = None
+    inspection_role: RoleField = None
 
     @classmethod
     def make(
@@ -60,6 +61,7 @@ class LogEvent(BaseModel):
         speech_id: int | None = None,
         reply_to: int | None = None,
         claimed_role: RoleField = None,
+        inspection_role: RoleField = None,
     ) -> "LogEvent":
         return cls(
             day=day,
@@ -72,4 +74,5 @@ class LogEvent(BaseModel):
             speech_id=speech_id,
             reply_to=reply_to,
             claimed_role=claimed_role,
+            inspection_role=inspection_role,
         )

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -197,13 +197,15 @@ def _publish_inspection(engine: GameEngine, inspection: InspectionResult) -> Non
         seer.state.beliefs[name].trust = 1.0
         seer.state.beliefs[name].reason.append(f"Day {engine.day}: inspected as Not Werewolf")
     store.save(seer)
+    role_name = result.name if result is not None else "Villager"
     engine._emit(LogEvent.make(
         day=engine.day,
         phase=Phase.NIGHT.value,
         event_type=EventType.INSPECTION,
         agent=seer.name,
         target=name,
-        content=f"{seer.name} inspects {name}: {result}",
+        content=f"{seer.name} inspects {name}: {'Werewolf' if isinstance(result, Werewolf) else 'Not Werewolf'}",
+        inspection_role=role_name,
         is_public=False,
     ))
 

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -21,10 +21,9 @@ class Renderer:
 
     # Simple events where the output is ``[PREFIX] {content}`` in a fixed style.
     # Events needing dynamic style or extra fields (SPEECH, VOTE, PHASE_START,
-    # PRE_NIGHT_DECISION, GAME_OVER) are handled separately in ``on_event``.
+    # PRE_NIGHT_DECISION, INSPECTION, GAME_OVER) are handled separately in ``on_event``.
     _SIMPLE_EVENT_STYLES: dict[EventType, tuple[str, str]] = {
         EventType.NIGHT_ATTACK: ("[NIGHT] ", "red"),
-        EventType.INSPECTION: ("[INSPECT] ", "cyan"),
         EventType.WOLF_CHAT: ("[WOLF] ", "red"),
         EventType.GUARD: ("[GUARD] ", "bright_green"),
         EventType.GUARD_BLOCK: ("[GUARD BLOCK] ", "bold bright_green"),
@@ -72,6 +71,9 @@ class Renderer:
             else:
                 text.append(f"[NIGHT] {event.content}", style="red")
 
+        elif event.event_type == EventType.INSPECTION:
+            self._render_inspection(event, text)
+
         elif event.event_type == EventType.PRE_NIGHT_DECISION:
             # Spectator only — color by the speaker's true role.
             actor = self._get_agent(event.agent)
@@ -91,6 +93,14 @@ class Renderer:
             text.append(event.content)
 
         return text if len(text) > 0 else None
+
+    def _render_inspection(self, event: LogEvent, text: Text) -> None:
+        if event.inspection_role is not None:
+            result_str = "Werewolf" if event.inspection_role.name == "Werewolf" else "Not Werewolf"
+            display = f"{event.agent} inspects {event.target}: {result_str}"
+        else:
+            display = event.content
+        text.append(f"[INSPECT] {display}", style="cyan")
 
     def _render_speech(self, event: LogEvent, text: Text) -> None:
         if event.content.startswith("[THINK]"):

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -310,6 +310,100 @@ class TestPublishInspection:
         assert inspection_events[0].agent == "Seer1"
         assert inspection_events[0].target == "Alice"
 
+    def test_inspect_werewolf_sets_inspection_role_field(self, make_test_actor, make_test_engine):
+        """
+        SUT: _publish_inspection
+        Mock: store.save — ファイルI/Oを回避
+        Level: unit
+        Objective: Werewolf を占ったとき INSPECTION イベントの inspection_role.name が "Werewolf" であること。
+        """
+        from src.domain.roles import Werewolf as WerewolfRole
+
+        seer = make_test_actor("Seer1", "Seer")
+        wolf = make_test_actor("Wolf1", "Werewolf")
+        engine, events = make_test_engine([seer, wolf])
+
+        wolf_role_instance = wolf.role
+        assert isinstance(wolf_role_instance, WerewolfRole)
+
+        declaration = InspectDeclaration(actor=seer, target="Wolf1")
+        inspection = InspectionResult(declaration=declaration, result=wolf_role_instance)
+
+        with patch("src.engine.phase_night.store.save"):
+            _publish_inspection(engine, inspection)
+
+        ev = next(e for e in events if e.event_type == EventType.INSPECTION)
+        assert ev.inspection_role is not None
+        assert ev.inspection_role.name == "Werewolf"
+
+    def test_inspect_non_werewolf_sets_inspection_role_villager(self, make_test_actor, make_test_engine):
+        """
+        SUT: _publish_inspection
+        Mock: store.save — ファイルI/Oを回避
+        Level: unit
+        Objective: 村人を占ったとき INSPECTION イベントの inspection_role.name が "Villager" であること。
+        """
+        seer = make_test_actor("Seer1", "Seer")
+        villager = make_test_actor("Alice")
+        engine, events = make_test_engine([seer, villager])
+
+        declaration = InspectDeclaration(actor=seer, target="Alice")
+        inspection = InspectionResult(declaration=declaration, result=None)
+
+        with patch("src.engine.phase_night.store.save"):
+            _publish_inspection(engine, inspection)
+
+        ev = next(e for e in events if e.event_type == EventType.INSPECTION)
+        assert ev.inspection_role is not None
+        assert ev.inspection_role.name == "Villager"
+
+    def test_inspect_seer_sets_inspection_role_villager(self, make_test_actor, make_test_engine):
+        """
+        SUT: _publish_inspection
+        Mock: store.save — ファイルI/Oを回避
+        Level: unit
+        Objective: Seer（占い師）を占ったとき INSPECTION イベントの inspection_role.name が "Villager" であること。
+        """
+        seer1 = make_test_actor("Seer1", "Seer")
+        seer2 = make_test_actor("Seer2", "Seer")
+        engine, events = make_test_engine([seer1, seer2])
+
+        declaration = InspectDeclaration(actor=seer1, target="Seer2")
+        inspection = InspectionResult(declaration=declaration, result=None)
+
+        with patch("src.engine.phase_night.store.save"):
+            _publish_inspection(engine, inspection)
+
+        ev = next(e for e in events if e.event_type == EventType.INSPECTION)
+        assert ev.inspection_role is not None
+        assert ev.inspection_role.name == "Villager"
+
+    def test_inspect_content_is_human_readable(self, make_test_actor, make_test_engine):
+        """
+        SUT: _publish_inspection
+        Mock: store.save — ファイルI/Oを回避
+        Level: unit
+        Objective: INSPECTION イベントの content が Python repr ではなく固定文字列であること。
+        """
+        from src.domain.roles import Werewolf as WerewolfRole
+
+        seer = make_test_actor("Seer1", "Seer")
+        wolf = make_test_actor("Wolf1", "Werewolf")
+        engine, events = make_test_engine([seer, wolf])
+
+        wolf_role_instance = wolf.role
+        assert isinstance(wolf_role_instance, WerewolfRole)
+
+        declaration = InspectDeclaration(actor=seer, target="Wolf1")
+        inspection = InspectionResult(declaration=declaration, result=wolf_role_instance)
+
+        with patch("src.engine.phase_night.store.save"):
+            _publish_inspection(engine, inspection)
+
+        ev = next(e for e in events if e.event_type == EventType.INSPECTION)
+        assert "Werewolf" in ev.content
+        assert "<" not in ev.content  # no Python repr like <src.domain.roles.Werewolf object>
+
     def test_inspect_updates_existing_belief(self, make_test_actor, make_test_engine):
         """
         SUT: _publish_inspection

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -93,14 +93,58 @@ def test_vote_renders_agent_and_target(make_test_actor) -> None:
     assert result.plain == "[VOTE] Alice → Bob"
 
 
-def test_simple_event_uses_mapping_prefix(make_test_actor) -> None:
+def test_inspection_structured_field_used_when_present(make_test_actor) -> None:
+    """
+    SUT: Renderer._render_inspection
+    Mock: なし
+    Level: unit
+    Objective: inspection_role が設定されているとき content に依存せず構造化フィールドから描画されること。
+    """
+    from src.domain.roles import get_role
     renderer = Renderer([], spectator_mode=True)
-    event = _make_event(EventType.INSPECTION, content="Seer saw Bob is Werewolf", is_public=False)
+    event = _make_event(
+        EventType.INSPECTION,
+        agent="Seer1",
+        target="Wolf1",
+        content="Seer1 inspects Wolf1: Not Werewolf",  # wrong content — should be ignored
+        inspection_role=get_role("Werewolf"),
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert result.plain == "[INSPECT] Seer1 inspects Wolf1: Werewolf"
+
+
+def test_inspection_falls_back_to_content_for_legacy_events(make_test_actor) -> None:
+    """
+    SUT: Renderer._render_inspection
+    Mock: なし
+    Level: unit
+    Objective: inspection_role が None のレガシーイベントは content をそのまま表示すること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.INSPECTION,
+        content="Seer saw Bob is Werewolf",
+        is_public=False,
+    )
 
     result = renderer.on_event(event)
 
     assert result is not None
     assert result.plain == "[INSPECT] Seer saw Bob is Werewolf"
+
+
+def test_simple_event_uses_mapping_prefix(make_test_actor) -> None:
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(EventType.GUARD, content="Knight guards Alice", is_public=False)
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert result.plain == "[GUARD] Knight guards Alice"
 
 
 def test_night_attack_without_agent_falls_back_to_content(make_test_actor) -> None:


### PR DESCRIPTION
## Summary
- `LogEvent` に `inspection_role: RoleField = None` フィールドを追加
- `_publish_inspection()` で `inspection_role` を設定し、`content` も Python repr 排除の固定文字列に変更
- `Renderer` の INSPECTION 描画を `inspection_role` 優先・`content` フォールバック方式に変更
- `inspection_role=None` のレガシーアーカイブログは `content` フォールバックで引き続き正常表示

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `inspection_role` が Werewolf / 非Werewolf / Seer の各ケースで正しく設定されること
- [ ] レンダラーが `inspection_role` 優先・レガシー fallback の両パスで正しく描画すること
- [ ] content に Python repr（`<`）が含まれないこと

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)