### PR TITLE
feat: add wolf-aware vote strategy option (#212)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#207 | tech-debt | ❌ | 2 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
-| yukkie/AgentVillage#212 | enhancement | ❌ | - | Werewolf vote with wolf-aware strategy option | 狼が昼投票時に村人として振る舞うか狼有利に投票するか選択できるようにする |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#33 | enhancement | 🔴 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |

--- a/doc/Spec.md
+++ b/doc/Spec.md
@@ -135,16 +135,28 @@ LLMの出力は必ずJSONで受け取る。フェーズによって2種類のフ
 {
   "thought": "SQは昨日の票替えが不自然。おそらく人狼。",
   "speech": "今日はSQを疑っています。昨日の票替えが不自然でした。",
+  "reasoning": "SQの票替えとタイミングから人狼濃厚と判断。",
   "intent": {
     "vote_candidates": [
       {"target": "SQ", "score": 0.74},
       {"target": "Raqio", "score": 0.42}
     ],
-    "co": null
+    "co": null,
+    "strategy": "wolf_side"
   },
   "memory_update": ["SQの票替えを黒要素として維持"]
 }
 ```
+
+| フィールド | 型 | 内容 |
+|---|---|---|
+| `intent.vote_candidates` | `list` | 投票候補（target と score のリスト）。`_run_vote` が最高スコアの生存者を投票先に選ぶ |
+| `intent.co` | `str \| null` | 公言する役職（CO 時のみ） |
+| `intent.strategy` | `"village_side" \| "wolf_side" \| null` | **狼のみ**設定。`village_side` は村人として自然な投票（仲間への投票も許容、ライン切り戦略を含む）／ `wolf_side` は狼として有利な投票先（村側キーマンを狙う等）。村人陣営は常に `null` |
+
+> **Note**: `strategy` は #212 で発話プロンプト経由の暫定実装として導入された。
+> #216 で投票専用 LLM 呼び出し `call_vote` を実装する際、`vote_candidates` の廃止と
+> 併せて新スキーマ `VoteOutput` に移行する予定。
 
 #### (C) 前夜判断フォーマット（前夜フェーズ専用・村人以外）
 

--- a/src/domain/roles/werewolf.py
+++ b/src/domain/roles/werewolf.py
@@ -37,6 +37,16 @@ class Werewolf(Role):
             base += f"\nYour wolf partner(s): {', '.join(wolf_partners)}. Keep this secret."
         else:
             base += "\nYou are the last surviving Werewolf. You must act alone."
+        base += (
+            "\n\n--- VOTE STRATEGY ---\n"
+            "When you set vote_candidates, also pick a vote strategy in intent.strategy:\n"
+            '- "village_side": vote like a Villager would. You may even vote for a wolf partner '
+            "if it builds trust (the \"line-cutting\" play). Use this when you need to look innocent.\n"
+            '- "wolf_side": vote to advance the werewolf win condition. Target key village roles '
+            "(claimed Seer, Medium, Knight) or pile votes on a confirmed villager. "
+            "Be aware: an obviously wolf-aligned vote can draw suspicion from the village, "
+            "so use this only when the gain outweighs that risk."
+        )
         return base
 
     def co_prompt(self) -> str:
@@ -77,3 +87,40 @@ class Werewolf(Role):
             "village role with a fake CO can shape the board early. Fake Seer is the most common "
             "default, but adapt your claimed role to the current role distribution and existing claims."
         )
+
+    def output_format_prompt(self, lang: str = "English") -> str:
+        """Werewolf-specific output format including vote strategy field.
+
+        Adds intent.strategy on top of the shared speech schema.
+        See VOTE STRATEGY block in role_prompt() for usage.
+        """
+        return f"""
+--- OUTPUT FORMAT ---
+You MUST respond with ONLY valid JSON matching this exact schema. No other text.
+
+{{
+  "thought": "<your internal reasoning, hidden from others>",
+  "speech": "<what you say aloud to the group>",
+  "reasoning": "<your public deduction: who you suspect and why>",
+  "intent": {{
+    "vote_candidates": [
+      {{"target": "<player_name>", "score": <0.0-1.0>}},
+      ...
+    ],
+    "co": "<role_name or null>",
+    "strategy": "village_side" | "wolf_side"
+  }},
+  "memory_update": ["<key thing to remember for future turns>", ...]
+}}
+
+Rules:
+- "thought", "speech", "reasoning", "memory_update" must be written in {lang}
+- "thought" is your private inner monologue
+- "speech" is your actual spoken words (1-3 sentences)
+- "reasoning" is your public deduction statement (1-2 sentences)
+- "intent.vote_candidates" lists who you'd vote to eliminate (highest score = most suspect)
+- "intent.co" is your role claim if you choose to reveal it, otherwise null
+- "intent.strategy" is "village_side" or "wolf_side" (always English, see VOTE STRATEGY above)
+- "memory_update" lists 0-3 key observations to remember
+- Do NOT include your real role in speech unless you are doing a CO
+"""

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -72,6 +72,10 @@ class VoteCandidate(BaseModel):
 class Intent(BaseModel):
     vote_candidates: list[VoteCandidate] = []
     co: RoleField = None
+    # TODO(#216): Werewolf-only field below leaks into the village-side schema.
+    # When the dedicated VOTE phase prompt replaces vote_candidates, move this
+    # into a separate VoteOutput schema scoped to wolves.
+    strategy: Literal["village_side", "wolf_side"] | None = None
 
 
 class AgentOutput(BaseModel):

--- a/src/engine/phase_day.py
+++ b/src/engine/phase_day.py
@@ -104,6 +104,7 @@ def _run_vote(engine: GameEngine) -> str | None:
             if engine._validate_action(vote_action, actor, alive_names):
                 votes[actor.name] = target
                 vote_reasoning = output.reasoning if output else ""
+                strategy = output.intent.strategy if output and output.intent.strategy else ""
                 engine._emit(LogEvent.make(
                     day=engine.day,
                     phase=Phase.DAY_VOTE.value,
@@ -113,6 +114,7 @@ def _run_vote(engine: GameEngine) -> str | None:
                     content=f"{actor.name} votes for {target}",
                     is_public=True,
                     reasoning=vote_reasoning,
+                    decision=strategy,
                 ))
 
     if not votes:

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -56,6 +56,8 @@ class Renderer:
 
         elif event.event_type == EventType.VOTE:
             text.append(f"[VOTE] {event.agent} → {event.target}", style="white")
+            if self.spectator_mode and event.decision:
+                text.append(f" [strategy: {event.decision}]", style="dim red")
             if self.spectator_mode and event.reasoning:
                 text.append(f" — {event.reasoning}", style="dim")
 

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -215,6 +215,119 @@ class TestDiscussionCoDecision:
         assert wolf.state.claimed_role.name == "Medium"
 
 
+class TestVoteStrategyLogged:
+    """#212 — wolf strategy in Intent flows into VOTE LogEvent."""
+
+    def test_wolf_side_strategy_recorded_in_vote_event(self, make_test_actor, make_test_engine):
+        """
+        SUT: _run_vote
+        Mock: call_speech_parallel / call_discussion_parallel
+        Level: unit
+        Objective: 狼が intent.strategy="wolf_side" を返したとき、その値が VOTE LogEvent の decision に記録されること。
+        """
+        wolf = make_test_actor("Wolf1", "Werewolf")
+        seer = make_test_actor("Seer1", "Seer")
+        engine, events = make_test_engine([wolf, seer])
+
+        wolf_output = AgentOutput(
+            thought="t",
+            speech="s",
+            reasoning="Seer1 should be eliminated.",
+            intent=Intent(
+                vote_candidates=[{"target": "Seer1", "score": 0.9}],
+                strategy="wolf_side",
+            ),
+            memory_update=[],
+        )
+        seer_output = make_agent_output("Seer1")
+
+        def speech_side_effect(calls):
+            outputs = {"Wolf1": wolf_output, "Seer1": seer_output}
+            return iter([(a, outputs[a.name]) for a, *_ in calls])
+
+        engine._llm_client.call_speech_parallel.side_effect = speech_side_effect
+        engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        vote_events = [e for e in events if e.event_type == EventType.VOTE and e.agent == "Wolf1"]
+        assert len(vote_events) == 1
+        assert vote_events[0].decision == "wolf_side"
+        assert vote_events[0].reasoning == "Seer1 should be eliminated."
+        assert vote_events[0].target == "Seer1"
+
+    def test_villager_vote_has_no_strategy(self, make_test_actor, make_test_engine):
+        """
+        SUT: _run_vote
+        Mock: call_speech_parallel / call_discussion_parallel
+        Level: unit
+        Objective: 村人エージェントの VOTE LogEvent には strategy（decision）が空文字で入ること（村人プロンプトは strategy を出力しない）。
+        """
+        villager = make_test_actor("V1", "Villager")
+        target = make_test_actor("V2", "Villager")
+        engine, events = make_test_engine([villager, target])
+
+        v_output = AgentOutput(
+            thought="t",
+            speech="s",
+            reasoning="suspicion",
+            intent=Intent(vote_candidates=[{"target": "V2", "score": 0.5}]),
+            memory_update=[],
+        )
+
+        def speech_side_effect(calls):
+            return iter([(a, v_output) for a, *_ in calls])
+
+        engine._llm_client.call_speech_parallel.side_effect = speech_side_effect
+        engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        vote_events = [e for e in events if e.event_type == EventType.VOTE and e.agent == "V1"]
+        assert len(vote_events) == 1
+        assert vote_events[0].decision == ""
+
+    def test_village_side_allows_voting_for_wolf_partner(self, make_test_actor, make_test_engine):
+        """
+        SUT: _run_vote
+        Mock: call_speech_parallel / call_discussion_parallel
+        Level: unit
+        Objective: 狼が intent.strategy="village_side" で仲間（別の狼）を投票先に指定したとき、そのままその仲間に投票できること（ライン切り戦略）。
+        """
+        wolf1 = make_test_actor("Wolf1", "Werewolf")
+        wolf2 = make_test_actor("Wolf2", "Werewolf")
+        engine, events = make_test_engine([wolf1, wolf2])
+
+        wolf1_output = AgentOutput(
+            thought="line cut",
+            speech="s",
+            reasoning="line-cutting",
+            intent=Intent(
+                vote_candidates=[{"target": "Wolf2", "score": 0.8}],
+                strategy="village_side",
+            ),
+            memory_update=[],
+        )
+        wolf2_output = make_agent_output("Wolf2")
+
+        def speech_side_effect(calls):
+            outputs = {"Wolf1": wolf1_output, "Wolf2": wolf2_output}
+            return iter([(a, outputs[a.name]) for a, *_ in calls])
+
+        engine._llm_client.call_speech_parallel.side_effect = speech_side_effect
+        engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        wolf1_votes = [e for e in events if e.event_type == EventType.VOTE and e.agent == "Wolf1"]
+        assert len(wolf1_votes) == 1
+        assert wolf1_votes[0].target == "Wolf2"
+        assert wolf1_votes[0].decision == "village_side"
+
+
 class TestRunNightPhaseOrder:
     def test_declarations_finish_before_resolution(self, make_test_actor, make_test_engine):
         seer = make_test_actor("Seer1", "Seer")

--- a/tests/unit/test_role.py
+++ b/tests/unit/test_role.py
@@ -67,6 +67,32 @@ class TestRolePrompt:
         result = get_role("Werewolf").role_prompt(wolf_partners=["Alice"])
         assert "Alice" in result
 
+    def test_werewolf_includes_vote_strategy(self):
+        """
+        SUT: Werewolf.role_prompt
+        Mock: なし
+        Level: unit
+        Objective: 狼の役職プロンプトに village_side / wolf_side の戦略指示が含まれること（#212）。
+        """
+        result = get_role("Werewolf").role_prompt(wolf_partners=["Alice"])
+        assert "VOTE STRATEGY" in result
+        assert "village_side" in result
+        assert "wolf_side" in result
+        assert "line-cutting" in result  # village_side で仲間投票も許容する旨
+        assert "suspicion" in result  # wolf_side のリスク説明
+
+    def test_villager_does_not_include_vote_strategy(self):
+        """
+        SUT: Villager.role_prompt
+        Mock: なし
+        Level: unit
+        Objective: 村人の役職プロンプトに狼用の vote strategy 指示が含まれないこと（AC: 村人プロンプト不変）。
+        """
+        result = get_role("Villager").role_prompt()
+        assert "VOTE STRATEGY" not in result
+        assert "village_side" not in result
+        assert "wolf_side" not in result
+
     def test_werewolf_last_surviving(self):
         result = get_role("Werewolf").role_prompt(wolf_partners=[])
         assert "last surviving Werewolf" in result
@@ -157,6 +183,29 @@ class TestOutputFormatPrompt:
     def test_lang_is_injected(self):
         result = get_role("Villager").output_format_prompt(lang="Japanese")
         assert "Japanese" in result
+
+    def test_werewolf_output_format_includes_strategy_field(self):
+        """
+        SUT: Werewolf.output_format_prompt
+        Mock: なし
+        Level: unit
+        Objective: 狼の output_format に intent.strategy フィールドの案内が含まれること（#212）。
+        """
+        result = get_role("Werewolf").output_format_prompt()
+        assert "strategy" in result
+        assert "village_side" in result
+        assert "wolf_side" in result
+
+    def test_villager_output_format_excludes_strategy_field(self):
+        """
+        SUT: Villager.output_format_prompt
+        Mock: なし
+        Level: unit
+        Objective: 村人の output_format には狼用 strategy フィールドが含まれないこと（AC: 村人プロンプト不変）。
+        """
+        result = get_role("Villager").output_format_prompt()
+        assert "strategy" not in result
+        assert "village_side" not in result
 
     def test_returns_json_schema_instruction(self):
         result = get_role("Seer").output_format_prompt()

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -248,6 +248,52 @@ def test_vote_reasoning_is_dimmed_in_spectator_mode(make_test_actor) -> None:
     assert len(dim_spans) >= 1
 
 
+def test_vote_strategy_shown_in_spectator_mode() -> None:
+    """
+    SUT: Renderer.on_event (VOTE)
+    Mock: なし
+    Level: unit
+    Objective: spectator モードで decision (strategy) が VOTE イベントに表示されること（#212）。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.VOTE,
+        agent="Wolf1",
+        target="Seer1",
+        reasoning="Seer は処刑したい。",
+        decision="wolf_side",
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "wolf_side" in result.plain
+    assert "[VOTE] Wolf1 → Seer1" in result.plain
+
+
+def test_vote_strategy_hidden_in_public_mode() -> None:
+    """
+    SUT: Renderer.on_event (VOTE)
+    Mock: なし
+    Level: unit
+    Objective: public モードでは strategy（decision）が露出しないこと（観戦者専用情報）。
+    """
+    renderer = Renderer([], spectator_mode=False)
+    event = _make_event(
+        EventType.VOTE,
+        agent="Wolf1",
+        target="Seer1",
+        reasoning="Seer は処刑したい。",
+        decision="wolf_side",
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "wolf_side" not in result.plain
+    assert "Seer は処刑したい。" not in result.plain
+
+
 def test_guard_reasoning_is_dimmed_in_spectator_mode() -> None:
     """
     SUT: Renderer.on_event (GUARD)


### PR DESCRIPTION
## Summary
- 狼の役職プロンプトに `village_side` / `wolf_side` の投票戦略選択を指示
- `Intent` スキーマに `strategy: Literal["village_side", "wolf_side"] | None` を追加
- `Werewolf.output_format_prompt` をオーバーライドし、狼のみ JSON 出力に `intent.strategy` を含める
- `_run_vote` で `output.intent.strategy` を VOTE LogEvent の `decision` フィールドに記録
- Spectator モードの Renderer で `[VOTE] X → Y [strategy: wolf_side]` のように strategy を表示
- 村人エージェントの発話プロンプト・出力フォーマットは変更なし

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（258 tests）
- [x] 狼の役職プロンプトに VOTE STRATEGY 指示が含まれる（test_werewolf_includes_vote_strategy）
- [x] 村人プロンプトには strategy 関連指示が含まれない（test_villager_does_not_include_vote_strategy）
- [x] 狼の output_format_prompt に strategy フィールドが含まれる
- [x] 村人の output_format_prompt には strategy フィールドが含まれない
- [x] VOTE LogEvent の decision に strategy が記録される（TestVoteStrategyLogged）
- [x] village_side で狼仲間への投票が許容される（ライン切り戦略）
- [x] Spectator モードで strategy が表示され、Public モードでは隠れる

## Notes
- `Intent.strategy` は狼専用フィールドだが現状村人陣営の Intent にも存在する。これは
  暫定実装で、`vote_candidates` 廃止と投票専用 LLM 呼び出しへの移行を行う #216 で
  `VoteOutput` に切り出される予定。`src/domain/schema.py` に `TODO(#216)` コメント記載済み。

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)