### PR TITLE
fix: preserve readable UTF-8 in actor state JSON (closes #230)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#207 | tech-debt | ❌ | 2 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
-| yukkie/AgentVillage#230 | bug | 未設定 | 未設定 | Fix escaped Unicode in archived actor state JSON and add rescue script | actor state JSON の Unicode エスケープ回帰を修正し、既存 `state_archive` を救済する移行スクリプトを追加する |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |
 | yukkie/AgentVillage#36 | enhancement | 🟡 | 5 | Belief updates from agent reasoning | suspicion/trust を推理結果から更新 |

--- a/scripts/rescue_unicode.py
+++ b/scripts/rescue_unicode.py
@@ -1,0 +1,61 @@
+"""Rewrite actor state JSON files from escaped Unicode to readable UTF-8.
+
+Usage:
+    python scripts/rescue_unicode.py                    # dry-run (show what would change)
+    python scripts/rescue_unicode.py --apply            # actually rewrite files
+    python scripts/rescue_unicode.py --apply --verbose  # show each file processed
+
+Targets: state_archive/**/agents/*.json
+Idempotent: files already in readable UTF-8 are skipped (output equals input).
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _rewrite(path: Path, apply: bool, verbose: bool) -> bool:
+    """Return True if the file would be (or was) changed."""
+    original = path.read_text(encoding="utf-8")
+    data = json.loads(original)
+    rewritten = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+    if rewritten == original:
+        if verbose:
+            print(f"  skip (already readable): {path}")
+        return False
+
+    if apply:
+        path.write_text(rewritten, encoding="utf-8")
+        print(f"  fixed: {path}")
+    else:
+        print(f"  would fix: {path}")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Actually rewrite files (default: dry-run)")
+    parser.add_argument("--verbose", action="store_true", help="Also report already-readable files")
+    args = parser.parse_args()
+
+    root = Path(__file__).parent.parent
+    targets = sorted(root.glob("state_archive/**/agents/*.json"))
+
+    if not targets:
+        print("No files found under state_archive/**/agents/")
+        return
+
+    changed = 0
+    for path in targets:
+        if _rewrite(path, apply=args.apply, verbose=args.verbose):
+            changed += 1
+
+    mode = "fixed" if args.apply else "would fix"
+    print(f"\n{mode}: {changed} / {len(targets)} files")
+    if not args.apply and changed:
+        print("Re-run with --apply to actually rewrite.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/store.py
+++ b/src/agent/store.py
@@ -13,7 +13,7 @@ def save(actor: Actor) -> None:
     _ensure_dir()
     path = STATE_DIR / f"{actor.name.lower()}.json"
     data = actor_to_dict(actor)
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
 def load(name: str) -> Actor:

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -80,3 +80,25 @@ def test_save_writes_split_json(tmp_path: Path, monkeypatch) -> None:
     assert "profile" in written
     assert "state" in written
     assert written["role"] == "Villager"
+
+
+def test_save_preserves_non_ascii_text(tmp_path: Path, monkeypatch) -> None:
+    """
+    SUT: store.save()
+    Mock: monkeypatch で STATE_DIR を tmp_path に差し替え
+    Level: unit
+    Objective: memory_summary に日本語を含む ActorState を save したとき、
+               書き込まれたファイルに \\uXXXX 形式のエスケープが含まれないこと。
+    """
+    monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+    japanese_memory = "初日：setsu を怪しいと感じた"
+    actor = Actor(
+        profile=ActorProfile(name="Alice", persona=Persona(style="calm")),
+        state=ActorState(beliefs={}, memory_summary=[japanese_memory], is_alive=True),
+        role=get_role("Villager"),
+    )
+    store.save(actor)
+
+    raw = (tmp_path / "alice.json").read_text(encoding="utf-8")
+    assert japanese_memory in raw, "Japanese text must appear as-is in the saved file"
+    assert r"\u" not in raw, "Escaped Unicode sequences must not appear in the saved file"


### PR DESCRIPTION
## Summary
- `store.save()` に `ensure_ascii=False` を追加し、日本語などの非 ASCII テキストが `\uXXXX` 形式でエスケープされなくなった
- `scripts/rescue_unicode.py` を追加。既存の `state_archive/**/agents/*.json` を UTF-8 可読形式に一括変換できる（冪等・dry-run デフォルト）
- `test_save_preserves_non_ascii_text` を追加し、リグレッションを防ぐ

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（288 passed）
- [ ] `test_save_preserves_non_ascii_text` — 日本語テキストが `\uXXXX` 形式でエスケープされないことを検証

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)