### PR TITLE
refactor: remove VoteCandidate; use dict[str, float] for attack_candidates

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#235 | tech-debt | ❌ | 1 | Remove VoteCandidate class; use plain dict for attack_candidates | VoteCandidate を削除し attack_candidates を dict に統一 |
 | yukkie/AgentVillage#207 | tech-debt | ❌ | 2 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
 | yukkie/AgentVillage#237 | enhancement | ❌ | 3 | Add threat_scores for Werewolf to guide night attack decisions | 狼専用の脅威スコアを発言出力に追加し夜会話のヒントとして渡す |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -64,11 +64,6 @@ class NightActionOutput(BaseModel):
     reasoning: str = ""
 
 
-class VoteCandidate(BaseModel):
-    target: str
-    score: float
-
-
 class WolfSelfCoDecision(BaseModel):
     """LLM response schema for a werewolf's personal final next-day CO decision."""
 
@@ -124,5 +119,5 @@ class WolfChatOutput(BaseModel):
 
     thought: str
     speech: str
-    attack_candidates: list[VoteCandidate] = []
+    attack_candidates: dict[str, float] = {}
     self_co_decision: WolfSelfCoDecision = WolfSelfCoDecision()

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -124,9 +124,9 @@ def _run_wolf_chat(engine: GameEngine) -> str | None:
     for wolf in wolves:
         out = last_wolf_outputs[wolf.name]
         if out and out.attack_candidates:
-            for vc in out.attack_candidates:
-                if vc.target in alive_names and vc.target not in wolf_names:
-                    score_totals[vc.target] = score_totals.get(vc.target, 0.0) + vc.score
+            for target, score in out.attack_candidates.items():
+                if target in alive_names and target not in wolf_names:
+                    score_totals[target] = score_totals.get(target, 0.0) + score
     if score_totals:
         return max(score_totals, key=lambda t: score_totals[t])
     return None

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -353,7 +353,7 @@ class LLMClient:
             return WolfChatOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
             _classify_and_log_error("call_wolf_chat", actor.name, e, raw)
-            return WolfChatOutput(thought="...", speech="...", attack_candidates=[])
+            return WolfChatOutput(thought="...", speech="...", attack_candidates={})
 
     def call_night_action(
         self,

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -422,10 +422,7 @@ Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
 {{
   "thought": "<your private reasoning>",
   "speech": "<what you say to your wolf partner(s)>",
-  "attack_candidates": [
-    {{"target": "<player_name>", "score": <0.0-1.0>}},
-    ...
-  ],
+  "attack_candidates": {{"<player_name>": <0.0-1.0>, ...}},
   "self_co_decision": {{
     "claim_role": "<role_name or null>",
     "timing": "next_day" | "wait"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def make_wolf_chat_side_effect(score: float = 0.8) -> callable:
         callable that accepts (actor: Actor, wolf_partners: list[str], alive: list[str], log, lang)
         and returns WolfChatOutput with a non-wolf target.
     """
-    from src.domain.schema import VoteCandidate, WolfChatOutput
+    from src.domain.schema import WolfChatOutput
 
     def _side_effect(actor, wolf_partners, alive, log, lang):
         # actor: Actor instance
@@ -208,7 +208,7 @@ def make_wolf_chat_side_effect(score: float = 0.8) -> callable:
         return WolfChatOutput(
             thought="thinking",
             speech=f"{actor.name} votes to attack {target}" if target else "no valid target",
-            attack_candidates=[VoteCandidate(target=target, score=score)] if target else [],
+            attack_candidates={target: score} if target else {},
         )
 
     return _side_effect
@@ -250,7 +250,7 @@ PRE_NIGHT_CO_OUTPUT_JSON = json.dumps({
 WOLF_CHAT_OUTPUT_JSON = json.dumps({
     "thought": "thinking",
     "speech": "Let's attack Alice.",
-    "attack_candidates": [{"target": "Alice", "score": 0.9}],
+    "attack_candidates": {"Alice": 0.9},
     "self_co_decision": {"claim_role": "Seer", "timing": "next_day"},
 })
 

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -6,7 +6,7 @@ SUT: src/engine/phase_night — _run_wolf_chat, _resolve_night_outcomes, _publis
 from unittest.mock import patch
 
 from src.domain.event import EventType
-from src.domain.schema import VoteCandidate, WolfChatOutput
+from src.domain.schema import WolfChatOutput
 from src.engine.phase_night import (
     AttackDeclaration,
     GuardDeclaration,
@@ -77,7 +77,7 @@ class TestRunWolfChat:
         engine._llm_client.call_wolf_chat.return_value = WolfChatOutput(
             thought="thinking",
             speech="...",
-            attack_candidates=[],
+            attack_candidates={},
         )
 
         result = _run_wolf_chat(engine)
@@ -101,10 +101,7 @@ class TestRunWolfChat:
             return WolfChatOutput(
                 thought="thinking",
                 speech="...",
-                attack_candidates=[
-                    VoteCandidate(target="Wolf2", score=0.9),  # own pack — must be excluded
-                    VoteCandidate(target="Alice", score=0.5),
-                ],
+                attack_candidates={"Wolf2": 0.9, "Alice": 0.5},
             )
 
         engine._llm_client.call_wolf_chat.side_effect = wolf_chat_with_wolf_target
@@ -131,7 +128,7 @@ class TestRunWolfChat:
                 {
                     "thought": "thinking",
                     "speech": "...",
-                    "attack_candidates": [{"target": "Alice", "score": 0.7}],
+                    "attack_candidates": {"Alice": 0.7},
                     "self_co_decision": {
                         "claim_role": "Seer" if actor.name == "Wolf1" else "Medium",
                         "timing": "next_day",
@@ -166,7 +163,7 @@ class TestRunWolfChat:
             {
                 "thought": "thinking",
                 "speech": "...",
-                "attack_candidates": [{"target": "Alice", "score": 0.7}],
+                "attack_candidates": {"Alice": 0.7},
                 "self_co_decision": {"claim_role": None, "timing": "wait"},
             }
         )
@@ -196,7 +193,7 @@ class TestRunWolfChat:
                     {
                         "thought": "thinking",
                         "speech": "You fake-CO Medium, I will fake-CO Seer.",
-                        "attack_candidates": [{"target": "Alice", "score": 0.7}],
+                        "attack_candidates": {"Alice": 0.7},
                         "self_co_decision": {"claim_role": "Seer", "timing": "next_day"},
                     }
                 )
@@ -204,7 +201,7 @@ class TestRunWolfChat:
                 {
                     "thought": "thinking",
                     "speech": "I disagree, I will wait.",
-                    "attack_candidates": [{"target": "Alice", "score": 0.7}],
+                    "attack_candidates": {"Alice": 0.7},
                     "self_co_decision": {"claim_role": None, "timing": "wait"},
                 }
             )


### PR DESCRIPTION
## Summary
- `VoteCandidate` クラスを `src/domain/schema.py` から削除
- `WolfChatOutput.attack_candidates` を `list[VoteCandidate]` → `dict[str, float]` に変更（`suspicion_scores` と同じ形に統一）
- `phase_night.py` の集計ループを `out.attack_candidates.items()` で直接回すようシンプル化
- engine・tests・conftest の全参照を更新

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（295 passed）
- [x] `VoteCandidate` の残存参照がないことを確認

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)