### PR TITLE
feat: add reasoning field to Vote/Guard/Inspect/Judgment actions

### DIFF
--- a/config/tokens.json
+++ b/config/tokens.json
@@ -3,5 +3,5 @@
   "call_judgment": 1024,
   "call_pre_night_action": 1024,
   "call_wolf_chat": 2048,
-  "call_night_action": 64
+  "call_night_action": 256
 }

--- a/config/tokens.json
+++ b/config/tokens.json
@@ -1,0 +1,7 @@
+{
+  "call_speech": 2048,
+  "call_judgment": 1024,
+  "call_pre_night_action": 1024,
+  "call_wolf_chat": 2048,
+  "call_night_action": 64
+}

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -160,7 +160,7 @@ CO には2種類のフォールバックがある。
 |---|---|---|---|
 | `call()` | 発言生成（OPENING / DISCUSSION） | フル（役職・性格・記憶・当日ログ・他者のCO情報・狼仲間（狼のみ）） | `AgentOutput` |
 | `call_judgment()` | 判断（DISCUSSION 並列） | 軽量（役職・性格・memory_summary・直近発言のみ） | `JudgmentOutput` (`claim_role` を含む) |
-| `call_night_action()` | 夜行動 | 夜フェーズ専用 | `str`（ターゲット名） |
+| `call_night_action()` | 夜行動 | 夜フェーズ専用 | `NightActionOutput` (`target` + `reasoning`) |
 | `call_pre_night_action()` | 前夜判断・単体呼び出し | 役職・性格・参加者情報 | `PreNightOutput` (`claim_role` を含む) |
 | `call_pre_night_parallel()` | 前夜判断・並列呼び出し（`call_speech_parallel` と同パターン） | 同上 | `Iterator[tuple[Actor, PreNightOutput]]` |
 | `call_discussion_parallel()` | 昼DISCUSSION 判断→発言チェーンの並列実行 | — | `Iterator[tuple[Actor, JudgmentOutput, AgentOutput \| None, SpeechEntry \| None]]` |

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -203,6 +203,12 @@ class JudgmentOutput(BaseModel):
     decision: Literal["challenge", "speak", "silent", "co"]
     reply_to: int | None = None
     claim_role: Role | None = None
