### PR TITLE
refactor: rename vote_candidates to attack_candidates in WolfChatOutput

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -228,7 +228,7 @@ class VoteOutput(BaseModel):
 | `call()` | 昼フェーズの発言生成（OPENING / DISCUSSION） | 2048 | thought が日本語で長くなりやすい |
 | `call_judgment()` | 昼フェーズの並列判断（challenge / speak / silent / co） | 1024 | `decision`, `reply_to`, `claim_role` の軽量JSON。`co_eligible=True` のときのみ `"co"` を選択肢に含める |
 | `call_vote()` | 昼フェーズの投票判断（VOTE） | 512 | `target` + `reasoning` + `strategy`（狼のみ）。reasoning が日本語で多少長くなることを見込む |
-| `call_wolf_chat()` | 夜フェーズの狼チーム会話 | 2048 | thought + speech + vote_candidates + self_co_decision。日本語で長くなりやすい |
+| `call_wolf_chat()` | 夜フェーズの狼チーム会話 | 2048 | thought + speech + attack_candidates + self_co_decision。日本語で長くなりやすい |
 | `call_pre_night_action()` | 前夜フェーズの CO 判断（村人以外） | 1024 | thought + decision + claim_role + reasoning の4フィールド |
 | `call_night_action()` | 夜フェーズの個別行動（襲撃・占い・護衛） | 256 | `NightActionOutput` (target + reasoning) |
 
@@ -275,7 +275,7 @@ class WolfSelfCoDecision(BaseModel):
 class WolfChatOutput(BaseModel):
     thought: str
     speech: str
