### PR TITLE
docs: remove completed issue #224 from Ideas.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ issues/
 .tracecov/
 .coverage
 htmlcov/
+coverage.json

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#224 | tech-debt | ❌ | 2 | Add coverage_diff.py script to surface uncovered added lines | pytest Missing 行と git diff 追加行を突合せて今回変更分だけ抽出するスクリプト |
 | yukkie/AgentVillage#207 | tech-debt | ❌ | 2 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#33 | enhancement | 🔴 | 5 | Wolf chat improvements | 早期終了・偽CO協議・テスト |


### PR DESCRIPTION
## Summary
- remove the completed Issue #224 entry from doc/Ideas.md
- keep the ideas backlog aligned with implemented work

## Test plan
- [x] pre-commit pytest passed during commit
- [x] verified the doc/Ideas.md entry for #224 was removed
