### PR TITLE
feat: add threat_scores for Werewolf to guide night attack

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -328,6 +328,8 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 | `PRE_NIGHT_DECISION` | False | 前夜CO判断（観戦者のみ） |
 | `CO_ANNOUNCEMENT` | True | 役職公言。`claimed_role` フィールドに公言した役職名を格納 |
 | `VOTE_CANDIDATES` | False | 発言フェーズ（OPENING / DISCUSSION）での vote_candidates スナップショット（観戦者のみ）。`intent.vote_candidates` が非空のとき各発言後に emit される |
+| `SUSPICION_UPDATE` | False | 発言フェーズで村人視点の疑惑スコアが更新されたとき（観戦者のみ・dim cyan） |
+| `THREAT_UPDATE` | False | 発言フェーズで人狼視点の脅威スコアが更新されたとき（観戦者のみ・dim red） |
 | `PHASE_START` | True / False | フェーズ開始通知 |
 | `GAME_OVER` | True | ゲーム終了 |
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#207 | tech-debt | ❌ | 2 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
-| yukkie/AgentVillage#237 | enhancement | ❌ | 3 | Add threat_scores for Werewolf to guide night attack decisions | 狼専用の脅威スコアを発言出力に追加し夜会話のヒントとして渡す |
 | yukkie/AgentVillage#21 | enhancement | 🔴 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |
 | yukkie/AgentVillage#26 | enhancement | 🟢 | 2 | Thought log display mode switching | 思考ログの表示モード切り替え |

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -29,3 +29,17 @@ def update_beliefs(actor: Actor, suspicion_scores: dict[str, float]) -> Actor:
     except OSError as e:
         raise OSError(f"Failed to persist beliefs for {actor.name}: {e}") from e
     return actor
+
+
+def update_threat_scores(actor: Actor, threat_scores: dict[str, float]) -> Actor:
+    """Apply threat score updates to actor state and persist.
+
+    Values are clamped to [0.0, 1.0]. Intended for Werewolf actors only.
+    """
+    for name, score in threat_scores.items():
+        actor.state.threat_scores[name] = max(0.0, min(1.0, score))
+    try:
+        store.save(actor)
+    except OSError as e:
+        raise OSError(f"Failed to persist threat scores for {actor.name}: {e}") from e
+    return actor

--- a/src/domain/actor.py
+++ b/src/domain/actor.py
@@ -43,6 +43,7 @@ class ActorState(BaseModel):
     is_alive: bool = True
     claimed_role: RoleField = None  # publicly claimed role via CO; None until CO
     intended_co: RoleField = None  # role to claim in the next speech; None when not planning a CO
+    threat_scores: dict[str, float] = {}  # Werewolf-side: how threatening each player is (0.0=safe, 1.0=must eliminate)
 
 
 @dataclass

--- a/src/domain/event.py
+++ b/src/domain/event.py
@@ -21,6 +21,7 @@ class EventType(Enum):
     MEDIUM_RESULT = "medium_result"
     CO_ANNOUNCEMENT = "co_announcement"
     SUSPICION_UPDATE = "suspicion_update"
+    THREAT_UPDATE = "threat_update"
     GAME_OVER = "game_over"
     PHASE_START = "phase_start"
 

--- a/src/domain/roles/werewolf.py
+++ b/src/domain/roles/werewolf.py
@@ -78,6 +78,35 @@ class Werewolf(Role):
             "default, but adapt your claimed role to the current role distribution and existing claims."
         )
 
+    def output_format_prompt(self, lang: str = "English") -> str:
+        return f"""
+--- OUTPUT FORMAT ---
+You MUST respond with ONLY valid JSON matching this exact schema. No other text.
+
+{{
+  "thought": "<your internal reasoning, hidden from others>",
+  "speech": "<what you say aloud to the group>",
+  "reasoning": "<your public deduction: who you suspect and why>",
+  "intent": {{
+    "co": "<role_name or null>"
+  }},
+  "memory_update": ["<key thing to remember for future turns>", ...],
+  "suspicion_scores": {{"<player_name>": <0.0-1.0>, ...}},
+  "threat_scores": {{"<player_name>": <0.0-1.0>, ...}}
+}}
+
+Rules:
+- "thought", "speech", "reasoning", "memory_update" must be written in {lang}
+- "thought" is your private inner monologue
+- "speech" is your actual spoken words (1-3 sentences)
+- "reasoning" is your public deduction statement (1-2 sentences)
+- "intent.co" is your role claim if you choose to reveal it, otherwise null
+- "memory_update" lists 0-3 key observations to remember
+- "suspicion_scores" maps each player you have updated village-side suspicion about (0.0=trusted, 1.0=certain werewolf from the village perspective); omit players whose suspicion has not changed
+- "threat_scores" maps each player by how threatening they are to your werewolf team (0.0=safe, 1.0=must eliminate — prioritize Seer, Knight, or anyone close to exposing you); omit players whose threat level has not changed
+- Do NOT include your real role in speech unless you are doing a CO
+"""
+
     def vote_strategy_prompt(self) -> str:
         return (
             "\n--- VOTE STRATEGY ---\n"

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -107,6 +107,7 @@ class AgentOutput(BaseModel):
     intent: Intent
     memory_update: list[str] = []
     suspicion_scores: dict[str, float] | None = None
+    threat_scores: dict[str, float] | None = None
 
 
 class WolfChatOutput(BaseModel):

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -224,6 +224,20 @@ class GameEngine:
                 is_public=False,
             ))
 