+    reasoning: str = ""   # why this action was chosen (spectator-only)
+
+
+class NightActionOutput(BaseModel):
+    target: str           # validated alive player name
+    reasoning: str = ""   # why this target was chosen (spectator-only)
 ```
 
 - `claim_role` は `decision="co"` のときに名乗る予定の役職
@@ -217,7 +223,7 @@ class JudgmentOutput(BaseModel):
 | `call_judgment()` | 昼フェーズの並列判断（challenge / speak / silent / co） | 1024 | `decision`, `reply_to`, `claim_role` の軽量JSON。`co_eligible=True` のときのみ `"co"` を選択肢に含める |
 | `call_wolf_chat()` | 夜フェーズの狼チーム会話 | 2048 | thought + speech + vote_candidates。日本語で長くなりやすい |
 | `call_pre_night_action()` | 前夜フェーズの CO 判断（村人以外） | 1024 | thought + decision + claim_role + reasoning の4フィールド |
-| `call_night_action()` | 夜フェーズの個別行動（襲撃・占い・護衛） | 64 | プレイヤー名1つだけ返す |
+| `call_night_action()` | 夜フェーズの個別行動（襲撃・占い・護衛） | 256 | `NightActionOutput` (target + reasoning) |
 
 ### claim_role 解決フロー
 
@@ -259,12 +265,13 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 | EventType | is_public | 説明 |
 |---|---|---|
 | `SPEECH` | True | エージェントの発言 |
-| `VOTE` | True | 投票行動 |
+| `VOTE` | True | 投票行動。`reasoning` フィールドに投票理由（観戦者のみ表示） |
+| `JUDGMENT` | False | 昼DISCUSSION判断フェーズの行動選択理由（観戦者のみ） |
 | `ELIMINATION` | True | 昼の処刑 |
 | `NIGHT_ATTACK` | False | 狼の夜襲（観戦者のみ） |
-| `INSPECTION` | False | 占い師の占い結果（観戦者のみ） |
+| `INSPECTION` | False | 占い師の占い結果（観戦者のみ）。`reasoning` フィールドに占い対象を選んだ理由 |
 | `MEDIUM_RESULT` | False | 霊媒師が受け取った処刑者の役職（観戦者のみ・黄色表示） |
-| `GUARD` | False | 騎士の護衛行動（観戦者のみ） |
+| `GUARD` | False | 騎士の護衛行動（観戦者のみ）。`reasoning` フィールドに護衛対象を選んだ理由 |
 | `GUARD_BLOCK` | False / True | 護衛成功の詳細（観戦者）/ 全体通知（村人全員） |
 | `WOLF_CHAT` | False | 狼チャット（観戦者のみ） |
 | `PRE_NIGHT_DECISION` | False | 前夜CO判断（観戦者のみ） |
@@ -281,6 +288,10 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 `INSPECTION` イベントには `inspection_role: str | None` フィールドを使う。
 占い師が確認した役職名（`"Werewolf"` または `"Villager"`）を格納し、レンダラーが文字列パースなしに役職情報を参照できる。
 既存アーカイブとの後方互換は `default=None` で対応し、`None` の場合は `content` フォールバックで表示する。
+
+`VOTE` / `GUARD` / `INSPECTION` / `JUDGMENT` イベントには `reasoning: str` フィールドを使う。
+エージェントが行動を選んだ理由を格納し、観戦者モードで表示する。他エージェントのゲーム状態には含めない（`is_public=False` または表示フィルタで制御）。
+既存アーカイブとの後方互換は `default=""` で対応する。
 
 ---
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
-| yukkie/AgentVillage#47 | enhancement | 🔴 | 3 | Reasoning field for Vote/Guard/Divination/Judgment | 各アクションに reasoning を追加し spectator ログ・memory_update に記録 |
 | yukkie/AgentVillage#33 | enhancement | 🔴 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |
 | yukkie/AgentVillage#36 | enhancement | 🟡 | 5 | Belief updates from agent reasoning | suspicion/trust を推理結果から更新 |

--- a/doc/Spec.md
+++ b/doc/Spec.md
@@ -168,13 +168,12 @@ LLMの出力は必ずJSONで受け取る。フェーズによって2種類のフ
 
 #### (B) 判断フォーマット（DISCUSSIONの判断フェーズ・軽量）
 
-outputが数トークンで済むよう最小限の構造にする。
-
 ```json
 {
   "decision": "challenge",
   "reply_to": 3,
-  "claim_role": null
+  "claim_role": null,
+  "reasoning": "Alice's claim contradicts yesterday's vote pattern."
 }
 ```
 
@@ -183,6 +182,7 @@ outputが数トークンで済むよう最小限の構造にする。
 | `decision` | `"challenge"` \| `"speak"` \| `"silent"` \| `"co"` | 行動の選択。`"co"` は適格エージェント（未COの非村人役職）のみ有効 |
 | `reply_to` | `int` \| `null` | `challenge` 時に突っ込む発言のspeech_id。他は null |
 | `claim_role` | `str` \| `null` | `decision="co"` のときに公言する役職。他は null。未指定時は役職ごとのデフォルトにフォールバック |
+| `reasoning` | `str` | なぜこの行動を選んだかの短文（観戦者向け）。省略時は `""` |
 
 判断プロンプトには、適格エージェントに対してのみ `"co"` の選択肢と役職別の戦略ヒント（例: 占い師の単独CO、人狼の偽CO、狂人の勝利確定COなど）を含める。不適格なエージェントが万一 `"co"` を返した場合、エンジン側で `"speak"` にフォールバックする。
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 # Game settings
@@ -11,3 +12,8 @@ LOG_DIR = PROJECT_ROOT / "state"
 PUBLIC_LOG = LOG_DIR / "public_log.jsonl"
 SPECTATOR_LOG = LOG_DIR / "spectator_log.jsonl"
 ARCHIVE_DIR = PROJECT_ROOT / "state_archive"
+
+# LLM token limits
+MAX_TOKENS: dict[str, int] = json.loads(
+    (PROJECT_ROOT / "config" / "tokens.json").read_text(encoding="utf-8")
+)

--- a/src/domain/event.py
+++ b/src/domain/event.py
@@ -10,6 +10,7 @@ class EventType(Enum):
     SPEECH = "speech"
     REASONING = "reasoning"
     VOTE = "vote"
+    JUDGMENT = "judgment"
     ELIMINATION = "elimination"
     NIGHT_ATTACK = "night_attack"
     INSPECTION = "inspection"
@@ -47,6 +48,7 @@ class LogEvent(BaseModel):
     reply_to: int | None = None
     claimed_role: RoleField = None
     inspection_role: RoleField = None
+    reasoning: str = ""
 
     @classmethod
     def make(
@@ -62,6 +64,7 @@ class LogEvent(BaseModel):
         reply_to: int | None = None,
         claimed_role: RoleField = None,
         inspection_role: RoleField = None,
+        reasoning: str = "",
     ) -> "LogEvent":
         return cls(
             day=day,
@@ -75,4 +78,5 @@ class LogEvent(BaseModel):
             reply_to=reply_to,
             claimed_role=claimed_role,
             inspection_role=inspection_role,
+            reasoning=reasoning,
         )

--- a/src/domain/roles/knight.py
+++ b/src/domain/roles/knight.py
@@ -50,8 +50,9 @@ class Knight(Role):
             f"Context: {context}\n"
             f"Alive players (excluding you): {', '.join(candidates)}\n"
             f"Your task: choose one player to GUARD (protect from werewolf attack) tonight.\n"
-            "Pick a player you want to protect. You cannot guard yourself. "
-            "Respond with ONLY the player's exact name, nothing else."
+            "Pick a player you want to protect. You cannot guard yourself.\n"
+            "Respond with ONLY valid JSON, no other text:\n"
+            '{"target": "<player name>", "reasoning": "<one sentence why>"}'
         )
 
     def co_strategy_hint(self) -> str:

--- a/src/domain/roles/seer.py
+++ b/src/domain/roles/seer.py
@@ -50,7 +50,9 @@ class Seer(Role):
             f"Context: {context}\n"
             f"Alive players (excluding you): {', '.join(candidates)}\n"
             f"Your task: choose one player to INSPECT (learn their alignment) tonight.\n"
-            "Pick a player you want to investigate. Respond with ONLY the player's exact name, nothing else."
+            "Pick a player you want to investigate.\n"
+            "Respond with ONLY valid JSON, no other text:\n"
+            '{"target": "<player name>", "reasoning": "<one sentence why>"}'
         )
 
     def co_strategy_hint(self) -> str:

--- a/src/domain/roles/werewolf.py
+++ b/src/domain/roles/werewolf.py
@@ -66,7 +66,9 @@ class Werewolf(Role):
             f"Context: {context}\n"
             f"Alive players (excluding you): {', '.join(candidates)}\n"
             f"Your task: choose one player to ATTACK (eliminate) tonight.\n"
-            "You must pick a non-Werewolf target. Respond with ONLY the player's exact name, nothing else."
+            "You must pick a non-Werewolf target.\n"
+            "Respond with ONLY valid JSON, no other text:\n"
+            '{"target": "<player name>", "reasoning": "<one sentence why>"}'
         )
 
     def co_strategy_hint(self) -> str:

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -49,6 +49,19 @@ class JudgmentOutput(BaseModel):
     decision: Literal["challenge", "speak", "silent", "co"]
     reply_to: int | None = None
     claim_role: RoleField = None
+    reasoning: str = ""
+
+
+class NightActionOutput(BaseModel):
+    """LLM response schema for night actions (guard / inspect / attack-fallback).
+
+    Mock-Policy: Forbidden
+        LLM I/O contract. See ``PreNightOutput`` and
+        ``tests/TestStrategy.md`` §5.
+    """
+
+    target: str
+    reasoning: str = ""
 
 
 class VoteCandidate(BaseModel):

--- a/src/engine/phase_day.py
+++ b/src/engine/phase_day.py
@@ -43,6 +43,16 @@ def _run_discussion(engine: GameEngine) -> None:
             engine.lang,
             engine._build_speech_args,
         ):
+            if judgment.reasoning:
+                engine._emit(LogEvent.make(
+                    day=engine.day,
+                    phase=Phase.DAY_DISCUSSION.value,
+                    event_type=EventType.JUDGMENT,
+                    agent=actor.name,
+                    content=f"{actor.name} [{judgment.decision}]: {judgment.reasoning}",
+                    is_public=False,
+                    reasoning=judgment.reasoning,
+                ))
             if output is None:
                 engine._emit(LogEvent.make(
                     day=engine.day,
@@ -92,6 +102,7 @@ def _run_vote(engine: GameEngine) -> str | None:
             vote_action = engine._make_vote(target)
             if engine._validate_action(vote_action, actor, alive_names):
                 votes[actor.name] = target
+                vote_reasoning = output.reasoning if output else ""
                 engine._emit(LogEvent.make(
                     day=engine.day,
                     phase=Phase.DAY_VOTE.value,
@@ -100,6 +111,7 @@ def _run_vote(engine: GameEngine) -> str | None:
                     target=target,
                     content=f"{actor.name} votes for {target}",
                     is_public=True,
+                    reasoning=vote_reasoning,
                 ))
 
     if not votes:

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -28,12 +28,14 @@ class GuardDeclaration:
     actor: Actor
     target: str
     succeeded: bool = False
+    reasoning: str = ""
 
 
 @dataclass
 class InspectDeclaration:
     actor: Actor
     target: str
+    reasoning: str = ""
 
 
 @dataclass
@@ -107,8 +109,8 @@ def _resolve_fallback_attack(engine: GameEngine, alive_names: list[str]) -> str 
     for actor in engine._alive_agents():
         if not isinstance(actor.role, Werewolf):
             continue
-        target_name = engine._llm_client.call_night_action(actor, night_context, alive_names)
-        attack = Attack(target=target_name)
+        result = engine._llm_client.call_night_action(actor, night_context, alive_names)
+        attack = Attack(target=result.target)
         if engine._validate_action(attack, actor, alive_names):
             return resolve_attack(attack, engine.agents)
     return None
@@ -132,15 +134,15 @@ def _declare_night_actions(
 
     for actor in engine._alive_agents():
         if isinstance(actor.role, Knight):
-            target_name = engine._llm_client.call_night_action(actor, night_context, alive_names)
+            result = engine._llm_client.call_night_action(actor, night_context, alive_names)
             candidates = [n for n in alive_names if n != actor.name]
-            if target_name in candidates:
-                guard = GuardDeclaration(actor=actor, target=target_name)
+            if result.target in candidates:
+                guard = GuardDeclaration(actor=actor, target=result.target, reasoning=result.reasoning)
         elif isinstance(actor.role, Seer):
-            target_name = engine._llm_client.call_night_action(actor, night_context, alive_names)
-            inspect_action = Inspect(target=target_name)
+            result = engine._llm_client.call_night_action(actor, night_context, alive_names)
+            inspect_action = Inspect(target=result.target)
             if engine._validate_action(inspect_action, actor, alive_names):
-                inspect = InspectDeclaration(actor=actor, target=inspect_action.target)
+                inspect = InspectDeclaration(actor=actor, target=inspect_action.target, reasoning=result.reasoning)
 
     return NightDeclarations(attack=attack, guard=guard, inspect=inspect)
 
@@ -207,6 +209,7 @@ def _publish_inspection(engine: GameEngine, inspection: InspectionResult) -> Non
         content=f"{seer.name} inspects {name}: {'Werewolf' if isinstance(result, Werewolf) else 'Not Werewolf'}",
         inspection_role=role_name,
         is_public=False,
+        reasoning=inspection.declaration.reasoning,
     ))
 
 
@@ -220,6 +223,7 @@ def _publish_night_results(engine: GameEngine, resolution: NightResolution) -> N
             target=resolution.guard.target,
             content=f"{resolution.guard.actor.name} guards {resolution.guard.target}",
             is_public=False,
+            reasoning=resolution.guard.reasoning,
         ))
 
     if resolution.attack is not None:

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import anthropic
 import pydantic
 
+from src.config import MAX_TOKENS
 from src.domain.actor import Actor
 from src.domain.roles import Role
 from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, SpeechEntry, WolfChatOutput
@@ -132,7 +133,7 @@ class LLMClient:
         try:
             message = self._client.messages.create(
                 model=actor.model,
-                max_tokens=2048,
+                max_tokens=MAX_TOKENS["call_speech"],
                 system=system_prompt,
                 messages=[
                     {
@@ -162,7 +163,7 @@ class LLMClient:
         try:
             message = self._client.messages.create(
                 model=actor.model,
-                max_tokens=1024,
+                max_tokens=MAX_TOKENS["call_judgment"],
                 messages=[{"role": "user", "content": prompt}],
             )
             raw = message.content[0].text
@@ -197,7 +198,7 @@ class LLMClient:
         try:
             message = self._client.messages.create(
                 model=actor.model,
-                max_tokens=1024,
+                max_tokens=MAX_TOKENS["call_pre_night_action"],
                 messages=[{"role": "user", "content": prompt}],
             )
             raw = message.content[0].text
@@ -276,7 +277,7 @@ class LLMClient:
         try:
             message = self._client.messages.create(
                 model=actor.model,
-                max_tokens=2048,
+                max_tokens=MAX_TOKENS["call_wolf_chat"],
                 messages=[{"role": "user", "content": prompt}],
             )
             raw = message.content[0].text
@@ -301,7 +302,7 @@ class LLMClient:
         try:
             message = self._client.messages.create(
                 model=actor.model,
-                max_tokens=64,
+                max_tokens=MAX_TOKENS["call_night_action"],
                 messages=[
                     {
                         "role": "user",

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -9,7 +9,7 @@ import pydantic
 from src.config import MAX_TOKENS
 from src.domain.actor import Actor
 from src.domain.roles import Role
-from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, SpeechEntry, WolfChatOutput
+from src.domain.schema import AgentOutput, Intent, JudgmentOutput, NightActionOutput, PreNightOutput, SpeechEntry, WolfChatOutput
 from src.llm.prompt import PublicContext, RoleSpecificContext, SpeechDirection, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_system_prompt, build_wolf_chat_prompt
 
 
@@ -170,7 +170,7 @@ class LLMClient:
             return JudgmentOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
             _classify_and_log_error("call_judgment", actor.name, e, raw)
-            return JudgmentOutput(decision="silent")
+            return JudgmentOutput(decision="silent", reasoning="")
 
     def call_speech_parallel(
         self,
@@ -291,11 +291,11 @@ class LLMClient:
         actor: Actor,
         context: str,
         alive_players: list[str],
-    ) -> str:
-        """Call LLM for night action and return target player name."""
+    ) -> NightActionOutput:
+        """Call LLM for night action and return structured NightActionOutput."""
         prompt = build_night_action_prompt(actor, alive_players, context)
         if not prompt:
-            return ""
+            return NightActionOutput(target="", reasoning="")
 
         candidates = [p for p in alive_players if p != actor.name]
         raw = ""
@@ -311,16 +311,20 @@ class LLMClient:
                 ],
             )
             raw = message.content[0].text.strip()
+            parsed = NightActionOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
             _classify_and_log_error("call_night_action", actor.name, e, raw)
-            return candidates[0] if candidates else ""
-        # Validate that the returned name is a valid alive player
+            return NightActionOutput(target=candidates[0] if candidates else "", reasoning="")
+
+        # Validate target is a live player; fall back to first candidate on mismatch
+        target = parsed.target
         for candidate in candidates:
-            if candidate.lower() == raw.lower():
-                return candidate
-        # If exact match fails, try partial match
+            if candidate.lower() == target.lower():
+                return NightActionOutput(target=candidate, reasoning=parsed.reasoning)
         for candidate in candidates:
-            if candidate.lower() in raw.lower():
-                return candidate
-        # Fallback: first candidate
-        return candidates[0] if candidates else ""
+            if candidate.lower() in target.lower():
+                return NightActionOutput(target=candidate, reasoning=parsed.reasoning)
+        return NightActionOutput(
+            target=candidates[0] if candidates else "",
+            reasoning=parsed.reasoning,
+        )

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -289,7 +289,8 @@ Decide your next action. Respond with ONLY valid JSON. No extra fields, no expla
 {{
   "decision": {decision_options},
   "reply_to": <speech_id to challenge, or null>,
-  "claim_role": <role_name to claim, or null>
+  "claim_role": <role_name to claim, or null>,
+  "reasoning": "<one sentence: why you chose this action>"
 }}
 - "challenge": directly counter a specific speech (set reply_to to its speech_id)
 - "speak": add a new statement unprompted
@@ -302,8 +303,9 @@ Decide your next action. Respond with ONLY valid JSON. No extra fields, no expla
         )
     else:
         lines.append('- Set "claim_role" to null')
-    lines.append(f"""- The JSON must contain exactly these three fields and nothing else.
-Use {lang} only for internal reasoning if needed, but keep the JSON minimal.""")
+    lines.append(f"""- The JSON must contain exactly these four fields and nothing else.
+- "reasoning" must be written in {lang}
+- Keep the JSON minimal — "reasoning" should be one short sentence.""")
     return "\n".join(lines)
 
 

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -20,12 +20,11 @@ class Renderer:
     """Convert ``LogEvent`` instances into Rich ``Text`` for console output."""
 
     # Simple events where the output is ``[PREFIX] {content}`` in a fixed style.
-    # Events needing dynamic style or extra fields (SPEECH, VOTE, PHASE_START,
-    # PRE_NIGHT_DECISION, INSPECTION, GAME_OVER) are handled separately in ``on_event``.
+    # Events needing dynamic style or extra fields (SPEECH, VOTE, JUDGMENT, PHASE_START,
+    # PRE_NIGHT_DECISION, INSPECTION, GUARD, GAME_OVER) are handled separately in ``on_event``.
     _SIMPLE_EVENT_STYLES: dict[EventType, tuple[str, str]] = {
         EventType.NIGHT_ATTACK: ("[NIGHT] ", "red"),
         EventType.WOLF_CHAT: ("[WOLF] ", "red"),
-        EventType.GUARD: ("[GUARD] ", "bright_green"),
         EventType.GUARD_BLOCK: ("[GUARD BLOCK] ", "bold bright_green"),
         EventType.CO_ANNOUNCEMENT: ("[CO] ", "bold white"),
         EventType.MEDIUM_RESULT: ("[MEDIUM] ", "cyan"),
@@ -56,7 +55,13 @@ class Renderer:
             text.append(event.content, style="magenta")
 
         elif event.event_type == EventType.VOTE:
-            text.append(f"[VOTE] {event.agent} → {event.target}", style="white")
+            vote_text = f"[VOTE] {event.agent} → {event.target}"
+            if self.spectator_mode and event.reasoning:
+                vote_text += f" — {event.reasoning}"
+            text.append(vote_text, style="white")
+
+        elif event.event_type == EventType.JUDGMENT:
+            text.append(f"[JUDGMENT] {event.agent}: {event.reasoning}", style="dim cyan")
 
         elif event.event_type == EventType.ELIMINATION:
             text.append(f"\n{event.content}\n", style="bold red")
@@ -70,6 +75,12 @@ class Renderer:
                 )
             else:
                 text.append(f"[NIGHT] {event.content}", style="red")
+
+        elif event.event_type == EventType.GUARD:
+            guard_text = f"[GUARD] {event.content}"
+            if self.spectator_mode and event.reasoning:
+                guard_text += f" — {event.reasoning}"
+            text.append(guard_text, style="bright_green")
 
         elif event.event_type == EventType.INSPECTION:
             self._render_inspection(event, text)
@@ -100,6 +111,8 @@ class Renderer:
             display = f"{event.agent} inspects {event.target}: {result_str}"
         else:
             display = event.content
+        if self.spectator_mode and event.reasoning:
+            display += f" — {event.reasoning}"
         text.append(f"[INSPECT] {display}", style="cyan")
 
     def _render_speech(self, event: LogEvent, text: Text) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,3 +169,8 @@ WOLF_CHAT_OUTPUT_JSON = json.dumps({
     "speech": "Let's attack Alice.",
     "vote_candidates": [{"target": "Alice", "score": 0.9}],
 })
+
+NIGHT_ACTION_OUTPUT_JSON = json.dumps({
+    "target": "Alice",
+    "reasoning": "She is the most suspicious.",
+})

--- a/tests/contract/test_engine_renderer_contract.py
+++ b/tests/contract/test_engine_renderer_contract.py
@@ -31,12 +31,13 @@ from src.ui.renderer import Renderer
 def _run_night(engine, attack_target: str, inspect_target: str) -> None:
     """Drive a real night phase: wolves attack ``attack_target``, seer
     inspects ``inspect_target``. Other roles auto-resolve to no action."""
+    from src.domain.schema import NightActionOutput
 
     def night_action(actor, _context, _alive_names):
         if actor.role.name == "Werewolf":
-            return attack_target
+            return NightActionOutput(target=attack_target, reasoning="")
         if actor.role.name == "Seer":
-            return inspect_target
+            return NightActionOutput(target=inspect_target, reasoning="")
         # Other roles (e.g. Knight) are not exercised in these tests; if a
         # caller sets up such an actor they need to extend this helper.
         raise AssertionError(f"unexpected actor role in test: {actor.role.name}")

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -5,13 +5,14 @@ import anthropic
 import pydantic
 import pytest
 
-from src.domain.schema import AgentOutput, JudgmentOutput, PreNightOutput, WolfChatOutput
+from src.domain.schema import AgentOutput, JudgmentOutput, NightActionOutput, PreNightOutput, WolfChatOutput
 from src.domain.roles import get_role
 from src.llm.client import _classify_error, resolve_claim_role
 from tests.conftest import (
     AGENT_OUTPUT_JSON,
     JUDGMENT_CO_OUTPUT_JSON,
     JUDGMENT_OUTPUT_JSON,
+    NIGHT_ACTION_OUTPUT_JSON,
     PRE_NIGHT_CO_OUTPUT_JSON,
     PRE_NIGHT_OUTPUT_JSON,
     WOLF_CHAT_OUTPUT_JSON,
@@ -103,34 +104,83 @@ class TestCallWolfChat:
 
 class TestCallNightAction:
     def test_exact_match(self, make_test_actor):
+        """
+        SUT: LLMClient.call_night_action
+        Mock: anthropic SDK — returns JSON with target matching a candidate exactly
+        Level: unit
+        Objective: exact name match resolves to correct NightActionOutput.target
+        """
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = make_llm_client_with_response("Alice")
+        llm = make_llm_client_with_response(NIGHT_ACTION_OUTPUT_JSON)
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
-        assert result == "Alice"
+        assert isinstance(result, NightActionOutput)
+        assert result.target == "Alice"
+
+    def test_reasoning_is_extracted(self, make_test_actor):
+        """
+        SUT: LLMClient.call_night_action
+        Mock: anthropic SDK — returns JSON with reasoning field
+        Level: unit
+        Objective: reasoning field is preserved in NightActionOutput
+        """
+        actor = make_test_actor("Wolf", "Werewolf")
+        llm = make_llm_client_with_response(NIGHT_ACTION_OUTPUT_JSON)
+        result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
+        assert result.reasoning == "She is the most suspicious."
 
     def test_partial_match(self, make_test_actor):
+        """
+        SUT: LLMClient.call_night_action
+        Mock: anthropic SDK — returns JSON with target embedded in longer string
+        Level: unit
+        Objective: partial name match still resolves to correct target
+        """
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = make_llm_client_with_response("I think Alice is the target")
+        llm = make_llm_client_with_response(
+            json.dumps({"target": "I think Alice", "reasoning": "suspicious"})
+        )
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
-        assert result == "Alice"
+        assert result.target == "Alice"
 
     def test_fallback_to_first_candidate_on_no_match(self, make_test_actor):
+        """
+        SUT: LLMClient.call_night_action
+        Mock: anthropic SDK — returns JSON with unrecognized target
+        Level: unit
+        Objective: falls back to first candidate when target cannot be matched
+        """
         actor = make_test_actor("Wolf", "Werewolf")
-        llm = make_llm_client_with_response("Nobody")
+        llm = make_llm_client_with_response(
+            json.dumps({"target": "Nobody", "reasoning": ""})
+        )
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
-        assert result == "Alice"
+        assert result.target == "Alice"
 
     def test_fallback_to_first_candidate_on_exception(self, make_test_actor):
+        """
+        SUT: LLMClient.call_night_action
+        Mock: anthropic SDK — raises RuntimeError
+        Level: unit
+        Objective: returns empty reasoning and first candidate on API failure
+        """
         actor = make_test_actor("Wolf", "Werewolf")
         llm = make_failing_llm_client()
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
-        assert result == "Alice"
+        assert result.target == "Alice"
+        assert result.reasoning == ""
 
-    def test_returns_empty_string_when_no_prompt(self, make_test_actor):
+    def test_returns_empty_when_no_prompt(self, make_test_actor):
+        """
+        SUT: LLMClient.call_night_action
+        Mock: anthropic SDK — not called (Villager has no night_action_prompt)
+        Level: unit
+        Objective: returns NightActionOutput with empty target when no prompt is generated
+        """
         actor = make_test_actor("Alice", "Villager")
         llm = make_failing_llm_client()
         result = llm.call_night_action(actor, "night context", ["Alice", "Bob"])
-        assert result == ""
+        assert result.target == ""
+        assert result.reasoning == ""
         llm._client.messages.create.assert_not_called()
 
 

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -223,11 +223,12 @@ class TestRunNightPhaseOrder:
         order: list[str] = []
 
         def night_action(actor, _context, _alive_names):
+            from src.domain.schema import NightActionOutput
             order.append(f"declare:{actor.name}")
             if actor.name == "Wolf1":
-                return "Seer1"
+                return NightActionOutput(target="Seer1", reasoning="")
             if actor.name == "Seer1":
-                return "Villager1"
+                return NightActionOutput(target="Villager1", reasoning="")
             raise AssertionError(f"unexpected actor {actor.name}")
 
         engine._llm_client.call_night_action.side_effect = night_action
@@ -262,10 +263,11 @@ class TestRunNightPhaseOrder:
         engine, events = make_test_engine([seer, wolf, target])
 
         def night_action(actor, _context, _alive_names):
+            from src.domain.schema import NightActionOutput
             if actor.name == "Wolf1":
-                return "Seer1"
+                return NightActionOutput(target="Seer1", reasoning="")
             if actor.name == "Seer1":
-                return "Villager1"
+                return NightActionOutput(target="Villager1", reasoning="")
             raise AssertionError(f"unexpected actor {actor.name}")
 
         engine._llm_client.call_night_action.side_effect = night_action
@@ -284,10 +286,11 @@ class TestRunNightPhaseOrder:
         engine, events = make_test_engine([seer, wolf, target])
 
         def night_action(actor, _context, _alive_names):
+            from src.domain.schema import NightActionOutput
             if actor.name == "Wolf1":
-                return "Villager1"
+                return NightActionOutput(target="Villager1", reasoning="")
             if actor.name == "Seer1":
-                return "Wolf1"
+                return NightActionOutput(target="Wolf1", reasoning="")
             raise AssertionError(f"unexpected actor {actor.name}")
 
         engine._llm_client.call_night_action.side_effect = night_action

--- a/tests/unit/test_judgment_schema.py
+++ b/tests/unit/test_judgment_schema.py
@@ -48,3 +48,34 @@ class TestJudgmentOutput:
     def test_claim_role_defaults_to_none(self):
         j = JudgmentOutput(decision="speak")
         assert j.claim_role is None
+
+    def test_reasoning_defaults_to_empty_string(self):
+        """
+        SUT: JudgmentOutput
+        Mock: なし
+        Level: unit
+        Objective: reasoning フィールドが省略されたとき空文字列になること（過去ログ互換）
+        """
+        j = JudgmentOutput(decision="speak")
+        assert j.reasoning == ""
+
+    def test_reasoning_is_preserved(self):
+        """
+        SUT: JudgmentOutput
+        Mock: なし
+        Level: unit
+        Objective: reasoning フィールドが指定されたとき保持されること
+        """
+        j = JudgmentOutput(decision="challenge", reply_to=1, reasoning="Alice looks suspicious.")
+        assert j.reasoning == "Alice looks suspicious."
+
+    def test_parse_from_json_without_reasoning(self):
+        """
+        SUT: JudgmentOutput
+        Mock: なし
+        Level: unit
+        Objective: reasoning を含まない旧フォーマットのJSONでもバリデーションが通ること（後方互換）
+        """
+        j = JudgmentOutput.model_validate_json('{"decision": "silent"}')
+        assert j.decision == "silent"
+        assert j.reasoning == ""

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -256,6 +256,30 @@ class TestPublishNightResults:
         assert not any(e.event_type == EventType.GUARD_BLOCK for e in events)
 
 
+class TestGuardReasoning:
+    def test_guard_reasoning_stored_in_log_event(self, make_test_actor, make_test_engine):
+        """
+        SUT: _publish_night_results
+        Mock: なし
+        Level: unit
+        Objective: GuardDeclaration.reasoning が GUARD LogEvent の reasoning フィールドに渡ること
+        """
+        wolf = make_test_actor("Wolf1", "Werewolf")
+        knight = make_test_actor("Knight1", "Knight")
+        alice = make_test_actor("Alice")
+        engine, events = make_test_engine([wolf, knight, alice])
+
+        attack = AttackDeclaration(actor=wolf, target="Alice")
+        guard = GuardDeclaration(actor=knight, target="Alice", succeeded=False, reasoning="Alice is the Seer candidate.")
+        resolution = NightResolution(attack=attack, guard=guard, inspection=None)
+
+        _publish_night_results(engine, resolution)
+
+        guard_events = [e for e in events if e.event_type == EventType.GUARD]
+        assert len(guard_events) == 1
+        assert guard_events[0].reasoning == "Alice is the Seer candidate."
+
+
 class TestPublishInspection:
     def test_inspect_werewolf_sets_suspicion_max(self, make_test_actor, make_test_engine):
         """
@@ -403,6 +427,26 @@ class TestPublishInspection:
         ev = next(e for e in events if e.event_type == EventType.INSPECTION)
         assert "Werewolf" in ev.content
         assert "<" not in ev.content  # no Python repr like <src.domain.roles.Werewolf object>
+
+    def test_inspect_reasoning_stored_in_log_event(self, make_test_actor, make_test_engine):
+        """
+        SUT: _publish_inspection
+        Mock: store.save — ファイルI/Oを回避
+        Level: unit
+        Objective: InspectDeclaration.reasoning が INSPECTION LogEvent の reasoning フィールドに渡ること
+        """
+        seer = make_test_actor("Seer1", "Seer")
+        villager = make_test_actor("Alice")
+        engine, events = make_test_engine([seer, villager])
+
+        declaration = InspectDeclaration(actor=seer, target="Alice", reasoning="Alice seems evasive.")
+        inspection = InspectionResult(declaration=declaration, result=None)
+
+        with patch("src.engine.phase_night.store.save"):
+            _publish_inspection(engine, inspection)
+
+        ev = next(e for e in events if e.event_type == EventType.INSPECTION)
+        assert ev.reasoning == "Alice seems evasive."
 
     def test_inspect_updates_existing_belief(self, make_test_actor, make_test_engine):
         """


### PR DESCRIPTION
## Summary
- `JudgmentOutput` に `reasoning: str = ""` を追加（後方互換）
- `NightActionOutput` 新スキーマ（`target` + `reasoning`）
- Knight/Seer/Werewolf の `night_action_prompt` を JSON 出力形式に変更
- `call_night_action` の返り値を `str` → `NightActionOutput` に変更
- `LogEvent` に `reasoning: str = ""` フィールドと `JUDGMENT` EventType を追加
- 昼フェーズ: DISCUSSION 判断ごとに `JUDGMENT` イベントを emit、VOTE に reasoning を付与
- 夜フェーズ: Guard/Inspect の `LogEvent` に reasoning を付与
- Renderer: 観戦者モードで VOTE/GUARD/INSPECTION に reasoning を追記表示、JUDGMENT を `[JUDGMENT]` として表示
- `config/tokens.json`: `call_night_action` を 64→256 に更新
- Spec.md / Architecture.md / DetailDesign.md を更新

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（240 tests）
- [ ] `JudgmentOutput.reasoning` フィールドのデフォルト・パース・後方互換テスト追加
- [ ] `call_night_action` が `NightActionOutput` を返し reasoning が取れることをテスト
- [ ] Guard reasoning が `GUARD` LogEvent に渡るテスト追加
- [ ] Inspect reasoning が `INSPECTION` LogEvent に渡るテスト追加
- [ ] 旧テスト（`test_game_day_loop.py`, `test_engine_renderer_contract.py`）を `NightActionOutput` 対応に更新

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)