### PR TITLE
fix: renderer spectator log fixes (#203, #205, #206)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,9 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#203 | bug | ❌ | - | [JUDGMENT] log missing decision field in renderer output | [JUDGMENT] ログに decision が表示されず何を決定したか不明 |
-| yukkie/AgentVillage#205 | bug | ❌ | - | Renderer: reasoning text should be visually dimmed in spectator log | VOTE/GUARD/INSPECTION/JUDGMENT の reasoning が薄い色で表示されない |
-| yukkie/AgentVillage#206 | bug | ❌ | - | GUARD/INSPECTION reasoning not shown in spectator log | 夜フェーズの GUARD/INSPECTION ログに reasoning が表示されない |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#33 | enhancement | 🔴 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,6 +13,7 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
+| yukkie/AgentVillage#210 | bug | ❌ | - | NIGHT_ATTACK: werewolf attack reasoning not passed to LogEvent | 狼が1体のとき wolf chat なしで攻撃するが reasoning が観戦者ログに表示されない |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#33 | enhancement | 🔴 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |

--- a/doc/Spec.md
+++ b/doc/Spec.md
@@ -271,6 +271,7 @@ Rich を使用したカラー表示。
 | 前夜判断ログ・狂人（観戦者のみ） | オレンジ | |
 | 死亡通知 | 赤・太字 | |
 | フェーズ区切り | 黄・太字 | |
+| reasoning テキスト（観戦者ログ） | dim（薄色） | VOTE / GUARD / INSPECTION / JUDGMENT の補足情報。主要情報と同一スパンに混在させない |
 
 **public モードと spectator モードの色の扱い**
 - public モード: `claimed_role` が設定されている場合のみ役職色を適用。未COのエージェントは白

--- a/src/domain/event.py
+++ b/src/domain/event.py
@@ -49,6 +49,7 @@ class LogEvent(BaseModel):
     claimed_role: RoleField = None
     inspection_role: RoleField = None
     reasoning: str = ""
+    decision: str = ""
 
     @classmethod
     def make(
@@ -65,6 +66,7 @@ class LogEvent(BaseModel):
         claimed_role: RoleField = None,
         inspection_role: RoleField = None,
         reasoning: str = "",
+        decision: str = "",
     ) -> "LogEvent":
         return cls(
             day=day,
@@ -79,4 +81,5 @@ class LogEvent(BaseModel):
             claimed_role=claimed_role,
             inspection_role=inspection_role,
             reasoning=reasoning,
+            decision=decision,
         )

--- a/src/engine/phase_day.py
+++ b/src/engine/phase_day.py
@@ -51,6 +51,7 @@ def _run_discussion(engine: GameEngine) -> None:
                     agent=actor.name,
                     content=f"{actor.name} [{judgment.decision}]: {judgment.reasoning}",
                     is_public=False,
+                    decision=judgment.decision,
                     reasoning=judgment.reasoning,
                 ))
             if output is None:

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from src.agent import memory as memory_mod, store
@@ -155,7 +155,7 @@ def _resolve_declared_inspection(
 
     name, result = resolve_inspect(Inspect(target=inspect.target), engine.agents)
     return InspectionResult(
-        declaration=InspectDeclaration(actor=inspect.actor, target=name),
+        declaration=replace(inspect, target=name),
         result=result,
     )
 

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -55,13 +55,14 @@ class Renderer:
             text.append(event.content, style="magenta")
 
         elif event.event_type == EventType.VOTE:
-            vote_text = f"[VOTE] {event.agent} → {event.target}"
+            text.append(f"[VOTE] {event.agent} → {event.target}", style="white")
             if self.spectator_mode and event.reasoning:
-                vote_text += f" — {event.reasoning}"
-            text.append(vote_text, style="white")
+                text.append(f" — {event.reasoning}", style="dim")
 
         elif event.event_type == EventType.JUDGMENT:
-            text.append(f"[JUDGMENT] {event.agent}: {event.reasoning}", style="dim cyan")
+            text.append(f"[JUDGMENT] {event.agent}: {event.decision}", style="cyan")
+            if event.reasoning:
+                text.append(f"\n{event.reasoning}", style="dim")
 
         elif event.event_type == EventType.ELIMINATION:
             text.append(f"\n{event.content}\n", style="bold red")
@@ -77,10 +78,9 @@ class Renderer:
                 text.append(f"[NIGHT] {event.content}", style="red")
 
         elif event.event_type == EventType.GUARD:
-            guard_text = f"[GUARD] {event.content}"
+            text.append(f"[GUARD] {event.content}", style="bright_green")
             if self.spectator_mode and event.reasoning:
-                guard_text += f" — {event.reasoning}"
-            text.append(guard_text, style="bright_green")
+                text.append(f" — {event.reasoning}", style="dim")
 
         elif event.event_type == EventType.INSPECTION:
             self._render_inspection(event, text)
@@ -111,9 +111,9 @@ class Renderer:
             display = f"{event.agent} inspects {event.target}: {result_str}"
         else:
             display = event.content
-        if self.spectator_mode and event.reasoning:
-            display += f" — {event.reasoning}"
         text.append(f"[INSPECT] {display}", style="cyan")
+        if self.spectator_mode and event.reasoning:
+            text.append(f" — {event.reasoning}", style="dim")
 
     def _render_speech(self, event: LogEvent, text: Text) -> None:
         if event.content.startswith("[THINK]"):

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -16,6 +16,7 @@ from src.engine.phase_night import (
     NightResolution,
     _publish_inspection,
     _publish_night_results,
+    _resolve_declared_inspection,
     _resolve_night_outcomes,
     _run_wolf_chat,
 )
@@ -471,3 +472,36 @@ class TestPublishInspection:
 
         assert seer.state.beliefs["Alice"].trust == 1.0
         assert len([e for e in events if e.event_type == EventType.INSPECTION]) == 1
+
+
+class TestResolveDeclaredInspection:
+    def test_reasoning_is_preserved_after_target_resolution(self, make_test_actor, make_test_engine):
+        """
+        SUT: _resolve_declared_inspection
+        Mock: なし
+        Level: unit
+        Objective: dataclasses.replace で target を上書きしても reasoning が失われないこと。
+        """
+        seer = make_test_actor("Seer1", "Seer")
+        villager = make_test_actor("Alice")
+        engine, _ = make_test_engine([seer, villager])
+
+        declaration = InspectDeclaration(actor=seer, target="Alice", reasoning="Alice looks suspicious.")
+        result = _resolve_declared_inspection(engine, declaration)
+
+        assert result is not None
+        assert result.declaration.reasoning == "Alice looks suspicious."
+
+    def test_none_input_returns_none(self, make_test_actor, make_test_engine):
+        """
+        SUT: _resolve_declared_inspection
+        Mock: なし
+        Level: unit
+        Objective: inspect=None のとき None を返すこと。
+        """
+        seer = make_test_actor("Seer1", "Seer")
+        engine, _ = make_test_engine([seer])
+
+        result = _resolve_declared_inspection(engine, None)
+
+        assert result is None

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -176,3 +176,145 @@ def test_game_over_has_header_and_footer(make_test_actor) -> None:
     assert result is not None
     assert "Village wins!" in result.plain
     assert result.plain.count("=" * 50) == 2
+
+
+# ── #203: JUDGMENT decision フィールド ──────────────────────────────────────────
+
+
+def test_judgment_shows_decision_field() -> None:
+    """
+    SUT: Renderer.on_event (JUDGMENT)
+    Mock: なし
+    Level: unit
+    Objective: JUDGMENT イベントの decision フィールドがエージェント名の後に表示されること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.JUDGMENT,
+        agent="Gina",
+        decision="speak",
+        reasoning="情報が少ないため発言する。",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "[JUDGMENT] Gina: speak" in result.plain
+
+
+def test_judgment_reasoning_follows_decision_on_newline() -> None:
+    """
+    SUT: Renderer.on_event (JUDGMENT)
+    Mock: なし
+    Level: unit
+    Objective: reasoning が decision の後に改行で続くこと。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.JUDGMENT,
+        agent="Gina",
+        decision="speak",
+        reasoning="情報が少ないため発言する。",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "[JUDGMENT] Gina: speak\n情報が少ないため発言する。" in result.plain
+
+
+# ── #205: reasoning の dim 表示 ──────────────────────────────────────────────────
+
+
+def test_vote_reasoning_is_dimmed_in_spectator_mode(make_test_actor) -> None:
+    """
+    SUT: Renderer.on_event (VOTE)
+    Mock: なし
+    Level: unit
+    Objective: spectator モードで reasoning が dim スタイルの別 span として追加されること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.VOTE, agent="Alice", target="Bob", reasoning="Bobが怪しい。"
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "Bobが怪しい。" in result.plain
+    dim_spans = [s for s in result.spans if "dim" in str(s.style)]
+    assert len(dim_spans) >= 1
+
+
+def test_guard_reasoning_is_dimmed_in_spectator_mode() -> None:
+    """
+    SUT: Renderer.on_event (GUARD)
+    Mock: なし
+    Level: unit
+    Objective: spectator モードで reasoning が dim スタイルの別 span として追加されること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.GUARD,
+        content="Knight guards Alice",
+        reasoning="Aliceが占い師候補。",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "Aliceが占い師候補。" in result.plain
+    dim_spans = [s for s in result.spans if "dim" in str(s.style)]
+    assert len(dim_spans) >= 1
+
+
+def test_inspection_reasoning_is_dimmed_in_spectator_mode() -> None:
+    """
+    SUT: Renderer._render_inspection
+    Mock: なし
+    Level: unit
+    Objective: spectator モードで reasoning が dim スタイルの別 span として追加されること。
+    """
+    from src.domain.roles import get_role
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.INSPECTION,
+        agent="Seer1",
+        target="Wolf1",
+        inspection_role=get_role("Werewolf"),
+        reasoning="Wolfの行動パターンが一致。",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "Wolfの行動パターンが一致。" in result.plain
+    dim_spans = [s for s in result.spans if "dim" in str(s.style)]
+    assert len(dim_spans) >= 1
+
+
+def test_judgment_reasoning_is_dimmed() -> None:
+    """
+    SUT: Renderer.on_event (JUDGMENT)
+    Mock: なし
+    Level: unit
+    Objective: reasoning が dim スタイルの別 span として追加されること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.JUDGMENT,
+        agent="Gina",
+        decision="silent",
+        reasoning="今は静観が最善。",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    dim_spans = [s for s in result.spans if "dim" in str(s.style)]
+    assert len(dim_spans) >= 1


### PR DESCRIPTION
## Summary
- **#203**: `LogEvent` に `decision` フィールドを追加し、`[JUDGMENT] Gina: speak` のように decision 値を表示するよう修正
- **#205**: VOTE / GUARD / INSPECTION / JUDGMENT の reasoning を `"dim"` スタイルの別 span で描画し、主要情報と視覚的に区別
- **#206**: `_resolve_declared_inspection` が `dataclasses.replace` で既存の `InspectDeclaration` をコピーするよう修正し、INSPECTION reasoning の欠落を解消

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` 248テスト全パス
- [ ] `[JUDGMENT]` ログに `decision` 値が表示される
- [ ] VOTE / GUARD / INSPECTION / JUDGMENT の reasoning が dim（薄色）で表示される
- [ ] 観戦者ログの `[INSPECT]` に reasoning が表示される
- [ ] `_resolve_declared_inspection` の reasoning 保持を検証するユニットテスト追加

Closes #203, #205, #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)