+        if output.threat_scores:
+            memory_mod.update_threat_scores(actor, output.threat_scores)
+            scores_str = ", ".join(
+                f"{name}={score:.2f}" for name, score in output.threat_scores.items()
+            )
+            self._emit(LogEvent.make(
+                day=self.day,
+                phase=phase.value,
+                event_type=EventType.THREAT_UPDATE,
+                agent=actor.name,
+                content=f"{actor.name} threat update: {scores_str}",
+                is_public=False,
+            ))
+
         if output.memory_update:
             memory_mod.update_memory(actor, output.memory_update)
 

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -412,6 +412,11 @@ def build_wolf_chat_prompt(
         "Also coordinate your deception plan for the next day: who should fake-CO, which role each wolf should claim, and whether anyone should wait instead.",
         "You are allowed to decide that both wolves fake-CO, only one does, both wait, or even claim the same role if that fits your strategy.",
     ]
+    if actor.state.threat_scores:
+        lines.append("\nYour current threat assessments (0.0=safe to ignore, 1.0=must eliminate soon):")
+        lines.append("Use these to prioritize tonight's attack target.")
+        for name, score in actor.state.threat_scores.items():
+            lines.append(f"  {name}: threat={score:.2f}")
     if wolf_chat_log:
         lines.append("\nWolf team conversation so far:")
         for entry in wolf_chat_log:

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -92,6 +92,9 @@ class Renderer:
         elif event.event_type == EventType.SUSPICION_UPDATE:
             text.append(f"[SUSPICION] {event.content}", style="dim cyan")
 
+        elif event.event_type == EventType.THREAT_UPDATE:
+            text.append(f"[THREAT] {event.content}", style="dim red")
+
         elif event.event_type == EventType.PRE_NIGHT_DECISION:
             # Spectator only — color by the speaker's true role.
             actor = self._get_agent(event.agent)

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -2,6 +2,7 @@
 _run_day() のフェーズ順・speech_id採番・フォールバックを検証する。
 LLM呼び出し (LLMClient メソッド) はモック。
 """
+import pytest
 from unittest.mock import MagicMock, patch
 
 from src.engine.game import GameEngine
@@ -417,6 +418,64 @@ class TestRunNightPhaseOrder:
         assert seer.is_alive is False
         assert seer.state.beliefs == {}
         assert not any(e.event_type == EventType.INSPECTION for e in events)
+
+    def test_apply_speech_output_threat_scores_updates_state_and_emits_event(
+        self, make_test_actor, make_test_engine
+    ):
+        """
+        SUT: GameEngine._apply_speech_output()
+        Mock: monkeypatch で store.save を no-op に差し替え（make_test_engine 経由）
+        Level: unit
+        Objective: AgentOutput.threat_scores が非 None のとき actor.state.threat_scores が
+                   更新され THREAT_UPDATE イベントが emit されること。
+        """
+        wolf = make_test_actor("Wolf", "Werewolf")
+        villager = make_test_actor("Alice")
+        engine, events = make_test_engine([wolf, villager])
+
+        output = AgentOutput(
+            thought="thinking",
+            speech="Hello.",
+            reasoning="reasoning",
+            intent=Intent(),
+            threat_scores={"Alice": 0.85},
+        )
+
+        with patch("src.agent.store.save"):
+            engine._apply_speech_output(wolf, output, Phase.DAY_OPENING)
+
+        assert wolf.state.threat_scores["Alice"] == pytest.approx(0.85)
+        threat_events = [e for e in events if e.event_type == EventType.THREAT_UPDATE]
+        assert len(threat_events) == 1
+        assert "Alice=0.85" in threat_events[0].content
+        assert threat_events[0].is_public is False
+
+    def test_apply_speech_output_no_threat_scores_emits_no_threat_event(
+        self, make_test_actor, make_test_engine
+    ):
+        """
+        SUT: GameEngine._apply_speech_output()
+        Mock: patch で store.save を no-op に差し替え
+        Level: unit
+        Objective: AgentOutput.threat_scores が None のとき THREAT_UPDATE イベントが
+                   emit されないこと。
+        """
+        wolf = make_test_actor("Wolf", "Werewolf")
+        villager = make_test_actor("Alice")
+        engine, events = make_test_engine([wolf, villager])
+
+        output = AgentOutput(
+            thought="thinking",
+            speech="Hello.",
+            reasoning="reasoning",
+            intent=Intent(),
+            threat_scores=None,
+        )
+
+        with patch("src.agent.store.save"):
+            engine._apply_speech_output(wolf, output, Phase.DAY_OPENING)
+
+        assert not any(e.event_type == EventType.THREAT_UPDATE for e in events)
 
     def test_inspection_is_published_if_seer_survives(self, make_test_actor, make_test_engine):
         seer = make_test_actor("Seer1", "Seer")

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -1,7 +1,7 @@
 """src/agent/memory.py のテスト。"""
 import pytest
 
-from src.agent.memory import update_beliefs, update_memory
+from src.agent.memory import update_beliefs, update_memory, update_threat_scores
 
 def test_update_memory_appends_new_items(monkeypatch, make_test_actor) -> None:
     """
