### PR TITLE
feat: dedicated VOTE phase prompt with VoteOutput schema

### DIFF
--- a/config/tokens.json
+++ b/config/tokens.json
@@ -1,6 +1,7 @@
 {
   "call_speech": 2048,
   "call_judgment": 1024,
+  "call_vote": 512,
   "call_pre_night_action": 1024,
   "call_wolf_chat": 2048,
   "call_night_action": 256

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -160,10 +160,12 @@ CO には2種類のフォールバックがある。
 |---|---|---|---|
 | `call()` | 発言生成（OPENING / DISCUSSION） | フル（役職・性格・記憶・当日ログ・他者のCO情報・狼仲間（狼のみ）） | `AgentOutput` |
 | `call_judgment()` | 判断（DISCUSSION 並列） | 軽量（役職・性格・memory_summary・直近発言のみ） | `JudgmentOutput` (`claim_role` を含む) |
+| `call_vote()` | 投票（VOTE フェーズ専用） | 役職・性格・当日議論ログ・past_votes・past_deaths・最終 vote_candidates・狼仲間／VOTE STRATEGY（狼のみ） | `VoteOutput` (`target` + `reasoning` + `strategy`) |
 | `call_night_action()` | 夜行動 | 夜フェーズ専用 | `NightActionOutput` (`target` + `reasoning`) |
 | `call_pre_night_action()` | 前夜判断・単体呼び出し | 役職・性格・参加者情報 | `PreNightOutput` (`claim_role` を含む) |
 | `call_pre_night_parallel()` | 前夜判断・並列呼び出し（`call_speech_parallel` と同パターン） | 同上 | `Iterator[tuple[Actor, PreNightOutput]]` |
 | `call_discussion_parallel()` | 昼DISCUSSION 判断→発言チェーンの並列実行 | — | `Iterator[tuple[Actor, JudgmentOutput, AgentOutput \| None, SpeechEntry \| None]]` |
+| `call_vote_parallel()` | 昼VOTE 投票判断の並列実行 | — | `Iterator[tuple[Actor, VoteOutput]]` |
 
 #### 並列実行
 
@@ -174,6 +176,7 @@ CO には2種類のフォールバックがある。
 | `call_speech_parallel()` | DAY_OPENING — 全員発言を並列実行 |
 | `call_pre_night_parallel()` | PRE_NIGHT — CO判断を並列実行 |
 | `call_discussion_parallel()` | DAY_DISCUSSION — 判断→発言チェーンを並列実行 |
+| `call_vote_parallel()` | DAY_VOTE — 全員の投票判断を並列実行 |
 
 #### Extended thinking
 

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -209,6 +209,12 @@ class JudgmentOutput(BaseModel):
 class NightActionOutput(BaseModel):
     target: str           # validated alive player name
     reasoning: str = ""   # why this target was chosen (spectator-only)
+
+
+class VoteOutput(BaseModel):
+    target: str           # vote target (alive player, not self)
+    reasoning: str = ""   # why this target was chosen (spectator-only)
+    strategy: Literal["village_side", "wolf_side"] | None = None  # Werewolf-only
 ```
 
 - `claim_role` は `decision="co"` のときに名乗る予定の役職
@@ -221,9 +227,32 @@ class NightActionOutput(BaseModel):
 |---|---|---|---|
 | `call()` | 昼フェーズの発言生成（OPENING / DISCUSSION） | 2048 | thought が日本語で長くなりやすい |
 | `call_judgment()` | 昼フェーズの並列判断（challenge / speak / silent / co） | 1024 | `decision`, `reply_to`, `claim_role` の軽量JSON。`co_eligible=True` のときのみ `"co"` を選択肢に含める |
+| `call_vote()` | 昼フェーズの投票判断（VOTE） | 512 | `target` + `reasoning` + `strategy`（狼のみ）。reasoning が日本語で多少長くなることを見込む |
 | `call_wolf_chat()` | 夜フェーズの狼チーム会話 | 2048 | thought + speech + vote_candidates。日本語で長くなりやすい |
 | `call_pre_night_action()` | 前夜フェーズの CO 判断（村人以外） | 1024 | thought + decision + claim_role + reasoning の4フィールド |
 | `call_night_action()` | 夜フェーズの個別行動（襲撃・占い・護衛） | 256 | `NightActionOutput` (target + reasoning) |
+
+### build_vote_prompt — VOTE フェーズ専用プロンプト
+
+`call_vote` は OPENING/DISCUSSION の `call()` とは独立した軽量プロンプトを使う。
+最終投票判断に必要な情報だけを集約し、発話用の役職・性格・カラーリング指示は含めない。
+
+含める要素:
+- 役職名 + 自分の名前（一人称）
+- 当日の議論ログ全体（`today_log`）
+- `past_votes`（過去日の投票結果）
+- `past_deaths`（過去日の死亡情報）
+- 自分が発話フェーズで蓄積した最終 `vote_candidates`（投票意向のヒント）
+- 投票候補（自分以外の生存者一覧）
+- 狼の場合のみ: 仲間情報 + VOTE STRATEGY 指示（`village_side` / `wolf_side`）
+
+`vote_strategy_prompt()` を `Role` 基底に追加し、`Werewolf` のみオーバーライドする。
+村人陣営は空文字を返すため、プロンプト本文に追加で何も挿入されない。
+
+出力フォーマット:
+```json
+{ "target": "<player>", "reasoning": "<one short paragraph>", "strategy": "village_side" | "wolf_side" | null }
+```
 
 ### claim_role 解決フロー
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#207 | tech-debt | ❌ | 2 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
-| yukkie/AgentVillage#216 | enhancement / tech-debt | ❌ | - | Replace vote_candidates with dedicated VOTE phase prompt | 投票フェーズを専用 LLM 呼び出しに置き換え、発話フェーズの最終 vote_candidates を VOTE プロンプトへの入力として渡す |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#33 | enhancement | 🔴 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |

--- a/doc/Spec.md
+++ b/doc/Spec.md
@@ -76,7 +76,10 @@ LLMエージェント同士が自律的に人狼ゲームをプレイする社�
           co の場合、発言生成プロンプトに役職公言の指示が追加され、発言後に
           claimed_role が更新される
   3. 投票（VOTE）
-       各エージェントが投票先を宣言
+       各エージェントに投票専用の LLM 呼び出し（call_vote）を行う
+       投票プロンプトには議論ログ全体・past_votes・past_deaths・発言フェーズ
+       で蓄積された最終 vote_candidates・狼の場合は仲間情報＋VOTE STRATEGY を含む
+       LLM が返す VoteOutput.target を投票先として採用
        システムが多数決を集計 → 最多得票者を追放
   4. 霊媒結果の解決
        霊媒師が生存している場合、処刑直後に処刑者の真の役職を霊媒師へ通知する
@@ -150,13 +153,24 @@ LLMの出力は必ずJSONで受け取る。フェーズによって2種類のフ
 
 | フィールド | 型 | 内容 |
 |---|---|---|
-| `intent.vote_candidates` | `list` | 投票候補（target と score のリスト）。`_run_vote` が最高スコアの生存者を投票先に選ぶ |
+| `intent.vote_candidates` | `list` | 投票意向のヒント（target と score のリスト）。VOTE フェーズの専用 LLM 呼び出しへの入力として渡される |
 | `intent.co` | `str \| null` | 公言する役職（CO 時のみ） |
-| `intent.strategy` | `"village_side" \| "wolf_side" \| null` | **狼のみ**設定。`village_side` は村人として自然な投票（仲間への投票も許容、ライン切り戦略を含む）／ `wolf_side` は狼として有利な投票先（村側キーマンを狙う等）。村人陣営は常に `null` |
 
-> **Note**: `strategy` は #212 で発話プロンプト経由の暫定実装として導入された。
-> #216 で投票専用 LLM 呼び出し `call_vote` を実装する際、`vote_candidates` の廃止と
-> 併せて新スキーマ `VoteOutput` に移行する予定。
+#### (D) 投票フォーマット（VOTE フェーズ専用）
+
+```json
+{
+  "target": "SQ",
+  "reasoning": "DISCUSSION での占い結果と票の不自然さから SQ が最も人狼濃厚と判断した。",
+  "strategy": "wolf_side"
+}
+```
+
+| フィールド | 型 | 内容 |
+|---|---|---|
+| `target` | `str` | 投票先（生存者、自分自身を除く） |
+| `reasoning` | `str` | 投票理由（観戦者向け）。VOTE LogEvent の `reasoning` に格納 |
+| `strategy` | `"village_side" \| "wolf_side" \| null` | **狼のみ**設定。`village_side` は村人として自然な投票（仲間への投票も許容、ライン切り戦略を含む）／ `wolf_side` は狼として有利な投票先。村人陣営は常に `null` |
 
 #### (C) 前夜判断フォーマット（前夜フェーズ専用・村人以外）
 

--- a/src/domain/roles/role.py
+++ b/src/domain/roles/role.py
@@ -48,6 +48,14 @@ class Role(ABC):
     @abstractmethod
     def co_strategy_hint(self) -> str: ...
 
+    def vote_strategy_prompt(self) -> str:
+        """Role-specific guidance appended to the VOTE-phase prompt.
+
+        Default: empty (village-side roles need no extra strategy hint).
+        Override on Werewolf to inject the village_side / wolf_side choice.
+        """
+        return ""
+
     def output_format_prompt(self, lang: str = "English") -> str:
         """Instruct LLM to output structured JSON for the speech phase.
 

--- a/src/domain/roles/werewolf.py
+++ b/src/domain/roles/werewolf.py
@@ -37,16 +37,6 @@ class Werewolf(Role):
             base += f"\nYour wolf partner(s): {', '.join(wolf_partners)}. Keep this secret."
         else:
             base += "\nYou are the last surviving Werewolf. You must act alone."
-        base += (
-            "\n\n--- VOTE STRATEGY ---\n"
-            "When you set vote_candidates, also pick a vote strategy in intent.strategy:\n"
-            '- "village_side": vote like a Villager would. You may even vote for a wolf partner '
-            "if it builds trust (the \"line-cutting\" play). Use this when you need to look innocent.\n"
-            '- "wolf_side": vote to advance the werewolf win condition. Target key village roles '
-            "(claimed Seer, Medium, Knight) or pile votes on a confirmed villager. "
-            "Be aware: an obviously wolf-aligned vote can draw suspicion from the village, "
-            "so use this only when the gain outweighs that risk."
-        )
         return base
 
     def co_prompt(self) -> str:
@@ -88,39 +78,14 @@ class Werewolf(Role):
             "default, but adapt your claimed role to the current role distribution and existing claims."
         )
 
-    def output_format_prompt(self, lang: str = "English") -> str:
-        """Werewolf-specific output format including vote strategy field.
-
-        Adds intent.strategy on top of the shared speech schema.
-        See VOTE STRATEGY block in role_prompt() for usage.
-        """
-        return f"""
---- OUTPUT FORMAT ---
-You MUST respond with ONLY valid JSON matching this exact schema. No other text.
-
-{{
-  "thought": "<your internal reasoning, hidden from others>",
-  "speech": "<what you say aloud to the group>",
-  "reasoning": "<your public deduction: who you suspect and why>",
-  "intent": {{
-    "vote_candidates": [
-      {{"target": "<player_name>", "score": <0.0-1.0>}},
-      ...
-    ],
-    "co": "<role_name or null>",
-    "strategy": "village_side" | "wolf_side"
-  }},
-  "memory_update": ["<key thing to remember for future turns>", ...]
-}}
-
-Rules:
-- "thought", "speech", "reasoning", "memory_update" must be written in {lang}
-- "thought" is your private inner monologue
-- "speech" is your actual spoken words (1-3 sentences)
-- "reasoning" is your public deduction statement (1-2 sentences)
-- "intent.vote_candidates" lists who you'd vote to eliminate (highest score = most suspect)
-- "intent.co" is your role claim if you choose to reveal it, otherwise null
-- "intent.strategy" is "village_side" or "wolf_side" (always English, see VOTE STRATEGY above)
-- "memory_update" lists 0-3 key observations to remember
-- Do NOT include your real role in speech unless you are doing a CO
-"""
+    def vote_strategy_prompt(self) -> str:
+        return (
+            "\n--- VOTE STRATEGY ---\n"
+            "Pick a vote strategy and set it in the \"strategy\" field of your JSON output:\n"
+            '- "village_side": vote like a Villager would. You may even vote for a wolf partner '
+            'if it builds trust (the "line-cutting" play). Use this when you need to look innocent.\n'
+            '- "wolf_side": vote to advance the werewolf win condition. Target key village roles '
+            "(claimed Seer, Medium, Knight) or pile votes on a confirmed villager. "
+            "Be aware: an obviously wolf-aligned vote can draw suspicion from the village, "
+            "so use this only when the gain outweighs that risk."
+        )

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -72,9 +72,23 @@ class VoteCandidate(BaseModel):
 class Intent(BaseModel):
     vote_candidates: list[VoteCandidate] = []
     co: RoleField = None
-    # TODO(#216): Werewolf-only field below leaks into the village-side schema.
-    # When the dedicated VOTE phase prompt replaces vote_candidates, move this
-    # into a separate VoteOutput schema scoped to wolves.
+
+
+class VoteOutput(BaseModel):
+    """LLM response schema for the dedicated VOTE phase prompt.
+
+    The ``strategy`` field is only populated by Werewolf actors; village-side
+    actors leave it ``None``. Kept on the shared schema for simplicity — if
+    the field is mis-emitted by the wrong faction it surfaces in the spectator
+    VOTE log and is easy to spot.
+
+    Mock-Policy: Forbidden
+        LLM I/O contract. See ``PreNightOutput`` and
+        ``tests/TestStrategy.md`` §5.
+    """
+
+    target: str
+    reasoning: str = ""
     strategy: Literal["village_side", "wolf_side"] | None = None
 
 

--- a/src/engine/phase_day.py
+++ b/src/engine/phase_day.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from src.agent import memory as memory_mod
 from src.config import DISCUSSION_ROUNDS
+from src.domain.actor import Actor
 from src.domain.event import EventType, LogEvent
 from src.domain.roles import Medium, Werewolf
 from src.engine.phase import Phase
@@ -77,45 +78,61 @@ def _run_vote(engine: GameEngine) -> str | None:
     engine.phase = Phase.DAY_VOTE
     engine._phase_start(Phase.DAY_VOTE)
 
-    votes: dict[str, str] = {}
+    alive = engine._alive_agents()
     alive_names = engine._alive_names()
 
-    for actor in engine._alive_agents():
+    last_vote_candidates_by_agent: dict[str, list[tuple[str, float]]] = {}
+    for actor in alive:
         output = engine._day_outputs.get(actor.name)
-        target = None
-
         if output and output.intent.vote_candidates:
-            sorted_candidates = sorted(
-                output.intent.vote_candidates,
-                key=lambda vc: vc.score,
-                reverse=True,
-            )
-            for vc in sorted_candidates:
-                if vc.target in alive_names and vc.target != actor.name:
-                    target = vc.target
-                    break
+            last_vote_candidates_by_agent[actor.name] = [
+                (vc.target, vc.score) for vc in output.intent.vote_candidates
+            ]
 
-        if target is None:
+    calls: list[tuple[Actor, list[str] | None]] = []
+    for actor in alive:
+        wolf_partners: list[str] | None = None
+        if isinstance(actor.role, Werewolf):
+            wolf_partners = [
+                a.name for a in alive if isinstance(a.role, Werewolf) and a.name != actor.name
+            ]
+        calls.append((actor, wolf_partners))
+
+    votes: dict[str, str] = {}
+    for actor, vote_output in engine._llm_client.call_vote_parallel(
+        calls,
+        list(engine.today_log),
+        alive_names,
+        engine.day,
+        last_vote_candidates_by_agent,
+        engine._past_votes,
+        engine._past_deaths,
+        engine.lang,
+    ):
+        target: str | None = None
+        if vote_output.target in alive_names and vote_output.target != actor.name:
+            target = vote_output.target
+        else:
             others = [n for n in alive_names if n != actor.name]
             target = others[0] if others else None
 
-        if target:
-            vote_action = engine._make_vote(target)
-            if engine._validate_action(vote_action, actor, alive_names):
-                votes[actor.name] = target
-                vote_reasoning = output.reasoning if output else ""
-                strategy = output.intent.strategy if output and output.intent.strategy else ""
-                engine._emit(LogEvent.make(
-                    day=engine.day,
-                    phase=Phase.DAY_VOTE.value,
-                    event_type=EventType.VOTE,
-                    agent=actor.name,
-                    target=target,
-                    content=f"{actor.name} votes for {target}",
-                    is_public=True,
-                    reasoning=vote_reasoning,
-                    decision=strategy,
-                ))
+        if not target:
+            continue
+        vote_action = engine._make_vote(target)
+        if not engine._validate_action(vote_action, actor, alive_names):
+            continue
+        votes[actor.name] = target
+        engine._emit(LogEvent.make(
+            day=engine.day,
+            phase=Phase.DAY_VOTE.value,
+            event_type=EventType.VOTE,
+            agent=actor.name,
+            target=target,
+            content=f"{actor.name} votes for {target}",
+            is_public=True,
+            reasoning=vote_output.reasoning,
+            decision=vote_output.strategy or "",
+        ))
 
     if not votes:
         return None

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -9,8 +9,8 @@ import pydantic
 from src.config import MAX_TOKENS
 from src.domain.actor import Actor
 from src.domain.roles import Role
-from src.domain.schema import AgentOutput, Intent, JudgmentOutput, NightActionOutput, PreNightOutput, SpeechEntry, WolfChatOutput
-from src.llm.prompt import PublicContext, RoleSpecificContext, SpeechDirection, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_system_prompt, build_wolf_chat_prompt
+from src.domain.schema import AgentOutput, Intent, JudgmentOutput, NightActionOutput, PreNightOutput, SpeechEntry, VoteOutput, WolfChatOutput
+from src.llm.prompt import PastDeath, PastVote, PublicContext, RoleSpecificContext, SpeechDirection, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_system_prompt, build_vote_prompt, build_wolf_chat_prompt
 
 
 def resolve_claim_role(actor: Actor, claim_role: Role | None) -> Role | None:
@@ -262,6 +262,79 @@ class LLMClient:
             futures = {executor.submit(_chain, actor): actor for actor in actors}
             for future in as_completed(futures):
                 yield future.result()
+
+    def call_vote(
+        self,
+        actor: Actor,
+        today_log: list[SpeechEntry],
+        alive_players: list[str],
+        day: int,
+        last_vote_candidates: list[tuple[str, float]],
+        past_votes: list[PastVote] | None = None,
+        past_deaths: list[PastDeath] | None = None,
+        wolf_partners: list[str] | None = None,
+        lang: str = "English",
+    ) -> VoteOutput:
+        """Call LLM for the dedicated VOTE-phase decision."""
+        prompt = build_vote_prompt(
+            actor,
+            today_log,
+            alive_players,
+            day,
+            last_vote_candidates,
+            past_votes,
+            past_deaths,
+            wolf_partners,
+            lang,
+        )
+        raw = ""
+        try:
+            message = self._client.messages.create(
+                model=actor.model,
+                max_tokens=MAX_TOKENS["call_vote"],
+                messages=[{"role": "user", "content": prompt}],
+            )
+            raw = message.content[0].text
+            return VoteOutput.model_validate_json(_extract_json(raw))
+        except Exception as e:
+            _classify_and_log_error("call_vote", actor.name, e, raw)
+            return VoteOutput(target="", reasoning="", strategy=None)
+
+    def call_vote_parallel(
+        self,
+        calls: list[tuple[Actor, list[str] | None]],
+        today_log: list[SpeechEntry],
+        alive_players: list[str],
+        day: int,
+        last_vote_candidates_by_agent: dict[str, list[tuple[str, float]]],
+        past_votes: list[PastVote] | None = None,
+        past_deaths: list[PastDeath] | None = None,
+        lang: str = "English",
+    ) -> Iterator[tuple[Actor, VoteOutput]]:
+        """Run VOTE-phase calls for all actors in parallel; yield in completion order.
+
+        ``calls`` is a list of (actor, wolf_partners_or_None). Wolf partners
+        are pre-resolved by the engine so the client stays oblivious to game
+        state.
+        """
+        with ThreadPoolExecutor() as executor:
+            future_to_actor = {
+                executor.submit(
+                    self.call_vote,
+                    actor,
+                    today_log,
+                    alive_players,
+                    day,
+                    last_vote_candidates_by_agent.get(actor.name, []),
+                    past_votes,
+                    past_deaths,
+                    wolf_partners,
+                    lang,
+                ): actor
+                for actor, wolf_partners in calls
+            }
+            for future in as_completed(future_to_actor):
+                yield future_to_actor[future], future.result()
 
     def call_wolf_chat(
         self,

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -309,6 +309,84 @@ Decide your next action. Respond with ONLY valid JSON. No extra fields, no expla
     return "\n".join(lines)
 
 
+def build_vote_prompt(
+    actor: Actor,
+    today_log: list[SpeechEntry],
+    alive_players: list[str],
+    day: int,
+    last_vote_candidates: list[tuple[str, float]],
+    past_votes: list[PastVote] | None = None,
+    past_deaths: list[PastDeath] | None = None,
+    wolf_partners: list[str] | None = None,
+    lang: str = "English",
+) -> str:
+    """Build the dedicated VOTE-phase prompt.
+
+    Independent from build_system_prompt: the vote decision needs the full
+    day discussion + history + the speaker's own vote_candidates hint, not
+    the full speech-context (persona color, CO direction, etc.).
+    """
+    candidates = [p for p in alive_players if p != actor.name]
+    lines = [
+        f"You are {actor.name} ({actor.role.name}) in a Werewolf game. Day {day}.",
+        f"Alive players: {', '.join(alive_players)}",
+        f"You must vote for one of: {', '.join(candidates)} (cannot vote for yourself).",
+    ]
+
+    if wolf_partners is not None:
+        partners_str = ", ".join(wolf_partners) if wolf_partners else "none (you are the last wolf)"
+        lines.append(f"Your wolf partner(s): {partners_str}.")
+
+    if actor.state.memory_summary:
+        lines.append(f"\nYour memory: {'; '.join(actor.state.memory_summary)}")
+
+    if past_deaths:
+        lines.append("\nPast deaths:")
+        for d in past_deaths:
+            cause = "executed" if d["cause"] == "execution" else "killed by werewolves"
+            lines.append(f"  Day {d['day']}: {d['name']} was {cause}")
+
+    if past_votes:
+        lines.append("\nPast votes:")
+        for v in past_votes:
+            vote_str = ", ".join(f"{voter}→{target}" for voter, target in v["votes"].items())
+            lines.append(f"  Day {v['day']}: {vote_str}")
+
+    if today_log:
+        lines.append("\nToday's full discussion:")
+        for entry in today_log:
+            lines.append(f"  [{entry.speech_id}] {entry.agent}: {entry.text}")
+    else:
+        lines.append("\nNo discussion yet today.")
+
+    if last_vote_candidates:
+        cand_str = ", ".join(f"{t}({s:.2f})" for t, s in last_vote_candidates)
+        lines.append(
+            f"\nYour latest vote_candidates from the speech phase (hint, not binding): {cand_str}"
+        )
+
+    strategy_block = actor.role.vote_strategy_prompt()
+    if strategy_block:
+        lines.append(strategy_block)
+
+    has_strategy = bool(strategy_block)
+    strategy_field = '\n  "strategy": "village_side" | "wolf_side"' if has_strategy else '\n  "strategy": null'
+    lines.append(f"""
+--- OUTPUT FORMAT ---
+Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
+{{
+  "target": "<one player name from the candidates above>",
+  "reasoning": "<one short paragraph: why this target>",{strategy_field}
+}}
+- "reasoning" must be written in {lang}
+- "target" must be exactly one of: {', '.join(candidates)}""")
+    if has_strategy:
+        lines.append('- "strategy" must be exactly "village_side" or "wolf_side" (always English, see VOTE STRATEGY above)')
+    else:
+        lines.append('- "strategy" must be null (only Werewolves use this field)')
+    return "\n".join(lines)
+
+
 def build_wolf_chat_prompt(
     actor: Actor,
     wolf_partners: list[str],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 from src.domain.actor import Actor, ActorProfile, ActorState, Persona, make_actor
 from src.domain.event import LogEvent
-from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput
+from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, VoteOutput
 from src.engine.game import GameEngine
 from src.llm.client import LLMClient
 from src.logger.writer import LogWriter
@@ -59,6 +59,7 @@ def make_test_engine():
         log_writer = MagicMock(spec=LogWriter)
         log_writer.write.side_effect = lambda e: events.append(e)
         llm_client = MagicMock(spec=LLMClient)
+        llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect()
         engine = GameEngine(
             agents=agents,
             log_writer=log_writer,
@@ -114,6 +115,40 @@ def make_silent_discussion_side_effect():
     """Side effect for call_discussion_parallel: all actors respond with silent judgment."""
     def _side_effect(actors, *_, **__):
         return iter([(a, JudgmentOutput(decision="silent"), None, None) for a in actors])
+    return _side_effect
+
+
+def make_vote_parallel_side_effect(
+    targets: dict[str, str] | None = None,
+    reasonings: dict[str, str] | None = None,
+    strategies: dict[str, str] | None = None,
+):
+    """Side effect for ``LLMClient.call_vote_parallel``.
+
+    Defaults: each actor votes for the first other alive player; empty
+    reasoning; no strategy. Overrides per-agent via the optional dicts.
+    """
+    targets = targets or {}
+    reasonings = reasonings or {}
+    strategies = strategies or {}
+
+    def _side_effect(calls, today_log, alive_players, day, last_vote_candidates_by_agent, *args, **kwargs):
+        results = []
+        for actor, _wolf_partners in calls:
+            target = targets.get(actor.name)
+            if target is None:
+                others = [n for n in alive_players if n != actor.name]
+                target = others[0] if others else ""
+            results.append((
+                actor,
+                VoteOutput(
+                    target=target,
+                    reasoning=reasonings.get(actor.name, ""),
+                    strategy=strategies.get(actor.name),
+                ),
+            ))
+        return iter(results)
+
     return _side_effect
 
 
@@ -221,4 +256,16 @@ WOLF_CHAT_OUTPUT_JSON = json.dumps({
 NIGHT_ACTION_OUTPUT_JSON = json.dumps({
     "target": "Alice",
     "reasoning": "She is the most suspicious.",
+})
+
+VOTE_OUTPUT_JSON = json.dumps({
+    "target": "Alice",
+    "reasoning": "Her speech contradicts the seer claim.",
+    "strategy": None,
+})
+
+VOTE_OUTPUT_WOLF_JSON = json.dumps({
+    "target": "Seer1",
+    "reasoning": "Eliminate the seer to swing the village.",
+    "strategy": "wolf_side",
 })

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -5,7 +5,7 @@ import anthropic
 import pydantic
 import pytest
 
-from src.domain.schema import AgentOutput, JudgmentOutput, NightActionOutput, PreNightOutput, WolfChatOutput
+from src.domain.schema import AgentOutput, JudgmentOutput, NightActionOutput, PreNightOutput, VoteOutput, WolfChatOutput
 from src.domain.roles import get_role
 from src.llm.client import _classify_error, resolve_claim_role
 from tests.conftest import (
@@ -15,6 +15,8 @@ from tests.conftest import (
     NIGHT_ACTION_OUTPUT_JSON,
     PRE_NIGHT_CO_OUTPUT_JSON,
     PRE_NIGHT_OUTPUT_JSON,
+    VOTE_OUTPUT_JSON,
+    VOTE_OUTPUT_WOLF_JSON,
     WOLF_CHAT_OUTPUT_JSON,
     make_failing_llm_client,
     make_llm_client_with_response,
@@ -100,6 +102,68 @@ class TestCallWolfChat:
         llm = make_failing_llm_client()
         result = llm.call_wolf_chat(actor, ["OtherWolf"], ["Alice", "Wolf", "OtherWolf"], [])
         assert result.speech == "..."
+
+
+class TestCallVote:
+    def test_returns_vote_output(self, make_test_actor):
+        """
+        SUT: LLMClient.call_vote
+        Mock: anthropic SDK
+        Level: unit
+        Objective: VOTE プロンプトの応答が VoteOutput としてパースされること。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        llm = make_llm_client_with_response(VOTE_OUTPUT_JSON)
+        result = llm.call_vote(
+            actor,
+            today_log=[],
+            alive_players=["Alice", "Bob"],
+            day=1,
+            last_vote_candidates=[],
+        )
+        assert isinstance(result, VoteOutput)
+        assert result.target == "Alice"
+        assert result.reasoning == "Her speech contradicts the seer claim."
+        assert result.strategy is None
+
+    def test_returns_wolf_strategy_field(self, make_test_actor):
+        """
+        SUT: LLMClient.call_vote
+        Mock: anthropic SDK
+        Level: unit
+        Objective: 狼が strategy フィールド付きで返したとき VoteOutput.strategy として保持されること。
+        """
+        actor = make_test_actor("Wolf", "Werewolf")
+        llm = make_llm_client_with_response(VOTE_OUTPUT_WOLF_JSON)
+        result = llm.call_vote(
+            actor,
+            today_log=[],
+            alive_players=["Wolf", "Seer1"],
+            day=1,
+            last_vote_candidates=[],
+            wolf_partners=[],
+        )
+        assert result.strategy == "wolf_side"
+        assert result.target == "Seer1"
+
+    def test_returns_empty_fallback_on_exception(self, make_test_actor):
+        """
+        SUT: LLMClient.call_vote
+        Mock: anthropic SDK raises RuntimeError
+        Level: unit
+        Objective: API 失敗時に target="" の VoteOutput が返ること（_run_vote 側でフォールバック処理）。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        llm = make_failing_llm_client()
+        result = llm.call_vote(
+            actor,
+            today_log=[],
+            alive_players=["Alice", "Bob"],
+            day=1,
+            last_vote_candidates=[],
+        )
+        assert result.target == ""
+        assert result.strategy is None
 
 
 class TestCallNightAction:

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -19,6 +19,7 @@ from tests.conftest import (
     make_night_action_side_effect,
     make_silent_discussion_side_effect,
     make_speech_parallel_side_effect,
+    make_vote_parallel_side_effect,
 )
 
 
@@ -215,38 +216,27 @@ class TestDiscussionCoDecision:
         assert wolf.state.claimed_role.name == "Medium"
 
 
-class TestVoteStrategyLogged:
-    """#212 — wolf strategy in Intent flows into VOTE LogEvent."""
+class TestVoteOutputFlow:
+    """#216 — dedicated VoteOutput from call_vote_parallel flows into VOTE LogEvent."""
 
     def test_wolf_side_strategy_recorded_in_vote_event(self, make_test_actor, make_test_engine):
         """
         SUT: _run_vote
-        Mock: call_speech_parallel / call_discussion_parallel
+        Mock: call_vote_parallel returns VoteOutput with strategy="wolf_side"
         Level: unit
-        Objective: 狼が intent.strategy="wolf_side" を返したとき、その値が VOTE LogEvent の decision に記録されること。
+        Objective: 狼が VoteOutput.strategy="wolf_side" を返したとき、その値が VOTE LogEvent の decision に記録されること。reasoning は VoteOutput.reasoning から取り、AgentOutput.reasoning は流用しないこと。
         """
         wolf = make_test_actor("Wolf1", "Werewolf")
         seer = make_test_actor("Seer1", "Seer")
         engine, events = make_test_engine([wolf, seer])
 
-        wolf_output = AgentOutput(
-            thought="t",
-            speech="s",
-            reasoning="Seer1 should be eliminated.",
-            intent=Intent(
-                vote_candidates=[{"target": "Seer1", "score": 0.9}],
-                strategy="wolf_side",
-            ),
-            memory_update=[],
-        )
-        seer_output = make_agent_output("Seer1")
-
-        def speech_side_effect(calls):
-            outputs = {"Wolf1": wolf_output, "Seer1": seer_output}
-            return iter([(a, outputs[a.name]) for a, *_ in calls])
-
-        engine._llm_client.call_speech_parallel.side_effect = speech_side_effect
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
+        engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
+            targets={"Wolf1": "Seer1", "Seer1": "Wolf1"},
+            reasonings={"Wolf1": "Seer1 should be eliminated."},
+            strategies={"Wolf1": "wolf_side"},
+        )
 
         with patch("src.agent.store.save"):
             engine._run_day()
@@ -260,27 +250,20 @@ class TestVoteStrategyLogged:
     def test_villager_vote_has_no_strategy(self, make_test_actor, make_test_engine):
         """
         SUT: _run_vote
-        Mock: call_speech_parallel / call_discussion_parallel
+        Mock: call_vote_parallel returns VoteOutput with strategy=None
         Level: unit
-        Objective: 村人エージェントの VOTE LogEvent には strategy（decision）が空文字で入ること（村人プロンプトは strategy を出力しない）。
+        Objective: 村人エージェントの VOTE LogEvent には decision（strategy）が空文字で入ること（村人プロンプトは strategy を出力しない）。
         """
         villager = make_test_actor("V1", "Villager")
         target = make_test_actor("V2", "Villager")
         engine, events = make_test_engine([villager, target])
 
-        v_output = AgentOutput(
-            thought="t",
-            speech="s",
-            reasoning="suspicion",
-            intent=Intent(vote_candidates=[{"target": "V2", "score": 0.5}]),
-            memory_update=[],
-        )
-
-        def speech_side_effect(calls):
-            return iter([(a, v_output) for a, *_ in calls])
-
-        engine._llm_client.call_speech_parallel.side_effect = speech_side_effect
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
+        engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
+            targets={"V1": "V2", "V2": "V1"},
+            reasonings={"V1": "suspicion"},
+        )
 
         with patch("src.agent.store.save"):
             engine._run_day()
@@ -292,32 +275,21 @@ class TestVoteStrategyLogged:
     def test_village_side_allows_voting_for_wolf_partner(self, make_test_actor, make_test_engine):
         """
         SUT: _run_vote
-        Mock: call_speech_parallel / call_discussion_parallel
+        Mock: call_vote_parallel returns VoteOutput targeting wolf partner with strategy="village_side"
         Level: unit
-        Objective: 狼が intent.strategy="village_side" で仲間（別の狼）を投票先に指定したとき、そのままその仲間に投票できること（ライン切り戦略）。
+        Objective: 狼が VoteOutput.strategy="village_side" で仲間（別の狼）を投票先に指定したとき、そのままその仲間に投票できること（ライン切り戦略）。
         """
         wolf1 = make_test_actor("Wolf1", "Werewolf")
         wolf2 = make_test_actor("Wolf2", "Werewolf")
         engine, events = make_test_engine([wolf1, wolf2])
 
-        wolf1_output = AgentOutput(
-            thought="line cut",
-            speech="s",
-            reasoning="line-cutting",
-            intent=Intent(
-                vote_candidates=[{"target": "Wolf2", "score": 0.8}],
-                strategy="village_side",
-            ),
-            memory_update=[],
-        )
-        wolf2_output = make_agent_output("Wolf2")
-
-        def speech_side_effect(calls):
-            outputs = {"Wolf1": wolf1_output, "Wolf2": wolf2_output}
-            return iter([(a, outputs[a.name]) for a, *_ in calls])
-
-        engine._llm_client.call_speech_parallel.side_effect = speech_side_effect
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
+        engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
+            targets={"Wolf1": "Wolf2", "Wolf2": "Wolf1"},
+            reasonings={"Wolf1": "line-cutting"},
+            strategies={"Wolf1": "village_side"},
+        )
 
         with patch("src.agent.store.save"):
             engine._run_day()
@@ -326,6 +298,67 @@ class TestVoteStrategyLogged:
         assert len(wolf1_votes) == 1
         assert wolf1_votes[0].target == "Wolf2"
         assert wolf1_votes[0].decision == "village_side"
+
+    def test_vote_event_reasoning_comes_from_vote_output_not_speech(self, make_test_actor, make_test_engine):
+        """
+        SUT: _run_vote
+        Mock: call_speech_parallel emits AgentOutput with reasoning="speech-side"; call_vote_parallel emits VoteOutput with reasoning="vote-side"
+        Level: unit
+        Objective: ⚠️unit test mandatory — VOTE LogEvent の reasoning が VoteOutput.reasoning から取られ、AgentOutput.reasoning（発言用）は流用されないこと（AC）。
+        """
+        a = make_test_actor("A")
+        b = make_test_actor("B")
+        engine, events = make_test_engine([a, b])
+
+        speech_output = AgentOutput(
+            thought="t",
+            speech="s",
+            reasoning="speech-side reasoning that must NOT leak into the vote event",
+            intent=Intent(vote_candidates=[{"target": "B", "score": 0.9}]),
+            memory_update=[],
+        )
+
+        def speech_side_effect(calls):
+            return iter([(actor, speech_output) for actor, *_ in calls])
+
+        engine._llm_client.call_speech_parallel.side_effect = speech_side_effect
+        engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
+        engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
+            targets={"A": "B", "B": "A"},
+            reasonings={"A": "vote-side reasoning"},
+        )
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        a_votes = [e for e in events if e.event_type == EventType.VOTE and e.agent == "A"]
+        assert len(a_votes) == 1
+        assert a_votes[0].reasoning == "vote-side reasoning"
+        assert "speech-side" not in a_votes[0].reasoning
+
+    def test_invalid_target_falls_back_to_first_other(self, make_test_actor, make_test_engine):
+        """
+        SUT: _run_vote
+        Mock: call_vote_parallel returns VoteOutput with unknown target
+        Level: unit
+        Objective: VoteOutput.target が生存者でない場合、最初の他者へフォールバックして投票が記録されること。
+        """
+        a = make_test_actor("A")
+        b = make_test_actor("B")
+        engine, events = make_test_engine([a, b])
+
+        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
+        engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
+        engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
+            targets={"A": "Ghost", "B": "A"},
+        )
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        a_votes = [e for e in events if e.event_type == EventType.VOTE and e.agent == "A"]
+        assert len(a_votes) == 1
+        assert a_votes[0].target == "B"
 
 
 class TestRunNightPhaseOrder:

--- a/tests/unit/test_role.py
+++ b/tests/unit/test_role.py
@@ -67,19 +67,18 @@ class TestRolePrompt:
         result = get_role("Werewolf").role_prompt(wolf_partners=["Alice"])
         assert "Alice" in result
 
-    def test_werewolf_includes_vote_strategy(self):
+    def test_werewolf_speech_prompt_excludes_vote_strategy(self):
         """
         SUT: Werewolf.role_prompt
         Mock: なし
         Level: unit
-        Objective: 狼の役職プロンプトに village_side / wolf_side の戦略指示が含まれること（#212）。
+        Objective: 狼の発話プロンプト（speech 用）には VOTE STRATEGY 指示が含まれないこと
+                   （#216 で投票専用プロンプトに移動）。
         """
         result = get_role("Werewolf").role_prompt(wolf_partners=["Alice"])
-        assert "VOTE STRATEGY" in result
-        assert "village_side" in result
-        assert "wolf_side" in result
-        assert "line-cutting" in result  # village_side で仲間投票も許容する旨
-        assert "suspicion" in result  # wolf_side のリスク説明
+        assert "VOTE STRATEGY" not in result
+        assert "village_side" not in result
+        assert "wolf_side" not in result
 
     def test_villager_does_not_include_vote_strategy(self):
         """
@@ -184,17 +183,18 @@ class TestOutputFormatPrompt:
         result = get_role("Villager").output_format_prompt(lang="Japanese")
         assert "Japanese" in result
 
-    def test_werewolf_output_format_includes_strategy_field(self):
+    def test_werewolf_output_format_excludes_strategy_field(self):
         """
         SUT: Werewolf.output_format_prompt
         Mock: なし
         Level: unit
-        Objective: 狼の output_format に intent.strategy フィールドの案内が含まれること（#212）。
+        Objective: 狼の発話用 output_format には strategy フィールドが含まれないこと
+                   （#216 で投票専用プロンプトに移動）。
         """
         result = get_role("Werewolf").output_format_prompt()
-        assert "strategy" in result
-        assert "village_side" in result
-        assert "wolf_side" in result
+        assert "strategy" not in result
+        assert "village_side" not in result
+        assert "wolf_side" not in result
 
     def test_villager_output_format_excludes_strategy_field(self):
         """
@@ -211,6 +211,41 @@ class TestOutputFormatPrompt:
         result = get_role("Seer").output_format_prompt()
         assert "OUTPUT FORMAT" in result
         assert "memory_update" in result
+
+
+class TestVoteStrategyPrompt:
+    def test_villager_empty(self):
+        """
+        SUT: Villager.vote_strategy_prompt
+        Mock: なし
+        Level: unit
+        Objective: 村人の VOTE 戦略プロンプトは空であること（投票専用プロンプトでも村人には追加指示なし）。
+        """
+        assert get_role("Villager").vote_strategy_prompt() == ""
+
+    def test_werewolf_includes_village_and_wolf_sides(self):
+        """
+        SUT: Werewolf.vote_strategy_prompt
+        Mock: なし
+        Level: unit
+        Objective: 狼の VOTE 戦略プロンプトに village_side / wolf_side / line-cutting / suspicion ヒントが含まれること（#216）。
+        """
+        result = get_role("Werewolf").vote_strategy_prompt()
+        assert "VOTE STRATEGY" in result
+        assert "village_side" in result
+        assert "wolf_side" in result
+        assert "line-cutting" in result
+        assert "suspicion" in result
+
+    @pytest.mark.parametrize("role_name", ["Seer", "Knight", "Medium", "Madman"])
+    def test_other_village_side_roles_empty(self, role_name):
+        """
+        SUT: Role.vote_strategy_prompt (default)
+        Mock: なし
+        Level: unit
+        Objective: 狼以外の役職は VOTE 戦略プロンプトを持たないこと。
+        """
+        assert get_role(role_name).vote_strategy_prompt() == ""
 
 
 class TestCoStrategyHint:

--- a/tests/unit/test_vote_prompt.py
+++ b/tests/unit/test_vote_prompt.py
@@ -1,0 +1,162 @@
+"""build_vote_prompt のプロンプト組立テスト（Issue #216）。"""
+from src.domain.schema import SpeechEntry
+from src.llm.prompt import build_vote_prompt
+
+
+def _log(*texts: str) -> list[SpeechEntry]:
+    return [SpeechEntry(speech_id=i + 1, agent=f"A{i}", text=t) for i, t in enumerate(texts)]
+
+
+class TestBuildVotePrompt:
+    def test_includes_alive_candidates_and_excludes_self(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: 投票候補リストに自分自身が含まれず、他の生存者全員が含まれること。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        prompt = build_vote_prompt(
+            actor,
+            today_log=[],
+            alive_players=["Alice", "Bob", "Carol"],
+            day=1,
+            last_vote_candidates=[],
+        )
+        assert "must vote for one of: Bob, Carol" in prompt
+
+    def test_includes_today_full_discussion(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: 当日の議論ログ全体（speech_id 付き）がプロンプトに含まれること。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        prompt = build_vote_prompt(
+            actor,
+            today_log=_log("hello", "I suspect Bob"),
+            alive_players=["Alice", "Bob"],
+            day=1,
+            last_vote_candidates=[],
+        )
+        assert "Today's full discussion" in prompt
+        assert "[1] A0: hello" in prompt
+        assert "[2] A1: I suspect Bob" in prompt
+
+    def test_includes_last_vote_candidates_hint(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: 発言フェーズで蓄積された最終 vote_candidates が VOTE プロンプトに「ヒント」として含まれること（AC）。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        prompt = build_vote_prompt(
+            actor,
+            today_log=[],
+            alive_players=["Alice", "Bob", "Carol"],
+            day=1,
+            last_vote_candidates=[("Bob", 0.74), ("Carol", 0.42)],
+        )
+        assert "vote_candidates" in prompt
+        assert "Bob(0.74)" in prompt
+        assert "Carol(0.42)" in prompt
+
+    def test_includes_past_votes_and_deaths(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: past_votes と past_deaths がプロンプトに含まれること。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        prompt = build_vote_prompt(
+            actor,
+            today_log=[],
+            alive_players=["Alice", "Bob"],
+            day=2,
+            last_vote_candidates=[],
+            past_votes=[{"day": 1, "votes": {"Alice": "Bob", "Bob": "Carol"}}],
+            past_deaths=[{"day": 1, "name": "Carol", "cause": "execution"}],
+        )
+        assert "Past votes" in prompt
+        assert "Alice→Bob" in prompt
+        assert "Past deaths" in prompt
+        assert "Carol was executed" in prompt
+
+    def test_villager_prompt_excludes_strategy_block(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: 村人の VOTE プロンプトには VOTE STRATEGY ブロックが含まれず、strategy が null 強制される指示が入ること。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        prompt = build_vote_prompt(
+            actor,
+            today_log=[],
+            alive_players=["Alice", "Bob"],
+            day=1,
+            last_vote_candidates=[],
+        )
+        assert "VOTE STRATEGY" not in prompt
+        assert "must be null" in prompt
+
+    def test_werewolf_prompt_includes_strategy_block_and_partners(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: 狼の VOTE プロンプトに VOTE STRATEGY ブロック・village_side / wolf_side / 仲間情報が含まれること。
+        """
+        actor = make_test_actor("Wolf1", "Werewolf")
+        prompt = build_vote_prompt(
+            actor,
+            today_log=[],
+            alive_players=["Wolf1", "Wolf2", "Seer1"],
+            day=1,
+            last_vote_candidates=[],
+            wolf_partners=["Wolf2"],
+        )
+        assert "VOTE STRATEGY" in prompt
+        assert "village_side" in prompt
+        assert "wolf_side" in prompt
+        assert "Wolf2" in prompt
+
+    def test_includes_memory_summary_when_present(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: actor.state.memory_summary が非空のときその内容がプロンプトに含まれること。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        actor.state.memory_summary = ["Bob changed vote on Day1", "Carol stayed silent"]
+        prompt = build_vote_prompt(
+            actor,
+            today_log=[],
+            alive_players=["Alice", "Bob", "Carol"],
+            day=2,
+            last_vote_candidates=[],
+        )
+        assert "Bob changed vote on Day1" in prompt
+        assert "Carol stayed silent" in prompt
+
+    def test_lone_wolf_prompt_indicates_no_partner(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: 仲間が全滅した狼に渡される VOTE プロンプトで「last wolf」相当の表現が含まれること。
+        """
+        actor = make_test_actor("Wolf1", "Werewolf")
+        prompt = build_vote_prompt(
+            actor,
+            today_log=[],
+            alive_players=["Wolf1", "Seer1"],
+            day=2,
+            last_vote_candidates=[],
+            wolf_partners=[],
+        )
+        assert "last wolf" in prompt


### PR DESCRIPTION
## Summary
- Add `VoteOutput` schema and `LLMClient.call_vote` / `call_vote_parallel` for a dedicated VOTE-phase LLM call (`build_vote_prompt`)
- Rewrite `_run_vote` to drive the vote via `VoteOutput`; the speech-phase `vote_candidates` are passed into `build_vote_prompt` as a hint instead of deciding the vote
- Move Werewolf `village_side` / `wolf_side` strategy choice from `Intent` (#212 interim) into `VoteOutput.strategy` via the new `Role.vote_strategy_prompt()` hook (overridden on Werewolf)
- VOTE LogEvent `reasoning` now comes from `VoteOutput.reasoning`; the speech-phase `AgentOutput.reasoning` is no longer reused

## Test plan
- [x] \`ruff check .\` clean
- [x] \`pytest --cov=src\` — 284 passed
- [x] New unit tests:
  - \`tests/unit/test_vote_prompt.py\` — \`build_vote_prompt\` structure (8 cases)
  - \`tests/unit/test_client.py::TestCallVote\` — \`call_vote\` LLM contract (3 cases)
  - \`tests/unit/test_game_day_loop.py::TestVoteOutputFlow\` — \`_run_vote\` end-to-end (5 cases, incl. ⚠️ AC mandatory: VOTE LogEvent reasoning comes from \`VoteOutput\`, not \`AgentOutput\`)
  - \`tests/unit/test_role.py::TestVoteStrategyPrompt\` — \`Role.vote_strategy_prompt()\` per-role behavior

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)