-    vote_candidates: list[VoteCandidate] = []
+    attack_candidates: list[VoteCandidate] = []
     self_co_decision: WolfSelfCoDecision = WolfSelfCoDecision()
 ```
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#207 | tech-debt | ❌ | 2 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
-| yukkie/AgentVillage#228 | tech-debt | 未設定 | 未設定 | Clarify wolf chat attack target field naming | 人狼夜会話の `vote_candidates` 命名を見直し、prompt/schema/engine/tests の用語を統一する |
 | yukkie/AgentVillage#230 | bug | 未設定 | 未設定 | Fix escaped Unicode in archived actor state JSON and add rescue script | actor state JSON の Unicode エスケープ回帰を修正し、既存 `state_archive` を救済する移行スクリプトを追加する |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -124,5 +124,5 @@ class WolfChatOutput(BaseModel):
 
     thought: str
     speech: str
-    vote_candidates: list[VoteCandidate] = []
+    attack_candidates: list[VoteCandidate] = []
     self_co_decision: WolfSelfCoDecision = WolfSelfCoDecision()

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -123,8 +123,8 @@ def _run_wolf_chat(engine: GameEngine) -> str | None:
     score_totals: dict[str, float] = {}
     for wolf in wolves:
         out = last_wolf_outputs[wolf.name]
-        if out and out.vote_candidates:
-            for vc in out.vote_candidates:
+        if out and out.attack_candidates:
+            for vc in out.attack_candidates:
                 if vc.target in alive_names and vc.target not in wolf_names:
                     score_totals[vc.target] = score_totals.get(vc.target, 0.0) + vc.score
     if score_totals:

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -357,7 +357,7 @@ class LLMClient:
             return WolfChatOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
             _classify_and_log_error("call_wolf_chat", actor.name, e, raw)
-            return WolfChatOutput(thought="...", speech="...", vote_candidates=[])
+            return WolfChatOutput(thought="...", speech="...", attack_candidates=[])
 
     def call_night_action(
         self,

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -419,7 +419,7 @@ Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
 {{
   "thought": "<your private reasoning>",
   "speech": "<what you say to your wolf partner(s)>",
-  "vote_candidates": [
+  "attack_candidates": [
     {{"target": "<player_name>", "score": <0.0-1.0>}},
     ...
   ],
@@ -429,13 +429,14 @@ Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
   }}
 }}
 - "thought" and "speech" must be written in {lang}
-- "vote_candidates" lists your preferred attack targets (highest score = most preferred)
+- "attack_candidates" lists your preferred attack targets tonight (highest score = most preferred)
 - Use "speech" to discuss and negotiate fake-CO ideas with your wolf partner(s)
 - "self_co_decision" is your own final personal decision after this discussion, even if the wolves do not fully agree
 - If you decide to fake-CO on the next day, set "timing" to "next_day" and set "claim_role" to the role name you will claim
 - If you decide to wait, set "timing" to "wait" and "claim_role" to null
 - The engine will use only "self_co_decision" to decide your next-day intended fake-CO
-- The JSON must contain exactly these four fields and nothing else.""")
+- The JSON must contain exactly these four fields and nothing else.
+- Note: "attack_candidates" is the night-attack target field; the daytime speech schema uses a separate "vote_candidates" field.""")
     return "\n".join(lines)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,7 @@ def make_wolf_chat_side_effect(score: float = 0.8) -> callable:
         return WolfChatOutput(
             thought="thinking",
             speech=f"{actor.name} votes to attack {target}" if target else "no valid target",
-            vote_candidates=[VoteCandidate(target=target, score=score)] if target else [],
+            attack_candidates=[VoteCandidate(target=target, score=score)] if target else [],
         )
 
     return _side_effect
@@ -250,7 +250,7 @@ PRE_NIGHT_CO_OUTPUT_JSON = json.dumps({
 WOLF_CHAT_OUTPUT_JSON = json.dumps({
     "thought": "thinking",
     "speech": "Let's attack Alice.",
-    "vote_candidates": [{"target": "Alice", "score": 0.9}],
+    "attack_candidates": [{"target": "Alice", "score": 0.9}],
     "self_co_decision": {"claim_role": "Seer", "timing": "next_day"},
 })
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -95,7 +95,7 @@ class TestCallWolfChat:
         SUT: LLMClient.call_wolf_chat
         Mock: anthropic SDK
         Level: unit
-        Objective: 狼チャット応答の speech / vote_candidates / self_co_decision が WolfChatOutput としてパースされること。
+        Objective: 狼チャット応答の speech / attack_candidates / self_co_decision が WolfChatOutput としてパースされること。
         """
         actor = make_test_actor("Wolf", "Werewolf")
         llm = make_llm_client_with_response(WOLF_CHAT_OUTPUT_JSON)
@@ -111,7 +111,7 @@ class TestCallWolfChat:
         SUT: LLMClient.call_wolf_chat
         Mock: anthropic SDK raises RuntimeError
         Level: unit
-        Objective: API失敗時に空の vote_candidates と wait の self_co_decision を持つフォールバックが返ること。
+        Objective: API失敗時に空の attack_candidates と wait の self_co_decision を持つフォールバックが返ること。
         """
         actor = make_test_actor("Wolf", "Werewolf")
         llm = make_failing_llm_client()

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -45,7 +45,7 @@ class TestRunWolfChat:
         SUT: _run_wolf_chat
         Mock: engine._llm_client.call_wolf_chat — WolfChatOutputを返す
         Level: unit
-        Objective: 2体の狼が vote_candidates のスコアを合算し、最高スコアの攻撃対象名を返すこと。
+        Objective: 2体の狼が attack_candidates のスコアを合算し、最高スコアの攻撃対象名を返すこと。
         """
         wolf1 = make_test_actor("Wolf1", "Werewolf")
         wolf2 = make_test_actor("Wolf2", "Werewolf")
@@ -64,9 +64,9 @@ class TestRunWolfChat:
     def test_multi_wolf_chat_empty_candidates_returns_none(self, make_test_actor, make_test_engine):
         """
         SUT: _run_wolf_chat
-        Mock: engine._llm_client.call_wolf_chat — 空の vote_candidates を返す
+        Mock: engine._llm_client.call_wolf_chat — 空の attack_candidates を返す
         Level: unit
-        Objective: 全ての狼が vote_candidates を返さないとき None を返すこと。
+        Objective: 全ての狼が attack_candidates を返さないとき None を返すこと。
         """
         wolf1 = make_test_actor("Wolf1", "Werewolf")
         wolf2 = make_test_actor("Wolf2", "Werewolf")
@@ -77,7 +77,7 @@ class TestRunWolfChat:
         engine._llm_client.call_wolf_chat.return_value = WolfChatOutput(
             thought="thinking",
             speech="...",
-            vote_candidates=[],
+            attack_candidates=[],
         )
 
         result = _run_wolf_chat(engine)
@@ -87,9 +87,9 @@ class TestRunWolfChat:
     def test_multi_wolf_chat_wolf_target_excluded(self, make_test_actor, make_test_engine):
         """
         SUT: _run_wolf_chat
-        Mock: engine._llm_client.call_wolf_chat — 仲間の狼を vote 対象にする
+        Mock: engine._llm_client.call_wolf_chat — 仲間の狼を attack 対象にする
         Level: unit
-        Objective: 狼仲間への vote はスコア集計から除外され、他の有効な候補が選ばれること。
+        Objective: 狼仲間への attack_candidates はスコア集計から除外され、他の有効な候補が選ばれること。
         """
         wolf1 = make_test_actor("Wolf1", "Werewolf")
         wolf2 = make_test_actor("Wolf2", "Werewolf")
@@ -101,7 +101,7 @@ class TestRunWolfChat:
             return WolfChatOutput(
                 thought="thinking",
                 speech="...",
-                vote_candidates=[
+                attack_candidates=[
                     VoteCandidate(target="Wolf2", score=0.9),  # own pack — must be excluded
                     VoteCandidate(target="Alice", score=0.5),
                 ],
@@ -131,7 +131,7 @@ class TestRunWolfChat:
                 {
                     "thought": "thinking",
                     "speech": "...",
-                    "vote_candidates": [{"target": "Alice", "score": 0.7}],
+                    "attack_candidates": [{"target": "Alice", "score": 0.7}],
                     "self_co_decision": {
                         "claim_role": "Seer" if actor.name == "Wolf1" else "Medium",
                         "timing": "next_day",
@@ -196,7 +196,7 @@ class TestRunWolfChat:
                     {
                         "thought": "thinking",
                         "speech": "You fake-CO Medium, I will fake-CO Seer.",
-                        "vote_candidates": [{"target": "Alice", "score": 0.7}],
+                        "attack_candidates": [{"target": "Alice", "score": 0.7}],
                         "self_co_decision": {"claim_role": "Seer", "timing": "next_day"},
                     }
                 )
@@ -204,7 +204,7 @@ class TestRunWolfChat:
                 {
                     "thought": "thinking",
                     "speech": "I disagree, I will wait.",
-                    "vote_candidates": [{"target": "Alice", "score": 0.7}],
+                    "attack_candidates": [{"target": "Alice", "score": 0.7}],
                     "self_co_decision": {"claim_role": None, "timing": "wait"},
                 }
             )


### PR DESCRIPTION
## Summary
- `WolfChatOutput.vote_candidates` を `attack_candidates` にリネーム
- プロンプトの JSON フォーマット例・説明文も `attack_candidates` に統一
- `phase_night.py`・`client.py`・テスト・`DetailDesign.md` を一括更新
- daytime の `Intent.vote_candidates` は変更なし（別用途）

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（287 tests）
- [x] coverage_diff.py で追加行すべて `[o]` または `[ ]`（未カバー行なし）

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)