### PR TITLE
Classify LLM fallback errors through a client helper

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#184 | tech-debt | 🟡 | 3 | Add GameEngine tests for uncovered orchestration edge cases | `src/engine/game.py` の `run()` ループ、intended CO miss、memory update など未カバーの重要分岐を追加テストする |
-| yukkie/AgentVillage#178 | tech-debt | 🔴 | 2 | Classify LLM fallback errors through a client helper | `client.py` の helper で LLM fallback のエラー種別を分類し、挙動を変えずに観測性を上げる（⚠️unit test mandatory） |
 | yukkie/AgentVillage#177 | tech-debt | 🟢 | 5 | Centralize legacy compatibility normalization for logs and actor state | ログ・actor state の旧形式互換処理を 1 箇所に集約し、互換責務の分散を減らす |
 | yukkie/AgentVillage#176 | bug | 🟢 | 2 | Fix replay log role rendering regression | INSPECT などのログで role object の repr が出るデグレを修正し、過去ログ互換を保ったまま人間向けの役職名を表示する |
 | yukkie/AgentVillage#33 | enhancement | 🟢 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -1,8 +1,10 @@
+import json
 import sys
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import anthropic
+import pydantic
 
 from src.domain.actor import Actor
 from src.domain.roles import Role
@@ -47,10 +49,26 @@ def _default_output(actor: Actor) -> AgentOutput:
     )
 
 
+def _classify_error(e: Exception) -> str:
+    """Classify an LLM call exception into one of four categories."""
+    if isinstance(e, anthropic.APIError):
+        return "api"
+    if isinstance(e, pydantic.ValidationError):
+        return "validation"
+    if isinstance(e, json.JSONDecodeError):
+        return "extraction"
+    return "unexpected"
+
+
 def _log_error(fn: str, agent_name: str, stage: str, e: Exception, raw: str) -> None:
     print(f"[{fn}] {stage} error for {agent_name}: {e!r}", file=sys.stderr)
     if raw:
         print(f"[{fn}] raw response: {raw!r}", file=sys.stderr)
+
+
+def _classify_and_log_error(fn: str, agent_name: str, e: Exception, raw: str) -> None:
+    kind = _classify_error(e)
+    _log_error(fn, agent_name, kind, e, raw)
 
 
 def _log_warning(fn: str, agent_name: str, message: str) -> None:
@@ -125,7 +143,7 @@ class LLMClient:
             raw = message.content[0].text
             return AgentOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