@@ -112,3 +112,65 @@ def test_update_beliefs_raises_on_io_error(monkeypatch, make_test_actor) -> None
     actor = make_test_actor("Alice")
     with pytest.raises(OSError, match="Failed to persist beliefs for Alice"):
         update_beliefs(actor, {"Bob": 0.7})
+
+
+def test_update_threat_scores_sets_value(monkeypatch, make_test_actor) -> None:
+    """
+    SUT: update_threat_scores()
+    Mock: monkeypatch で store.save を no-op に差し替え
+    Level: unit
+    Objective: threat_scores に指定プレイヤーのスコアがセットされること。
+    """
+    from src.agent import memory as mem_mod
+    monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
+    actor = make_test_actor("Wolf")
+    result = update_threat_scores(actor, {"Seer": 0.9})
+    assert result.state.threat_scores["Seer"] == pytest.approx(0.9)
+
+
+def test_update_threat_scores_updates_existing(monkeypatch, make_test_actor) -> None:
+    """
+    SUT: update_threat_scores()
+    Mock: monkeypatch で store.save を no-op に差し替え
+    Level: unit
+    Objective: 既存エントリがあるとき上書き更新されること。
+    """
+    from src.agent import memory as mem_mod
+    monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
+    actor = make_test_actor("Wolf")
+    actor.state.threat_scores["Knight"] = 0.3
+    update_threat_scores(actor, {"Knight": 0.8})
+    assert actor.state.threat_scores["Knight"] == pytest.approx(0.8)
+
+
+def test_update_threat_scores_clamps_to_range(monkeypatch, make_test_actor) -> None:
+    """
+    SUT: update_threat_scores()
+    Mock: monkeypatch で store.save を no-op に差し替え
+    Level: unit
+    Objective: 範囲外の値（<0.0 または >1.0）が [0.0, 1.0] にクランプされること。
+    """
+    from src.agent import memory as mem_mod
+    monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
+    actor = make_test_actor("Wolf")
+    update_threat_scores(actor, {"Seer": 1.5, "Knight": -0.3})
+    assert actor.state.threat_scores["Seer"] == pytest.approx(1.0)
+    assert actor.state.threat_scores["Knight"] == pytest.approx(0.0)
+
+
+def test_update_threat_scores_raises_on_io_error(monkeypatch, make_test_actor) -> None:
+    """
+    SUT: update_threat_scores()
+    Mock: monkeypatch で store.save が OSError を送出するよう差し替え
+    Level: unit
+    Objective: store.save() が OSError を送出したとき、コンテキスト付きで OSError が re-raise されること。
+    """
+    from src.agent import memory as mem_mod
+
+    def failing_save(_):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mem_mod.store, "save", failing_save)
+    actor = make_test_actor("Wolf")
+    with pytest.raises(OSError, match="Failed to persist threat scores for Wolf"):
+        update_threat_scores(actor, {"Seer": 0.7})

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -1,7 +1,7 @@
 import pytest
 
 from src.domain.actor import Belief
-from src.llm.prompt import build_personal_info_prompt, build_role_prompt
+from src.llm.prompt import build_personal_info_prompt, build_role_prompt, build_wolf_chat_prompt
 from src.domain.roles import get_role
 
 
