### PR TITLE
fix: pass NIGHT_ATTACK reasoning to LogEvent (#210)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#210 | bug | ❌ | - | NIGHT_ATTACK: werewolf attack reasoning not passed to LogEvent | 狼が1体のとき wolf chat なしで攻撃するが reasoning が観戦者ログに表示されない |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#33 | enhancement | 🔴 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 class AttackDeclaration:
     actor: Actor
     target: str
+    reasoning: str = ""
 
 
 @dataclass
@@ -104,7 +105,9 @@ def _run_wolf_chat(engine: GameEngine) -> str | None:
     return None
 
 
-def _resolve_fallback_attack(engine: GameEngine, alive_names: list[str]) -> str | None:
+def _resolve_fallback_attack(
+    engine: GameEngine, alive_names: list[str]
+) -> tuple[str, str] | None:
     night_context = f"Day {engine.day} night. Alive: {', '.join(alive_names)}"
     for actor in engine._alive_agents():
         if not isinstance(actor.role, Werewolf):
@@ -112,7 +115,7 @@ def _resolve_fallback_attack(engine: GameEngine, alive_names: list[str]) -> str 
         result = engine._llm_client.call_night_action(actor, night_context, alive_names)
         attack = Attack(target=result.target)
         if engine._validate_action(attack, actor, alive_names):
-            return resolve_attack(attack, engine.agents)
+            return resolve_attack(attack, engine.agents), result.reasoning
     return None
 
 
@@ -120,14 +123,17 @@ def _declare_night_actions(
     engine: GameEngine, alive_names: list[str], night_context: str
 ) -> NightDeclarations:
     attack_target = _run_wolf_chat(engine)
+    fallback_reasoning = ""
 
     if attack_target is None:
-        attack_target = _resolve_fallback_attack(engine, alive_names)
+        fallback = _resolve_fallback_attack(engine, alive_names)
+        if fallback is not None:
+            attack_target, fallback_reasoning = fallback
 
     wolves = [a for a in engine._alive_agents() if isinstance(a.role, Werewolf)]
     attack: AttackDeclaration | None = None
     if attack_target and wolves:
-        attack = AttackDeclaration(actor=wolves[0], target=attack_target)
+        attack = AttackDeclaration(actor=wolves[0], target=attack_target, reasoning=fallback_reasoning)
 
     guard: GuardDeclaration | None = None
     inspect: InspectDeclaration | None = None
@@ -235,6 +241,7 @@ def _publish_night_results(engine: GameEngine, resolution: NightResolution) -> N
             target=resolution.attack.target,
             content=f"Werewolves attack {resolution.attack.target}",
             is_public=False,
+            reasoning=resolution.attack.reasoning,
         ))
 
     if (

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -76,6 +76,8 @@ class Renderer:
                 )
             else:
                 text.append(f"[NIGHT] {event.content}", style="red")
+            if self.spectator_mode and event.reasoning:
+                text.append(f" — {event.reasoning}", style="dim")
 
         elif event.event_type == EventType.GUARD:
             text.append(f"[GUARD] {event.content}", style="bright_green")

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -256,6 +256,26 @@ class TestPublishNightResults:
 
         assert not any(e.event_type == EventType.GUARD_BLOCK for e in events)
 
+    def test_attack_reasoning_stored_in_night_attack_log_event(self, make_test_actor, make_test_engine):
+        """
+        SUT: _publish_night_results
+        Mock: なし
+        Level: unit
+        Objective: AttackDeclaration.reasoning が NIGHT_ATTACK LogEvent の reasoning フィールドに渡ること
+        """
+        wolf = make_test_actor("Wolf1", "Werewolf")
+        alice = make_test_actor("Alice")
+        engine, events = make_test_engine([wolf, alice])
+
+        attack = AttackDeclaration(actor=wolf, target="Alice", reasoning="Alice is likely the Seer.")
+        resolution = NightResolution(attack=attack, guard=None, inspection=None)
+
+        _publish_night_results(engine, resolution)
+
+        attack_events = [e for e in events if e.event_type == EventType.NIGHT_ATTACK]
+        assert len(attack_events) == 1
+        assert attack_events[0].reasoning == "Alice is likely the Seer."
+
 
 class TestGuardReasoning:
     def test_guard_reasoning_stored_in_log_event(self, make_test_actor, make_test_engine):


### PR DESCRIPTION
## Summary
- `AttackDeclaration` に `reasoning: str = ""` フィールドを追加
- `_resolve_fallback_attack` が `(target, reasoning)` タプルを返すよう変更し、`_declare_night_actions` で `AttackDeclaration.reasoning` に保存
- `_publish_night_results` の NIGHT_ATTACK LogEvent に `reasoning` を渡すよう修正
- Renderer の `NIGHT_ATTACK` ブロックで観戦者モード時に reasoning を dim スタイルで表示

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（249 passed）
- [ ] `AttackDeclaration.reasoning` が NIGHT_ATTACK LogEvent に渡ることを検証するユニットテスト追加

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)