-            _log_error("call", actor.name, "error", e, raw)
+            _classify_and_log_error("call", actor.name, e, raw)
             return _default_output(actor)
 
     def call_judgment(
@@ -149,7 +167,7 @@ class LLMClient:
             raw = message.content[0].text
             return JudgmentOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
-            _log_error("call_judgment", actor.name, "error", e, raw)
+            _classify_and_log_error("call_judgment", actor.name, e, raw)
             return JudgmentOutput(decision="silent")
 
     def call_speech_parallel(
@@ -184,7 +202,7 @@ class LLMClient:
             raw = message.content[0].text
             return PreNightOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
-            _log_error("call_pre_night_action", actor.name, "error", e, raw)
+            _classify_and_log_error("call_pre_night_action", actor.name, e, raw)
             return PreNightOutput(thought="...", decision="wait", claim_role=None, reasoning="Defaulting to wait.")
 
     def call_pre_night_parallel(
@@ -263,7 +281,7 @@ class LLMClient:
             raw = message.content[0].text
             return WolfChatOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
-            _log_error("call_wolf_chat", actor.name, "error", e, raw)
+            _classify_and_log_error("call_wolf_chat", actor.name, e, raw)
             return WolfChatOutput(thought="...", speech="...", vote_candidates=[])
 
     def call_night_action(
@@ -292,7 +310,7 @@ class LLMClient:
             )
             raw = message.content[0].text.strip()
         except Exception as e:
-            _log_error("call_night_action", actor.name, "api", e, raw)
+            _classify_and_log_error("call_night_action", actor.name, e, raw)
             return candidates[0] if candidates else ""
         # Validate that the returned name is a valid alive player
         for candidate in candidates:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,7 +1,13 @@
 """Unit tests for src/llm/client.py — LLMClient with injected mock anthropic client."""
+import json
+
+import anthropic
+import pydantic
+import pytest
+
 from src.domain.schema import AgentOutput, JudgmentOutput, PreNightOutput, WolfChatOutput
 from src.domain.roles import get_role
-from src.llm.client import resolve_claim_role
+from src.llm.client import _classify_error, resolve_claim_role
 from tests.conftest import (
     AGENT_OUTPUT_JSON,
     JUDGMENT_CO_OUTPUT_JSON,
@@ -149,3 +155,116 @@ class TestResolveClaimRole:
         assert result.name == "Seer"
         assert "resolve_claim_role" in captured.err
         assert "falling back to default_claim_role=Seer" in captured.err
+
+
+@pytest.mark.unit
+class TestClassifyError:
+    def test_classifies_anthropic_api_error(self):
+        """
+        SUT: _classify_error()
+        Mock: なし
+        Level: unit
+        Objective: anthropic.APIError のサブクラスが "api" に分類されること。
+        """
+        import httpx
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        response = httpx.Response(429, request=request)
+        e = anthropic.RateLimitError(message="rate limit", response=response, body={})
+        assert _classify_error(e) == "api"
+
+    def test_classifies_pydantic_validation_error(self):
+        """
+        SUT: _classify_error()
+        Mock: なし
+        Level: unit
+        Objective: pydantic.ValidationError が "validation" に分類されること。
+        """
+        try:
+            pydantic.TypeAdapter(int).validate_python("not-an-int")
+        except pydantic.ValidationError as e:
+            assert _classify_error(e) == "validation"
+        else:
+            pytest.fail("Expected ValidationError")
+
+    def test_classifies_json_decode_error(self):
+        """
+        SUT: _classify_error()
+        Mock: なし
+        Level: unit
+        Objective: json.JSONDecodeError が "extraction" に分類されること。
+        """
+        try:
+            json.loads("{invalid}")
+        except json.JSONDecodeError as e:
+            assert _classify_error(e) == "extraction"
+        else:
+            pytest.fail("Expected JSONDecodeError")
+
+    def test_classifies_unexpected_error(self):
+        """
+        SUT: _classify_error()
+        Mock: なし
+        Level: unit
+        Objective: 上記以外の例外が "unexpected" に分類されること。
+        """
+        assert _classify_error(RuntimeError("boom")) == "unexpected"
+        assert _classify_error(ValueError("bad")) == "unexpected"
+        assert _classify_error(KeyError("missing")) == "unexpected"
+
+
+@pytest.mark.unit
+class TestClassifyAndLogError:
+    def test_api_error_logged_with_api_kind(self, capsys):
+        """
+        SUT: _classify_and_log_error()
+        Mock: なし
+        Level: unit
+        Objective: anthropic.APIError 系の例外が "api error" としてログ出力されること。
+        """
+        import httpx
+        from src.llm.client import _classify_and_log_error
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        response = httpx.Response(429, request=request)
+        e = anthropic.RateLimitError(message="rate limit", response=response, body={})
+        _classify_and_log_error("call", "Alice", e, "")
+        captured = capsys.readouterr()
+        assert "api error" in captured.err
+
+    def test_validation_error_logged_with_validation_kind(self, capsys):
+        """
+        SUT: _classify_and_log_error()
+        Mock: なし
+        Level: unit
+        Objective: pydantic.ValidationError が "validation error" としてログ出力されること。
+        """
+        from src.llm.client import _classify_and_log_error
+        try:
+            pydantic.TypeAdapter(int).validate_python("bad")
+        except pydantic.ValidationError as e:
+            _classify_and_log_error("call", "Alice", e, '{"bad": true}')
+            captured = capsys.readouterr()
+            assert "validation error" in captured.err
+
+    def test_unexpected_error_logged_with_unexpected_kind(self, capsys):
+        """
+        SUT: _classify_and_log_error()
+        Mock: なし
+        Level: unit
+        Objective: 未分類例外が "unexpected error" としてログ出力されること。
+        """
+        from src.llm.client import _classify_and_log_error
+        _classify_and_log_error("call", "Alice", RuntimeError("boom"), "")
+        captured = capsys.readouterr()
+        assert "unexpected error" in captured.err
+
+    def test_raw_response_logged_when_present(self, capsys):
+        """
+        SUT: _classify_and_log_error()
+        Mock: なし
+        Level: unit
+        Objective: raw が空でない場合にレスポンス内容もログ出力されること。
+        """
+        from src.llm.client import _classify_and_log_error
+        _classify_and_log_error("call", "Alice", RuntimeError("boom"), "some raw text")
+        captured = capsys.readouterr()
+        assert "some raw text" in captured.err


### PR DESCRIPTION
## Summary
- `_classify_error()` を追加: `anthropic.APIError` / `pydantic.ValidationError` / `json.JSONDecodeError` / それ以外 を4種に分類する純粋関数
- `_classify_and_log_error()` を追加: 分類結果を含む種別ラベル付きでログ出力するヘルパー
- 各 `call_*` の `except` ブロックを `_classify_and_log_error()` に統一（5箇所）
- `TestClassifyError` / `TestClassifyAndLogError` を追加（8テスト）

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（211 passed）
- [ ] 各エラー種別（api / validation / extraction / unexpected）の単体テストを網羅

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)