@@ -73,3 +73,33 @@ def test_personal_info_prompt_omits_suspicion_section_when_no_beliefs(make_test_
     actor.state.beliefs = {}
     prompt = build_personal_info_prompt(actor)
     assert "suspicion levels" not in prompt
+
+
+def test_wolf_chat_prompt_shows_threat_scores_when_present(make_test_actor):
+    """
+    SUT: build_wolf_chat_prompt()
+    Mock: なし
+    Level: unit
+    Objective: actor.state.threat_scores が非空のとき脅威スコアとガイダンスがプロンプトに含まれること。
+    """
+    actor = make_test_actor("Wolf", "Werewolf")
+    actor.state.threat_scores = {"Seer": 0.9, "Knight": 0.6}
+    prompt = build_wolf_chat_prompt(actor, [], ["Seer", "Knight", "Villager"], [])
+    assert "threat" in prompt.lower()
+    assert "Seer" in prompt
+    assert "0.90" in prompt
+    assert "Knight" in prompt
+    assert "0.60" in prompt
+
+
+def test_wolf_chat_prompt_omits_threat_section_when_empty(make_test_actor):
+    """
+    SUT: build_wolf_chat_prompt()
+    Mock: なし
+    Level: unit
+    Objective: actor.state.threat_scores が空のとき脅威スコアセクションが含まれないこと。
+    """
+    actor = make_test_actor("Wolf", "Werewolf")
+    actor.state.threat_scores = {}
+    prompt = build_wolf_chat_prompt(actor, [], ["Alice", "Bob"], [])
+    assert "threat assessments" not in prompt

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -82,6 +82,36 @@ def test_save_writes_split_json(tmp_path: Path, monkeypatch) -> None:
     assert written["role"] == "Villager"
 
 
+def test_actor_state_loads_without_threat_scores_field(tmp_path: Path, monkeypatch) -> None:
+    """
+    SUT: actor_from_dict() / ActorState
+    Mock: なし
+    Level: unit
+    Objective: threat_scores フィールドを持たない旧フォーマット JSON を読み込んだとき
+               エラーなく Actor が生成され、threat_scores が空辞書になること。
+    """
+    from src.domain.actor import actor_from_dict
+
+    old_json = {
+        "profile": {
+            "name": "Alice",
+            "model": "claude-haiku-4-5-20251001",
+            "persona": {"style": "calm", "lie_tendency": 0.2, "aggression": 0.3},
+        },
+        "state": {
+            "beliefs": {},
+            "memory_summary": [],
+            "is_alive": True,
+            "claimed_role": None,
+            "intended_co": None,
+            # threat_scores フィールドは意図的に省略
+        },
+        "role": "Villager",
+    }
+    actor = actor_from_dict(old_json)
+    assert actor.state.threat_scores == {}
+
+
 def test_save_preserves_non_ascii_text(tmp_path: Path, monkeypatch) -> None:
     """
     SUT: store.save()

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -364,3 +364,47 @@ def test_judgment_reasoning_is_dimmed() -> None:
     assert result is not None
     dim_spans = [s for s in result.spans if "dim" in str(s.style)]
     assert len(dim_spans) >= 1
+
+
+def test_threat_update_renders_with_dim_red_style() -> None:
+    """
+    SUT: Renderer.on_event (THREAT_UPDATE)
+    Mock: なし
+    Level: unit
+    Objective: THREAT_UPDATE イベントが [THREAT] プレフィックスで dim red スタイルとして描画されること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.THREAT_UPDATE,
+        agent="Wolf",
+        content="Wolf threat update: Seer=0.90, Knight=0.60",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "[THREAT]" in result.plain
+    assert "Seer=0.90" in result.plain
+    red_spans = [s for s in result.spans if "red" in str(s.style)]
+    assert len(red_spans) >= 1
+
+
+def test_threat_update_hidden_in_public_mode() -> None:
+    """
+    SUT: Renderer.on_event (THREAT_UPDATE)
+    Mock: なし
+    Level: unit
+    Objective: THREAT_UPDATE は is_public=False のため public モードでは None を返すこと。
+    """
+    renderer = Renderer([], spectator_mode=False)
+    event = _make_event(
+        EventType.THREAT_UPDATE,
+        agent="Wolf",
+        content="Wolf threat update: Seer=0.90",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is None


### PR DESCRIPTION
## Summary
- Add `ActorState.threat_scores: dict[str, float] = {}` (backward-compatible with old JSON)
- Add `AgentOutput.threat_scores: dict[str, float] | None = None` (Werewolf only)
- Add `update_threat_scores()` in `memory.py` with [0.0, 1.0] clamping
- Add `EventType.THREAT_UPDATE`; spectator log shows `[THREAT]` in dim red
- `build_wolf_chat_prompt()` shows current threat scores as attack hints
- `Werewolf.output_format_prompt()` instructs wolves to emit `threat_scores`

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス (306 tests)
- [ ] `update_threat_scores()` — clamp・更新・IOエラーの各ケース
- [ ] `build_wolf_chat_prompt()` — スコアあり/なし
- [ ] `_apply_speech_output()` — THREAT_UPDATE emit と非 emit
- [ ] `THREAT_UPDATE` renderer — dim red 表示・public モード非表示
- [ ] 旧 JSON（threat_scores なし）の backward 互換読み込み

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)