### PR TITLE
feat: merge judgment and speech into single DISCUSSION tool use call

### DIFF
--- a/config/tokens.json
+++ b/config/tokens.json
@@ -1,6 +1,6 @@
 {
   "call_speech": 2048,
-  "call_judgment": 1024,
+  "call_discussion": 2048,
   "call_vote": 512,
   "call_pre_night_action": 1024,
   "call_wolf_chat": 2048,

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -158,13 +158,13 @@ CO には2種類のフォールバックがある。
 
 | 関数 | 用途 | プロンプト | 出力モデル |
 |---|---|---|---|
-| `call()` | 発言生成（OPENING / DISCUSSION） | フル（役職・性格・記憶・当日ログ・他者のCO情報・狼仲間（狼のみ）） | `AgentOutput` |
-| `call_judgment()` | 判断（DISCUSSION 並列） | 軽量（役職・性格・memory_summary・直近発言のみ） | `JudgmentOutput` (`claim_role` を含む) |
+| `call()` | 発言生成（OPENING） | フル（役職・性格・記憶・当日ログ・他者のCO情報・狼仲間（狼のみ）） | `AgentOutput` |
+| `call_discussion()` | 発言生成（DISCUSSION 単体） | フル + tool use（`speak` / `challenge` / `co` / `silent` の4 tool） | `DiscussionResult`（`SpeakResult \| ChallengeResult \| CoResult \| SilentResult`） |
 | `call_vote()` | 投票（VOTE フェーズ専用） | 役職・性格・当日議論ログ・past_votes・past_deaths・最終 vote_candidates・狼仲間／VOTE STRATEGY（狼のみ） | `VoteOutput` (`target` + `reasoning` + `strategy`) |
 | `call_night_action()` | 夜行動 | 夜フェーズ専用 | `NightActionOutput` (`target` + `reasoning`) |
 | `call_pre_night_action()` | 前夜判断・単体呼び出し | 役職・性格・参加者情報 | `PreNightOutput` (`claim_role` を含む) |
 | `call_pre_night_parallel()` | 前夜判断・並列呼び出し（`call_speech_parallel` と同パターン） | 同上 | `Iterator[tuple[Actor, PreNightOutput]]` |
-| `call_discussion_parallel()` | 昼DISCUSSION 判断→発言チェーンの並列実行 | — | `Iterator[tuple[Actor, JudgmentOutput, AgentOutput \| None, SpeechEntry \| None]]` |
+| `call_discussion_parallel()` | 昼DISCUSSION 発言の並列実行 | — | `Iterator[tuple[Actor, DiscussionResult, SpeechEntry \| None]]` |
 | `call_vote_parallel()` | 昼VOTE 投票判断の並列実行 | — | `Iterator[tuple[Actor, VoteOutput]]` |
 
 #### 並列実行
@@ -175,7 +175,7 @@ CO には2種類のフォールバックがある。
 |---|---|
 | `call_speech_parallel()` | DAY_OPENING — 全員発言を並列実行 |
 | `call_pre_night_parallel()` | PRE_NIGHT — CO判断を並列実行 |
-| `call_discussion_parallel()` | DAY_DISCUSSION — 判断→発言チェーンを並列実行 |
+| `call_discussion_parallel()` | DAY_DISCUSSION — 発言（tool use 1ステップ）を並列実行 |
 | `call_vote_parallel()` | DAY_VOTE — 全員の投票判断を並列実行 |
 
 #### Extended thinking
@@ -304,19 +304,21 @@ SQLite、PostgreSQL。
 全エージェントが毎ターン発言するだけでは会話がモノローグの羅列になり、AIが自発的に反応する動的な議論が生まれない。
 
 **決定**
-昼フェーズに「判断ターン」を導入する。全エージェントに「challenge / speak / silent」の3択を並列で判断させ、発言意思があるエージェントだけ発言を生成する。発言順はAPIレスポンスが返ってきた順とする。
+昼フェーズに「判断ターン」を導入する。全エージェントに「challenge / speak / silent / co」の4択を並列で判断させ、発言意思があるエージェントだけ発言を生成する。発言順はAPIレスポンスが返ってきた順とする。
 
 **実装方法**
-- 各アクターに「`call_judgment()` → non-silent なら `build_speech_args()` → `call()`」をチェーンした callable を構成
-- `decision="co"` の場合は `JudgmentOutput.claim_role` を `resolve_claim_role()` で `intended_co` に正規化してから発言生成へ渡す
+- Claude の tool use を使い、`speak` / `challenge` / `co` / `silent` の4 tool を定義した1回の API コールで判断と発言を同時に生成する（`call_discussion()`）
+- decision ごとに専用 result dataclass（`SpeakResult` / `ChallengeResult` / `CoResult` / `SilentResult`）で受け取る
 - `call_discussion_parallel()` が `ThreadPoolExecutor` で全アクター分を並列実行（client.py 内）
-- game.py はチェーン用の `build_speech_args` コールバックを渡し、並列実行自体は client.py に委譲する
 - `as_completed()` でレスポンス順に post-processing（`today_log` 更新・イベント発行）を逐次実行
 - 発言コンテキストはラウンド開始時のスナップショットを共有（同ラウンド内の他者発言は見えない）
 - challenge 時は `reply_to`（speech_id）をスナップショット内で解決しプロンプトに含める
+- `phase_day.py` は `isinstance(result, SilentResult)` でガードし、残りは `speech` を持つとして処理する
 
 **理由**
-- 判断プロンプトは軽量（memory_summary + 直近発言のみ）なので並列実行しても低コスト
+- tool use により判断と発言が1回の API コールに統合され、レイテンシが削減される
+- decision ごとに tool schema が分かれるため、LLM の混乱が少なく構造化出力の精度が上がる
+- `build_speech_args` コールバックが不要になり、client.py のエンジン依存が解消される
 - レスポンス順発言により「先に返ってきた反応が場の流れを作る」自然な会話ダイナミクスが生まれる
 - challenge 時の speech_id 参照で、どの発言への反応かがログ上で追跡できる
 

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -190,7 +190,48 @@ class AgentOutput(BaseModel):
     memory_update: list[str]
 ```
 
-### JudgmentOutput / PreNightOutput スキーマ
+### DiscussionResult — tool use 結果 dataclass 群
+
+`call_discussion()` は Claude の tool use で4 tool を定義し、LLM が選んだ tool 名に応じて以下の dataclass を返す。
+
+```python
+@dataclass
+class SpeakResult:
+    thought: str
+    speech: str
+    co: Role | None = None          # speech 中に CO した場合
+    memory_update: list[str] = field(default_factory=list)
+    suspicion_scores: dict[str, float] | None = None
+    threat_scores: dict[str, float] | None = None
+
+@dataclass
+class ChallengeResult:
+    thought: str
+    speech: str
+    reply_to: int                   # 反論対象の speech_id
+    memory_update: list[str] = field(default_factory=list)
+    suspicion_scores: dict[str, float] | None = None
+    threat_scores: dict[str, float] | None = None
+
+@dataclass
+class CoResult:
+    thought: str
+    speech: str
+    claim_role: Role                # 公言する役職（必須）
+    memory_update: list[str] = field(default_factory=list)
+    suspicion_scores: dict[str, float] | None = None
+    threat_scores: dict[str, float] | None = None
+
+@dataclass
+class SilentResult:
+    reasoning: str                  # 観戦者向け理由
+
+DiscussionResult = SpeakResult | ChallengeResult | CoResult | SilentResult
+```
+
+エンジン側は `isinstance(result, SilentResult)` でガードし、残りは `speech` を持つとして処理する。
+
+### PreNightOutput スキーマ
 
 ```python
 class PreNightOutput(BaseModel):
@@ -198,14 +239,11 @@ class PreNightOutput(BaseModel):
     decision: Literal["co", "wait"]
     claim_role: Role | None = None
     reasoning: str
+```
 
-class JudgmentOutput(BaseModel):
-    decision: Literal["challenge", "speak", "silent", "co"]
-    reply_to: int | None = None
-    claim_role: Role | None = None
-    reasoning: str = ""   # why this action was chosen (spectator-only)
+### NightActionOutput / VoteOutput スキーマ
 
-
+```python
 class NightActionOutput(BaseModel):
     target: str           # validated alive player name
     reasoning: str = ""   # why this target was chosen (spectator-only)
@@ -217,16 +255,12 @@ class VoteOutput(BaseModel):
     strategy: Literal["village_side", "wolf_side"] | None = None  # Werewolf-only
 ```
 
-- `claim_role` は `decision="co"` のときに名乗る予定の役職
-- 未指定時は `resolve_claim_role()` が `default_claim_role` を使って補完する
-- `can_co=False` の役職に `claim_role` が入った場合は想定外経路として警告ログを出し、無視する
-
 ### LLM呼び出し関数と max_tokens 設定
 
 | 関数 | 用途 | max_tokens | 理由 |
 |---|---|---|---|
-| `call()` | 昼フェーズの発言生成（OPENING / DISCUSSION） | 2048 | thought が日本語で長くなりやすい |
-| `call_judgment()` | 昼フェーズの並列判断（challenge / speak / silent / co） | 1024 | `decision`, `reply_to`, `claim_role` の軽量JSON。`co_eligible=True` のときのみ `"co"` を選択肢に含める |
+| `call()` | 昼フェーズの発言生成（OPENING） | 2048 | thought が日本語で長くなりやすい |
+| `call_discussion()` | 昼フェーズの発言生成（DISCUSSION、tool use） | 2048 | thought + speech を tool use で1回に統合。日本語で長くなりやすい |
 | `call_vote()` | 昼フェーズの投票判断（VOTE） | 512 | `target` + `reasoning` + `strategy`（狼のみ）。reasoning が日本語で多少長くなることを見込む |
 | `call_wolf_chat()` | 夜フェーズの狼チーム会話 | 2048 | thought + speech + attack_candidates + self_co_decision。日本語で長くなりやすい |
 | `call_pre_night_action()` | 前夜フェーズの CO 判断（村人以外） | 1024 | thought + decision + claim_role + reasoning の4フィールド |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
-| yukkie/AgentVillage#88 | enhancement | 🔴 | 5 | Merge judgment and speech into single LLM call using tool use | tool useで発言+アクション構造化を1ステップ化。OPENING/DISCUSSION設計を統一 |
 | yukkie/AgentVillage#21 | enhancement | 🟡 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |
 | yukkie/AgentVillage#227 | enhancement | 🟡 | 2 | Add early exit for wolf night chat consensus | 全狼の最新攻撃候補が一致したら夜会話を早期終了し、未合意時は既存ラウンド継続を維持する |

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, BeforeValidator, PlainSerializer
@@ -38,18 +39,67 @@ class SpeechEntry(BaseModel):
     text: str
 
 
-class JudgmentOutput(BaseModel):
-    """LLM response schema for the discussion-phase judgment call.
+@dataclass
+class SpeakResult:
+    """Result of the 'speak' tool use in a DISCUSSION turn.
 
     Mock-Policy: Forbidden
-        LLM I/O contract. See ``PreNightOutput`` and
-        ``tests/TestStrategy.md`` §5.
+        DISCUSSION tool use result contract. Tests must not synthesize
+        free-form replacements. See ``tests/TestStrategy.md`` §5.
     """
 
-    decision: Literal["challenge", "speak", "silent", "co"]
-    reply_to: int | None = None
-    claim_role: RoleField = None
-    reasoning: str = ""
+    thought: str
+    speech: str
+    co: Role | None = None
+    memory_update: list[str] = field(default_factory=list)
+    suspicion_scores: dict[str, float] | None = None
+    threat_scores: dict[str, float] | None = None
+
+
+@dataclass
+class ChallengeResult:
+    """Result of the 'challenge' tool use in a DISCUSSION turn.
+
+    Mock-Policy: Forbidden
+        DISCUSSION tool use result contract. See ``tests/TestStrategy.md`` §5.
+    """
+
+    thought: str
+    speech: str
+    reply_to: int
+    memory_update: list[str] = field(default_factory=list)
+    suspicion_scores: dict[str, float] | None = None
+    threat_scores: dict[str, float] | None = None
+
+
+@dataclass
+class CoResult:
+    """Result of the 'co' tool use in a DISCUSSION turn.
+
+    Mock-Policy: Forbidden
+        DISCUSSION tool use result contract. See ``tests/TestStrategy.md`` §5.
+    """
+
+    thought: str
+    speech: str
+    claim_role: Role
+    memory_update: list[str] = field(default_factory=list)
+    suspicion_scores: dict[str, float] | None = None
+    threat_scores: dict[str, float] | None = None
+
+
+@dataclass
+class SilentResult:
+    """Result of the 'silent' tool use in a DISCUSSION turn.
+
+    Mock-Policy: Forbidden
+        DISCUSSION tool use result contract. See ``tests/TestStrategy.md`` §5.
+    """
+
+    reasoning: str
+
+
+DiscussionResult = SpeakResult | ChallengeResult | CoResult | SilentResult
 
 
 class NightActionOutput(BaseModel):

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -9,8 +9,8 @@ from src.engine.phase_night import run_night_phase
 from src.engine.phase_pre_night import run_pre_night_phase
 from src.llm import factory as llm_factory
 from src.llm.client import LLMClient
-from src.llm.prompt import PastDeath, PastVote, PublicContext, SpeechDirection, WolfSpecificContext
-from src.domain.schema import AgentOutput, SpeechEntry
+from src.llm.prompt import PastDeath, PastVote, PublicContext, RoleSpecificContext, SpeechDirection, WolfSpecificContext
+from src.domain.schema import AgentOutput, ChallengeResult, CoResult, DiscussionResult, SilentResult, SpeechEntry
 from src.action.types import ActionType, Vote
 from src.action.validator import validate
 from src.domain.event import LogEvent, EventType
@@ -240,6 +240,137 @@ class GameEngine:
 
         if output.memory_update:
             memory_mod.update_memory(actor, output.memory_update)
+
+        return entry
+
+    def _build_discussion_ctx_map(
+        self,
+        today_log_snapshot: list[SpeechEntry],
+    ) -> dict[str, tuple[PublicContext, RoleSpecificContext | None]]:
+        """Build ctx_map for call_discussion_parallel from the current game state."""
+        ctx = PublicContext(
+            today_log=list(today_log_snapshot),
+            alive_players=self._alive_names(),
+            dead_players=self._dead_names(),
+            day=self.day,
+            all_agents=self.agents,
+            past_votes=self._past_votes,
+            past_deaths=self._past_deaths,
+        )
+        result: dict[str, tuple[PublicContext, RoleSpecificContext | None]] = {}
+        for actor in self._alive_agents():
+            role_ctx: RoleSpecificContext | None = (
+                WolfSpecificContext(
+                    wolf_partners=[
+                        a.name for a in self._alive_agents()
+                        if isinstance(a.role, Werewolf) and a.name != actor.name
+                    ]
+                )
+                if isinstance(actor.role, Werewolf)
+                else None
+            )
+            result[actor.name] = (ctx, role_ctx)
+        return result
+
+    def _apply_discussion_result(
+        self,
+        actor: Actor,
+        result: DiscussionResult,
+        phase: Phase,
+    ) -> SpeechEntry | None:
+        """Post-process a DiscussionResult: emit events, update state, append to today_log.
+
+        Returns the SpeechEntry if the actor spoke, or None if silent.
+        """
+        if isinstance(result, SilentResult):
+            self._emit(LogEvent.make(
+                day=self.day,
+                phase=phase.value,
+                event_type=EventType.SPEECH,
+                agent=actor.name,
+                content=f"{actor.name} is watching the village silently...",
+                is_public=True,
+            ))
+            return None
+
+        # All speaking variants share thought, speech, memory_update, suspicion_scores, threat_scores
+        reply_to_entry: SpeechEntry | None = None
+        if isinstance(result, ChallengeResult):
+            reply_to_entry = next(
+                (e for e in self.today_log if e.speech_id == result.reply_to),
+                None,
+            )
+
+        if isinstance(result, CoResult):
+            claim_role = result.claim_role
+            if actor.state.claimed_role != claim_role:
+                actor.state.claimed_role = claim_role
+                actor.state.intended_co = None
+                store.save(actor)
+                self._emit(LogEvent.make(
+                    day=self.day,
+                    phase=phase.value,
+                    event_type=EventType.CO_ANNOUNCEMENT,
+                    agent=actor.name,
+                    content=f"{actor.name} claims to be {claim_role.name}",
+                    is_public=True,
+                    claimed_role=claim_role,
+                ))
+
+        speech_id = self._next_speech_id()
+        entry = SpeechEntry(speech_id=speech_id, agent=actor.name, text=result.speech)
+        self.today_log.append(entry)
+
+        self._emit(LogEvent.make(
+            day=self.day,
+            phase=phase.value,
+            event_type=EventType.SPEECH,
+            agent=actor.name,
+            content=result.speech,
+            is_public=True,
+            speech_id=speech_id,
+            reply_to=reply_to_entry.speech_id if reply_to_entry else None,
+        ))
+        self._emit(LogEvent.make(
+            day=self.day,
+            phase=phase.value,
+            event_type=EventType.SPEECH,
+            agent=actor.name,
+            content=f"[THINK] {result.thought}",
+            is_public=False,
+            speech_id=speech_id,
+        ))
+
+        if result.suspicion_scores:
+            memory_mod.update_beliefs(actor, result.suspicion_scores)
+            scores_str = ", ".join(
+                f"{name}={score:.2f}" for name, score in result.suspicion_scores.items()
+            )
+            self._emit(LogEvent.make(
+                day=self.day,
+                phase=phase.value,
+                event_type=EventType.SUSPICION_UPDATE,
+                agent=actor.name,
+                content=f"{actor.name} suspicion update: {scores_str}",
+                is_public=False,
+            ))
+
+        if result.threat_scores:
+            memory_mod.update_threat_scores(actor, result.threat_scores)
+            scores_str = ", ".join(
+                f"{name}={score:.2f}" for name, score in result.threat_scores.items()
+            )
+            self._emit(LogEvent.make(
+                day=self.day,
+                phase=phase.value,
+                event_type=EventType.THREAT_UPDATE,
+                agent=actor.name,
+                content=f"{actor.name} threat update: {scores_str}",
+                is_public=False,
+            ))
+
+        if result.memory_update:
+            memory_mod.update_memory(actor, result.memory_update)
 
         return entry
 

--- a/src/engine/phase_day.py
+++ b/src/engine/phase_day.py
@@ -34,41 +34,17 @@ def _run_discussion(engine: GameEngine) -> None:
         engine._phase_start(Phase.DAY_DISCUSSION)
         alive = engine._alive_agents()
         snapshot = list(engine.today_log)
+        ctx_map = engine._build_discussion_ctx_map(snapshot)
 
         spoke_anyone = False
-        for actor, judgment, output, reply_to_entry in engine._llm_client.call_discussion_parallel(
+        for actor, result in engine._llm_client.call_discussion_parallel(
             alive,
-            snapshot,
-            engine._alive_names(),
-            engine.day,
+            ctx_map,
             engine.lang,
-            engine._build_speech_args,
         ):
-            if judgment.reasoning:
-                engine._emit(LogEvent.make(
-                    day=engine.day,
-                    phase=Phase.DAY_DISCUSSION.value,
-                    event_type=EventType.JUDGMENT,
-                    agent=actor.name,
-                    content=f"{actor.name} [{judgment.decision}]: {judgment.reasoning}",
-                    is_public=False,
-                    decision=judgment.decision,
-                    reasoning=judgment.reasoning,
-                ))
-            if output is None:
-                engine._emit(LogEvent.make(
-                    day=engine.day,
-                    phase=Phase.DAY_DISCUSSION.value,
-                    event_type=EventType.SPEECH,
-                    agent=actor.name,
-                    content=f"{actor.name} is watching the village silently...",
-                    is_public=True,
-                ))
-            else:
+            entry = engine._apply_discussion_result(actor, result, Phase.DAY_DISCUSSION)
+            if entry is not None:
                 spoke_anyone = True
-                engine._apply_speech_output(
-                    actor, output, Phase.DAY_DISCUSSION, reply_to_entry
-                )
 
         if not spoke_anyone:
             break

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import anthropic
@@ -9,8 +9,31 @@ import pydantic
 from src.config import MAX_TOKENS
 from src.domain.actor import Actor
 from src.domain.roles import Role
-from src.domain.schema import AgentOutput, Intent, JudgmentOutput, NightActionOutput, PreNightOutput, SpeechEntry, VoteOutput, WolfChatOutput
-from src.llm.prompt import PastDeath, PastVote, PublicContext, RoleSpecificContext, SpeechDirection, build_judgment_prompt, build_night_action_prompt, build_pre_night_prompt, build_system_prompt, build_vote_prompt, build_wolf_chat_prompt
+from src.domain.schema import (
+    AgentOutput,
+    DiscussionResult,
+    Intent,
+    NightActionOutput,
+    PreNightOutput,
+    SilentResult,
+    SpeechEntry,
+    VoteOutput,
+    WolfChatOutput,
+)
+from src.llm.discussion_tools import build_discussion_tools, parse_discussion_tool_result
+from src.llm.prompt import (
+    PastDeath,
+    PastVote,
+    PublicContext,
+    RoleSpecificContext,
+    SpeechDirection,
+    build_discussion_system_prompt,
+    build_night_action_prompt,
+    build_pre_night_prompt,
+    build_system_prompt,
+    build_vote_prompt,
+    build_wolf_chat_prompt,
+)
 
 
 def resolve_claim_role(actor: Actor, claim_role: Role | None) -> Role | None:
@@ -148,29 +171,35 @@ class LLMClient:
             _classify_and_log_error("call", actor.name, e, raw)
             return _default_output(actor)
 
-    def call_judgment(
+    def call_discussion(
         self,
         actor: Actor,
-        today_log: list[SpeechEntry],
-        alive_players: list[str],
-        day: int = 1,
+        ctx: PublicContext,
         lang: str = "English",
-    ) -> JudgmentOutput:
-        """Call LLM for the lightweight parallel judgment decision."""
+        role_ctx: RoleSpecificContext | None = None,
+    ) -> DiscussionResult:
+        """Call LLM for a DISCUSSION turn using tool use; return one DiscussionResult."""
         co_eligible = actor.state.claimed_role is None and actor.role.can_co
-        prompt = build_judgment_prompt(actor, today_log, alive_players, day, lang, co_eligible)
-        raw = ""
+        system_prompt = build_discussion_system_prompt(actor, ctx, co_eligible, lang, role_ctx)
+        tools = build_discussion_tools(co_eligible)
         try:
             message = self._client.messages.create(
                 model=actor.model,
-                max_tokens=MAX_TOKENS["call_judgment"],
-                messages=[{"role": "user", "content": prompt}],
+                max_tokens=MAX_TOKENS["call_discussion"],
+                system=system_prompt,
+                tools=tools,
+                tool_choice={"type": "any"},
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "It's your turn. Use one of the available tools to take your action.",
+                    }
+                ],
             )
-            raw = message.content[0].text
-            return JudgmentOutput.model_validate_json(_extract_json(raw))
+            return parse_discussion_tool_result(message, actor.name)
         except Exception as e:
-            _classify_and_log_error("call_judgment", actor.name, e, raw)
-            return JudgmentOutput(decision="silent", reasoning="")
+            _classify_and_log_error("call_discussion", actor.name, e, "")
+            return SilentResult(reasoning="error fallback")
 
     def call_speech_parallel(
         self,
@@ -227,39 +256,22 @@ class LLMClient:
     def call_discussion_parallel(
         self,
         actors: list[Actor],
-        today_log_snapshot: list[SpeechEntry],
-        alive_names: list[str],
-        day: int,
+        ctx_map: dict[str, tuple[PublicContext, RoleSpecificContext | None]],
         lang: str,
-        build_speech_args: Callable[
-            [Actor, SpeechEntry | None, list[SpeechEntry]],
-            tuple[PublicContext, SpeechDirection, RoleSpecificContext | None],
-        ],
-    ) -> Iterator[tuple[Actor, JudgmentOutput, AgentOutput | None, SpeechEntry | None]]:
-        """Run judgment→speech chain for all actors in parallel; yield results in completion order."""
+    ) -> Iterator[tuple[Actor, DiscussionResult]]:
+        """Run DISCUSSION tool use calls for all actors in parallel; yield in completion order.
 
-        def _chain(actor: Actor) -> tuple[Actor, JudgmentOutput, AgentOutput | None, SpeechEntry | None]:
-            judgment = self.call_judgment(actor, today_log_snapshot, alive_names, day, lang)
-            if judgment.decision == "silent":
-                return actor, judgment, None, None
-            is_co_eligible = actor.state.claimed_role is None and actor.role.can_co
-            actor.state.intended_co = (
-                resolve_claim_role(actor, judgment.claim_role)
-                if judgment.decision == "co" and is_co_eligible
-                else None
-            )
-            reply_to_entry: SpeechEntry | None = None
-            if judgment.decision == "challenge" and judgment.reply_to is not None:
-                reply_to_entry = next(
-                    (e for e in today_log_snapshot if e.speech_id == judgment.reply_to),
-                    None,
-                )
-            ctx, direction, role_ctx = build_speech_args(actor, reply_to_entry, today_log_snapshot)
-            output = self.call(actor, ctx, direction, role_ctx)
-            return actor, judgment, output, reply_to_entry
+        ``ctx_map`` maps actor name → (PublicContext, RoleSpecificContext | None),
+        pre-built by the engine so the client stays oblivious to game state.
+        """
+
+        def _call(actor: Actor) -> tuple[Actor, DiscussionResult]:
+            ctx, role_ctx = ctx_map[actor.name]
+            result = self.call_discussion(actor, ctx, lang, role_ctx)
+            return actor, result
 
         with ThreadPoolExecutor() as executor:
-            futures = {executor.submit(_chain, actor): actor for actor in actors}
+            futures = {executor.submit(_call, actor): actor for actor in actors}
             for future in as_completed(futures):
                 yield future.result()
 

--- a/src/llm/discussion_tools.py
+++ b/src/llm/discussion_tools.py
@@ -1,0 +1,173 @@
+"""Tool definitions and response parsing for DISCUSSION phase tool use calls."""
+
+import sys
+
+import anthropic
+
+from src.domain.schema import (
+    ChallengeResult,
+    CoResult,
+    DiscussionResult,
+    SilentResult,
+    SpeakResult,
+)
+from src.legacy.role_normalizer import normalize_role_field
+
+
+def build_discussion_tools(co_eligible: bool) -> list[dict]:
+    """Build the tool definitions list for a DISCUSSION call."""
+    role_names_hint = "e.g. Seer, Villager, Knight, Werewolf"
+    tools: list[dict] = [
+        {
+            "name": "speak",
+            "description": "Make a new statement to the group.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "thought": {"type": "string", "description": "Your private reasoning (not shown to others)."},
+                    "speech": {"type": "string", "description": "What you say aloud to the group."},
+                    "memory_update": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Short notes to add to your memory for future days.",
+                    },
+                    "suspicion_scores": {
+                        "type": "object",
+                        "description": "Updated suspicion per player (0.0=trusted, 1.0=certain wolf). Omit if unchanged.",
+                        "additionalProperties": {"type": "number"},
+                    },
+                    "threat_scores": {
+                        "type": "object",
+                        "description": "Updated threat level per player (0.0=safe, 1.0=must eliminate). Omit if unchanged.",
+                        "additionalProperties": {"type": "number"},
+                    },
+                },
+                "required": ["thought", "speech"],
+            },
+        },
+        {
+            "name": "challenge",
+            "description": "Directly counter a specific previous speech.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "thought": {"type": "string", "description": "Your private reasoning."},
+                    "speech": {"type": "string", "description": "What you say aloud in response."},
+                    "reply_to": {"type": "integer", "description": "The speech_id of the entry you are challenging."},
+                    "memory_update": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Short notes to add to your memory.",
+                    },
+                    "suspicion_scores": {
+                        "type": "object",
+                        "description": "Updated suspicion per player. Omit if unchanged.",
+                        "additionalProperties": {"type": "number"},
+                    },
+                    "threat_scores": {
+                        "type": "object",
+                        "description": "Updated threat level per player. Omit if unchanged.",
+                        "additionalProperties": {"type": "number"},
+                    },
+                },
+                "required": ["thought", "speech", "reply_to"],
+            },
+        },
+        {
+            "name": "silent",
+            "description": "Pass this turn — you have nothing to add right now.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "reasoning": {"type": "string", "description": "Why you are staying silent."},
+                },
+                "required": ["reasoning"],
+            },
+        },
+    ]
+    if co_eligible:
+        tools.append({
+            "name": "co",
+            "description": "Publicly declare (Coming-Out) your role to the group.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "thought": {"type": "string", "description": "Your private reasoning."},
+                    "speech": {"type": "string", "description": "What you say aloud when declaring your role."},
+                    "claim_role": {"type": "string", "description": f"The role name you are claiming ({role_names_hint})."},
+                    "memory_update": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Short notes to add to your memory.",
+                    },
+                    "suspicion_scores": {
+                        "type": "object",
+                        "description": "Updated suspicion per player. Omit if unchanged.",
+                        "additionalProperties": {"type": "number"},
+                    },
+                    "threat_scores": {
+                        "type": "object",
+                        "description": "Updated threat level per player. Omit if unchanged.",
+                        "additionalProperties": {"type": "number"},
+                    },
+                },
+                "required": ["thought", "speech", "claim_role"],
+            },
+        })
+    return tools
+
+
+def parse_discussion_tool_result(message: anthropic.types.Message, agent_name: str) -> DiscussionResult:
+    """Extract the tool use block from an LLM message and return a DiscussionResult."""
+    for block in message.content:
+        if block.type != "tool_use":
+            continue
+        inp = block.input
+        name = block.name
+        if name == "speak":
+            return SpeakResult(
+                thought=inp.get("thought", ""),
+                speech=inp.get("speech", ""),
+                memory_update=inp.get("memory_update", []),
+                suspicion_scores=inp.get("suspicion_scores"),
+                threat_scores=inp.get("threat_scores"),
+            )
+        if name == "challenge":
+            return ChallengeResult(
+                thought=inp.get("thought", ""),
+                speech=inp.get("speech", ""),
+                reply_to=int(inp.get("reply_to", 0)),
+                memory_update=inp.get("memory_update", []),
+                suspicion_scores=inp.get("suspicion_scores"),
+                threat_scores=inp.get("threat_scores"),
+            )
+        if name == "co":
+            raw_role = inp.get("claim_role")
+            claim_role = normalize_role_field(raw_role)
+            if claim_role is None:
+                _log_warning(agent_name, f"co tool missing valid claim_role: {raw_role!r}; falling back to speak")
+                return SpeakResult(
+                    thought=inp.get("thought", ""),
+                    speech=inp.get("speech", ""),
+                    memory_update=inp.get("memory_update", []),
+                    suspicion_scores=inp.get("suspicion_scores"),
+                    threat_scores=inp.get("threat_scores"),
+                )
+            return CoResult(
+                thought=inp.get("thought", ""),
+                speech=inp.get("speech", ""),
+                claim_role=claim_role,
+                memory_update=inp.get("memory_update", []),
+                suspicion_scores=inp.get("suspicion_scores"),
+                threat_scores=inp.get("threat_scores"),
+            )
+        if name == "silent":
+            return SilentResult(reasoning=inp.get("reasoning", ""))
+
+    # No tool_use block found — fall back to silent
+    _log_warning(agent_name, "no tool_use block in response; falling back to silent")
+    return SilentResult(reasoning="no tool use block")
+
+
+def _log_warning(agent_name: str, message: str) -> None:
+    print(f"[discussion_tools] warning for {agent_name}: {message}", file=sys.stderr)

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -256,56 +256,42 @@ def build_pre_night_prompt(
     return "\n".join(lines)
 
 
-def build_judgment_prompt(
+def build_discussion_system_prompt(
     actor: Actor,
-    today_log: list[SpeechEntry],
-    alive_players: list[str],
-    day: int,
-    lang: str = "English",
+    ctx: PublicContext,
     co_eligible: bool = False,
+    lang: str = "English",
+    role_ctx: RoleSpecificContext | None = None,
 ) -> str:
-    """Build lightweight judgment prompt for the parallel decision phase.
+    """Build system prompt for the DISCUSSION tool use call.
 
-    When co_eligible is True, a 4th option "co" is added with a role-specific
-    strategic hint. Eligibility is decided by the engine (claimed_role is None
-    and role != "Villager").
+    The caller (client.py) passes the tool definitions separately via the
+    Anthropic tools parameter. This prompt provides persona, game state,
+    and instructions for choosing among the available tools.
     """
-    recent = today_log[-6:] if len(today_log) > 6 else today_log
-    lines = [
-        f"You are {actor.name} ({actor.role.name}) in a Werewolf game. Day {day}.",
-        f"Alive players: {', '.join(alive_players)}",
+    wolf_partners = role_ctx.wolf_partners if isinstance(role_ctx, WolfSpecificContext) else None
+    parts = [
+        build_persona_prompt(actor),
+        "\n",
+        build_role_prompt(actor.role, wolf_partners),
+        build_public_info_prompt(ctx),
+        build_personal_info_prompt(actor),
     ]
-    if actor.state.memory_summary:
-        lines.append(f"Your memory: {'; '.join(actor.state.memory_summary)}")
-    if recent:
-        lines.append("\nRecent speeches:")
-        for e in recent:
-            lines.append(f"  [{e.speech_id}] {e.agent}: {e.text}")
 
-    decision_options = '"challenge" | "speak" | "silent" | "co"' if co_eligible else '"challenge" | "speak" | "silent"'
-    lines.append(f"""
-Decide your next action. Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
-{{
-  "decision": {decision_options},
-  "reply_to": <speech_id to challenge, or null>,
-  "claim_role": <role_name to claim, or null>,
-  "reasoning": "<one sentence: why you chose this action>"
-}}
-- "challenge": directly counter a specific speech (set reply_to to its speech_id)
-- "speak": add a new statement unprompted
-- "silent": nothing to add right now""")
+    tool_instructions = [
+        "\n--- YOUR TURN ---",
+        "Choose exactly one of the following tools to take your action this turn:",
+        '- speak: make a new statement (use when you have something to say)',
+        '- challenge: directly counter a specific previous speech (use when you disagree with someone)',
+        '- silent: pass this turn (use when you have nothing to add)',
+    ]
     if co_eligible:
         co_hint = actor.role.co_strategy_hint()
-        lines.append(
-            '- "co": publicly declare a role (Coming-Out) in your next speech and set "claim_role" to that role\n'
-            f"{co_hint}"
-        )
-    else:
-        lines.append('- Set "claim_role" to null')
-    lines.append(f"""- The JSON must contain exactly these four fields and nothing else.
-- "reasoning" must be written in {lang}
-- Keep the JSON minimal — "reasoning" should be one short sentence.""")
-    return "\n".join(lines)
+        tool_instructions.append(f'- co: publicly declare a role (Coming-Out)\n  {co_hint}')
+    tool_instructions.append(f'\nAll "thought" and "speech" fields must be written in {lang}.')
+    parts.append("\n".join(tool_instructions))
+
+    return "\n".join(parts)
 
 
 def build_vote_prompt(

--- a/tests/TestStrategy.md
+++ b/tests/TestStrategy.md
@@ -106,7 +106,8 @@ Mock は SUT を依存から隔離する手段だが、**自分のコード同�
 |---|---|---|
 | `LogEvent` | `src/domain/event.py` | Engine ↔ Renderer / Replay / LogWriter |
 | `Actor`, `ActorState` | `src/domain/actor.py` | Engine ↔ store(JSON 永続化) |
-| `AgentOutput`, `JudgmentOutput`, `PreNightOutput`, `WolfChatOutput` | `src/domain/schema.py` | LLM 応答 JSON 契約 |
+| `AgentOutput`, `PreNightOutput`, `WolfChatOutput` | `src/domain/schema.py` | LLM 応答 JSON 契約 |
+| `SpeakResult`, `ChallengeResult`, `CoResult`, `SilentResult` | `src/domain/schema.py` | DISCUSSION tool use 結果契約 |
 
 ### Conditional(その他)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 from src.domain.actor import Actor, ActorProfile, ActorState, Persona, make_actor
 from src.domain.event import LogEvent
-from src.domain.schema import AgentOutput, Intent, JudgmentOutput, PreNightOutput, VoteOutput
+from src.domain.schema import AgentOutput, Intent, PreNightOutput, SilentResult, VoteOutput
 from src.engine.game import GameEngine
 from src.llm.client import LLMClient
 from src.logger.writer import LogWriter
@@ -112,9 +112,9 @@ def make_speech_parallel_side_effect():
 
 
 def make_silent_discussion_side_effect():
-    """Side effect for call_discussion_parallel: all actors respond with silent judgment."""
+    """Side effect for call_discussion_parallel: all actors respond with SilentResult."""
     def _side_effect(actors, *_, **__):
-        return iter([(a, JudgmentOutput(decision="silent"), None, None) for a in actors])
+        return iter([(a, SilentResult(reasoning="nothing to add")) for a in actors])
     return _side_effect
 
 
@@ -225,13 +225,6 @@ AGENT_OUTPUT_JSON = json.dumps({
     "memory_update": [],
 })
 
-JUDGMENT_OUTPUT_JSON = json.dumps({"decision": "speak"})
-
-JUDGMENT_CO_OUTPUT_JSON = json.dumps({
-    "decision": "co",
-    "reply_to": None,
-    "claim_role": "Knight",
-})
 
 PRE_NIGHT_OUTPUT_JSON = json.dumps({
     "thought": "thinking",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -5,13 +5,13 @@ import anthropic
 import pydantic
 import pytest
 
-from src.domain.schema import AgentOutput, JudgmentOutput, NightActionOutput, PreNightOutput, VoteOutput, WolfChatOutput
+from unittest.mock import MagicMock
+
+from src.domain.schema import AgentOutput, ChallengeResult, CoResult, NightActionOutput, PreNightOutput, SilentResult, SpeakResult, VoteOutput, WolfChatOutput
 from src.domain.roles import get_role
-from src.llm.client import _classify_error, resolve_claim_role
+from src.llm.client import LLMClient, _classify_error, resolve_claim_role
 from tests.conftest import (
     AGENT_OUTPUT_JSON,
-    JUDGMENT_CO_OUTPUT_JSON,
-    JUDGMENT_OUTPUT_JSON,
     NIGHT_ACTION_OUTPUT_JSON,
     PRE_NIGHT_CO_OUTPUT_JSON,
     PRE_NIGHT_OUTPUT_JSON,
@@ -45,26 +45,101 @@ class TestCall:
         assert result.speech == "I need to think more carefully."
 
 
-class TestCallJudgment:
-    def test_returns_judgment_output(self, make_test_actor):
-        actor = make_test_actor("Alice")
-        llm = make_llm_client_with_response(JUDGMENT_OUTPUT_JSON)
-        result = llm.call_judgment(actor, [], ["Alice", "Bob"], day=1)
-        assert isinstance(result, JudgmentOutput)
-        assert result.decision == "speak"
+def _make_tool_use_message(tool_name: str, tool_input: dict):
+    """Build a MagicMock simulating anthropic.types.Message with a tool_use block."""
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = tool_name
+    block.input = tool_input
+    msg = MagicMock()
+    msg.content = [block]
+    return msg
 
-    def test_returns_silent_on_exception(self, make_test_actor):
+
+def _make_discussion_llm_client(tool_name: str, tool_input: dict) -> LLMClient:
+    """Build LLMClient whose messages.create returns a tool use response."""
+    import anthropic
+    anthropic_client = MagicMock(spec=anthropic.Anthropic)
+    anthropic_client.messages.create.return_value = _make_tool_use_message(tool_name, tool_input)
+    return LLMClient(anthropic_client)
+
+
+class TestCallDiscussion:
+    def test_returns_speak_result(self, make_test_actor):
+        """
+        SUT: LLMClient.call_discussion
+        Mock: anthropic SDK — returns tool_use block for "speak"
+        Level: unit
+        Objective: speak ツール選択時に SpeakResult が返ること。
+        """
+        actor = make_test_actor("Alice")
+        llm = _make_discussion_llm_client("speak", {"thought": "thinking", "speech": "Hello!"})
+        from src.llm.prompt import PublicContext
+        ctx = PublicContext(alive_players=["Alice", "Bob"], dead_players=[], day=1, today_log=[])
+        result = llm.call_discussion(actor, ctx)
+        assert isinstance(result, SpeakResult)
+        assert result.speech == "Hello!"
+        assert result.thought == "thinking"
+
+    def test_returns_challenge_result(self, make_test_actor):
+        """
+        SUT: LLMClient.call_discussion
+        Mock: anthropic SDK — returns tool_use block for "challenge"
+        Level: unit
+        Objective: challenge ツール選択時に ChallengeResult が返り reply_to が保持されること。
+        """
+        actor = make_test_actor("Alice")
+        llm = _make_discussion_llm_client("challenge", {"thought": "t", "speech": "I disagree!", "reply_to": 3})
+        from src.llm.prompt import PublicContext
+        ctx = PublicContext(alive_players=["Alice", "Bob"], dead_players=[], day=1, today_log=[])
+        result = llm.call_discussion(actor, ctx)
+        assert isinstance(result, ChallengeResult)
+        assert result.reply_to == 3
+        assert result.speech == "I disagree!"
+
+    def test_returns_co_result(self, make_test_actor):
+        """
+        SUT: LLMClient.call_discussion
+        Mock: anthropic SDK — returns tool_use block for "co"
+        Level: unit
+        Objective: co ツール選択時に CoResult が返り claim_role が Role インスタンスに変換されること。
+        """
+        actor = make_test_actor("Alice", "Seer")
+        llm = _make_discussion_llm_client("co", {"thought": "t", "speech": "I am Seer!", "claim_role": "Seer"})
+        from src.llm.prompt import PublicContext
+        ctx = PublicContext(alive_players=["Alice", "Bob"], dead_players=[], day=1, today_log=[])
+        result = llm.call_discussion(actor, ctx)
+        assert isinstance(result, CoResult)
+        assert result.claim_role.name == "Seer"
+
+    def test_returns_silent_result(self, make_test_actor):
+        """
+        SUT: LLMClient.call_discussion
+        Mock: anthropic SDK — returns tool_use block for "silent"
+        Level: unit
+        Objective: silent ツール選択時に SilentResult が返ること。
+        """
+        actor = make_test_actor("Alice")
+        llm = _make_discussion_llm_client("silent", {"reasoning": "nothing to add"})
+        from src.llm.prompt import PublicContext
+        ctx = PublicContext(alive_players=["Alice", "Bob"], dead_players=[], day=1, today_log=[])
+        result = llm.call_discussion(actor, ctx)
+        assert isinstance(result, SilentResult)
+        assert result.reasoning == "nothing to add"
+
+    def test_returns_silent_fallback_on_exception(self, make_test_actor):
+        """
+        SUT: LLMClient.call_discussion
+        Mock: anthropic SDK raises RuntimeError
+        Level: unit
+        Objective: API 失敗時に SilentResult フォールバックが返ること。
+        """
         actor = make_test_actor("Alice")
         llm = make_failing_llm_client()
-        result = llm.call_judgment(actor, [], ["Alice", "Bob"], day=1)
-        assert result.decision == "silent"
-
-    def test_parses_claim_role_when_present(self, make_test_actor):
-        actor = make_test_actor("Alice", "Werewolf")
-        llm = make_llm_client_with_response(JUDGMENT_CO_OUTPUT_JSON)
-        result = llm.call_judgment(actor, [], ["Alice", "Bob"], day=1)
-        assert result.decision == "co"
-        assert result.claim_role.name == "Knight"
+        from src.llm.prompt import PublicContext
+        ctx = PublicContext(alive_players=["Alice", "Bob"], dead_players=[], day=1, today_log=[])
+        result = llm.call_discussion(actor, ctx)
+        assert isinstance(result, SilentResult)
 
 
 class TestCallPreNightAction:

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -10,13 +10,12 @@ from src.engine.phase_day import run_day_phase
 from src.engine.phase_night import run_night_phase
 from src.engine.phase_pre_night import run_pre_night_phase
 from src.engine.phase import Phase
-from src.domain.schema import AgentOutput, Intent, JudgmentOutput
+from src.domain.schema import AgentOutput, ChallengeResult, CoResult, Intent, SilentResult, SpeakResult
 from src.domain.event import EventType
 from src.domain.roles import Seer
 from src.llm.client import LLMClient
 from src.logger.writer import LogWriter
 from tests.conftest import (
-    make_agent_output,
     make_night_action_side_effect,
     make_silent_discussion_side_effect,
     make_speech_parallel_side_effect,
@@ -86,14 +85,10 @@ class TestRunDayPhaseOrder:
         engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
 
         # B challenges speech_id=1 (A's opening speech)
-        challenge = JudgmentOutput(decision="challenge", reply_to=1)
-
-        def discussion_with_challenge(actors, today_log, *_, **__):
-            # find speech_id=1 entry from today_log
-            reply_to_entry = next((e for e in today_log if e.speech_id == 1), None)
+        def discussion_with_challenge(actors, *_, **__):
             return iter([
-                (make_test_actor("A"), JudgmentOutput(decision="silent"), None, None),
-                (make_test_actor("B"), challenge, make_agent_output("B"), reply_to_entry),
+                (make_test_actor("A"), SilentResult(reasoning="quiet")),
+                (make_test_actor("B"), ChallengeResult(thought="t", speech="I disagree!", reply_to=1)),
             ])
 
         engine._llm_client.call_discussion_parallel.side_effect = discussion_with_challenge
@@ -121,24 +116,22 @@ class TestRunDayPhaseOrder:
 
 
 class TestDiscussionCoDecision:
-    """Tests for the "co" judgment option in discussion phase."""
+    """Tests for the "co" tool use in discussion phase."""
 
-    def test_eligible_agent_co_sets_claimed_role(self, make_test_actor, make_test_engine):
-        """Seer (unclaimed) chooses co → claimed_role is set after speaking."""
+    def test_co_result_sets_claimed_role(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result with CoResult
+        Mock: call_discussion_parallel returns CoResult(claim_role=Seer)
+        Level: unit
+        Objective: CoResult が返ったとき actor.state.claimed_role に正しいロールがセットされること。
+        """
         seer = make_test_actor("Seer1", "Seer")
         assert seer.state.claimed_role is None
         engine, _ = make_test_engine([seer])
 
-        co_output = AgentOutput(
-            thought="I'll CO now.",
-            speech="I am the Seer!",
-            reasoning="r",
-            intent=Intent(co="Seer"),
-            memory_update=[],
-        )
         engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
-            (seer, JudgmentOutput(decision="co"), co_output, None),
+            (seer, CoResult(thought="CO now", speech="I am the Seer!", claim_role=seer.role)),
         ])
 
         with patch("src.agent.store.save"):
@@ -146,69 +139,66 @@ class TestDiscussionCoDecision:
 
         assert isinstance(seer.state.claimed_role, Seer)
 
-    def test_ineligible_agent_co_treated_as_speak(self, make_test_actor, make_test_engine):
-        """Agent that already claimed a role cannot CO again — falls back to speak."""
+    def test_speak_result_does_not_set_claimed_role(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result with SpeakResult
+        Mock: call_discussion_parallel returns SpeakResult (no co)
+        Level: unit
+        Objective: SpeakResult では claimed_role が変わらないこと。
+        """
         seer = make_test_actor("Seer1", "Seer")
-        seer.state.claimed_role = "Seer"  # already claimed
         engine, _ = make_test_engine([seer])
 
-        normal_output = make_agent_output("Seer1", "Just speaking.")
         engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
-            (seer, JudgmentOutput(decision="co"), normal_output, None),
+            (seer, SpeakResult(thought="t", speech="Just speaking.")),
         ])
 
         with patch("src.agent.store.save"):
             engine._run_day()
 
-        # co intent is None in normal_output → claimed_role unchanged
-        assert seer.state.claimed_role is not None  # still the old value, not set again
+        assert seer.state.claimed_role is None
 
-    def test_villager_co_treated_as_speak(self, make_test_actor, make_test_engine):
-        """Villager cannot CO — co judgment falls back to speak."""
+    def test_silent_result_emits_silent_speech_event(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result with SilentResult
+        Mock: call_discussion_parallel returns SilentResult
+        Level: unit
+        Objective: SilentResult のとき is_public な SPEECH イベントが「silently watching」内容で emit されること。
+        """
         villager = make_test_actor("V1", "Villager")
-        engine, _ = make_test_engine([villager])
+        engine, events = make_test_engine([villager])
 
-        normal_output = make_agent_output("V1", "Just talking.")
         engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
-            (villager, JudgmentOutput(decision="co"), normal_output, None),
+            (villager, SilentResult(reasoning="nothing")),
         ])
 
         with patch("src.agent.store.save"):
             engine._run_day()
 
-        # Villager co intent is None → claimed_role stays None
-        assert villager.state.claimed_role is None
+        silent_events = [
+            e for e in events
+            if e.event_type == EventType.SPEECH and e.is_public and "silently" in e.content
+        ]
+        assert len(silent_events) >= 1
 
-    def test_failed_discussion_co_clears_intended_co(self, make_test_actor, make_test_engine):
-        seer = make_test_actor("Seer1", "Seer")
-        engine, _ = make_test_engine([seer])
-        normal_output = make_agent_output("Seer1", "I have something to say.")
-
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
-        engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
-            (seer, JudgmentOutput(decision="co"), normal_output, None),
-        ])
-
-        with patch("src.agent.store.save"):
-            engine._run_day()
-
-        assert seer.state.intended_co is None
-
-    def test_discussion_fake_co_uses_selected_claim_role(self, make_test_actor, make_test_engine):
+    def test_fake_co_wolf_sets_claimed_role(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result with CoResult (wolf fake CO)
+        Mock: call_discussion_parallel returns CoResult(claim_role=Medium) for wolf
+        Level: unit
+        Objective: 狼が CoResult で Medium を詐称したとき claimed_role に Medium がセットされること。
+        """
         wolf = make_test_actor("Wolf1", "Werewolf")
         engine, _ = make_test_engine([wolf])
-        co_output = AgentOutput(
-            thought="I'll fake medium.",
-            speech="I am the Medium.",
-            reasoning="r",
-            intent=Intent(co="Medium"),
-            memory_update=[],
-        )
+
+        from src.domain.roles import get_role
+        medium_role = get_role("Medium")
+
         engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
-            (wolf, JudgmentOutput(decision="co", claim_role="Medium"), co_output, None),
+            (wolf, CoResult(thought="fake", speech="I am the Medium.", claim_role=medium_role)),
         ])
 
         with patch("src.agent.store.save"):
@@ -497,3 +487,82 @@ class TestRunNightPhaseOrder:
             e.event_type == EventType.INSPECTION and e.agent == "Seer1" and e.target == "Wolf1"
             for e in events
         )
+
+
+class TestApplyDiscussionResult:
+    """Tests for GameEngine._apply_discussion_result."""
+
+    def test_suspicion_scores_update_state_and_emit_event(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result with SpeakResult
+        Mock: patch で store.save を no-op に差し替え
+        Level: unit
+        Objective: SpeakResult.suspicion_scores が非 None のとき beliefs が更新され
+                   SUSPICION_UPDATE イベントが emit されること。
+        """
+        actor = make_test_actor("Alice")
+        target = make_test_actor("Bob")
+        engine, events = make_test_engine([actor, target])
+
+        result = SpeakResult(
+            thought="thinking",
+            speech="I suspect Bob.",
+            suspicion_scores={"Bob": 0.8},
+        )
+
+        with patch("src.agent.store.save"):
+            engine._apply_discussion_result(actor, result, Phase.DAY_DISCUSSION)
+
+        assert actor.state.beliefs["Bob"].suspicion == pytest.approx(0.8)
+        suspicion_events = [e for e in events if e.event_type == EventType.SUSPICION_UPDATE]
+        assert len(suspicion_events) == 1
+        assert "Bob=0.80" in suspicion_events[0].content
+        assert suspicion_events[0].is_public is False
+
+    def test_threat_scores_update_state_and_emit_event(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result with SpeakResult
+        Mock: patch で store.save を no-op に差し替え
+        Level: unit
+        Objective: SpeakResult.threat_scores が非 None のとき threat_scores が更新され
+                   THREAT_UPDATE イベントが emit されること。
+        """
+        wolf = make_test_actor("Wolf", "Werewolf")
+        villager = make_test_actor("Alice")
+        engine, events = make_test_engine([wolf, villager])
+
+        result = SpeakResult(
+            thought="thinking",
+            speech="Hello.",
+            threat_scores={"Alice": 0.9},
+        )
+
+        with patch("src.agent.store.save"):
+            engine._apply_discussion_result(wolf, result, Phase.DAY_DISCUSSION)
+
+        assert wolf.state.threat_scores["Alice"] == pytest.approx(0.9)
+        threat_events = [e for e in events if e.event_type == EventType.THREAT_UPDATE]
+        assert len(threat_events) == 1
+        assert "Alice=0.90" in threat_events[0].content
+        assert threat_events[0].is_public is False
+
+    def test_memory_update_is_applied(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result with SpeakResult
+        Mock: patch で store.save を no-op に差し替え
+        Level: unit
+        Objective: SpeakResult.memory_update が非空のとき actor.state.memory_summary に追記されること。
+        """
+        actor = make_test_actor("Alice")
+        engine, _ = make_test_engine([actor])
+
+        result = SpeakResult(
+            thought="t",
+            speech="s",
+            memory_update=["Bob acted suspiciously on Day1"],
+        )
+
+        with patch("src.agent.store.save"):
+            engine._apply_discussion_result(actor, result, Phase.DAY_DISCUSSION)
+
+        assert any("Bob acted suspiciously" in m for m in actor.state.memory_summary)

--- a/tests/unit/test_judgment_prompt.py
+++ b/tests/unit/test_judgment_prompt.py
@@ -1,91 +1,120 @@
-from src.domain.actor import Belief
-from src.llm.prompt import build_judgment_prompt
+from src.llm.prompt import PublicContext, build_discussion_system_prompt
 from src.domain.schema import SpeechEntry
 
 
-def _make_log(*texts: str) -> list[SpeechEntry]:
-    return [SpeechEntry(speech_id=i + 1, agent=f"Agent{i}", text=t) for i, t in enumerate(texts)]
+def _make_ctx(*texts: str, day: int = 1) -> PublicContext:
+    log = [SpeechEntry(speech_id=i + 1, agent=f"Agent{i}", text=t) for i, t in enumerate(texts)]
+    return PublicContext(
+        today_log=log,
+        alive_players=["Setsu", "SQ"],
+        dead_players=[],
+        day=day,
+    )
 
 
-class TestBuildJudgmentPrompt:
+class TestBuildDiscussionSystemPrompt:
     def test_contains_agent_name_and_role(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: unit
+        Objective: プロンプトにエージェント名とロール名が含まれること。
+        """
         actor = make_test_actor("Setsu")
-        actor.state.beliefs = {"SQ": Belief()}
-        prompt = build_judgment_prompt(actor, [], ["Setsu", "SQ"], day=1)
+        ctx = _make_ctx()
+        prompt = build_discussion_system_prompt(actor, ctx)
         assert "Setsu" in prompt
         assert "Villager" in prompt
 
-    def test_contains_recent_speeches_with_ids(self, make_test_actor):
+    def test_contains_today_log_speeches(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: unit
+        Objective: 今日の発言ログが speech_id 付きでプロンプトに含まれること。
+        """
         actor = make_test_actor("Setsu")
-        actor.state.beliefs = {"SQ": Belief()}
-        log = _make_log("Hello everyone.", "I suspect SQ.")
-        prompt = build_judgment_prompt(actor, log, ["Setsu", "SQ"], day=1)
+        ctx = _make_ctx("Hello everyone.", "I suspect SQ.")
+        prompt = build_discussion_system_prompt(actor, ctx)
         assert "[1]" in prompt
         assert "[2]" in prompt
         assert "Hello everyone." in prompt
 
-    def test_only_last_6_speeches_included(self, make_test_actor):
+    def test_tool_instructions_present(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: unit
+        Objective: speak / challenge / silent ツール案内がプロンプトに含まれること。
+        """
         actor = make_test_actor("Setsu")
-        actor.state.beliefs = {"SQ": Belief()}
-        log = _make_log(*[f"speech {i}" for i in range(10)])
-        prompt = build_judgment_prompt(actor, log, ["Setsu"], day=2)
-        # speech 0-3 should be excluded (only last 6: 4-9)
-        assert "speech 0" not in prompt
-        assert "speech 9" in prompt
-
-    def test_memory_included(self, make_test_actor):
-        actor = make_test_actor("Setsu")
-        actor.state.beliefs = {"SQ": Belief()}
-        actor.state.memory_summary = ["SQ changed vote on Day1"]
-        prompt = build_judgment_prompt(actor, [], ["Setsu", "SQ"], day=2)
-        assert "SQ changed vote on Day1" in prompt
-
-    def test_json_format_instruction_present(self, make_test_actor):
-        actor = make_test_actor("Setsu")
-        actor.state.beliefs = {"SQ": Belief()}
-        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1)
+        ctx = _make_ctx()
+        prompt = build_discussion_system_prompt(actor, ctx)
+        assert "speak" in prompt
         assert "challenge" in prompt
         assert "silent" in prompt
-        assert "reply_to" in prompt
-        assert "claim_role" in prompt
 
-    def test_co_option_absent_for_villager(self, make_test_actor):
+    def test_co_tool_absent_for_villager(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: unit
+        Objective: co_eligible=False のとき「- co:」説明がプロンプトに含まれないこと。
+        """
         actor = make_test_actor("Setsu", "Villager")
-        actor.state.beliefs = {"SQ": Belief()}
-        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=False)
-        assert '"co"' not in prompt
+        ctx = _make_ctx()
+        prompt = build_discussion_system_prompt(actor, ctx, co_eligible=False)
+        assert "- co:" not in prompt
 
-    def test_co_option_present_when_co_eligible(self, make_test_actor):
+    def test_co_tool_present_when_co_eligible(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: unit
+        Objective: co_eligible=True のとき「- co:」説明がプロンプトに含まれること。
+        """
         actor = make_test_actor("Setsu", "Seer")
-        actor.state.beliefs = {"SQ": Belief()}
-        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
-        assert '"co"' in prompt
-        assert "claim_role" in prompt
+        ctx = _make_ctx()
+        prompt = build_discussion_system_prompt(actor, ctx, co_eligible=True)
+        assert "- co:" in prompt
 
     def test_co_strategy_hint_seer(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: unit
+        Objective: co_eligible=True で Seer のとき、Seer 固有の戦略ヒントが含まれること。
+        """
         actor = make_test_actor("Setsu", "Seer")
-        actor.state.beliefs = {"SQ": Belief()}
-        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
+        ctx = _make_ctx()
+        prompt = build_discussion_system_prompt(actor, ctx, co_eligible=True)
         assert "Seer" in prompt
         assert "trust" in prompt.lower()
 
     def test_co_strategy_hint_werewolf(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: unit
+        Objective: co_eligible=True で Werewolf のとき、偽 CO 向け戦略ヒントが含まれること。
+        """
+        from src.llm.prompt import WolfSpecificContext
         actor = make_test_actor("Setsu", "Werewolf")
-        actor.state.beliefs = {"SQ": Belief()}
-        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
-        assert "fake" in prompt.lower() or "claim_role" in prompt.lower()
+        ctx = _make_ctx()
+        role_ctx = WolfSpecificContext(wolf_partners=[])
+        prompt = build_discussion_system_prompt(actor, ctx, co_eligible=True, role_ctx=role_ctx)
+        assert "fake" in prompt.lower() or "claim" in prompt.lower()
         assert "Seer" in prompt or "Medium" in prompt
 
-    def test_co_strategy_hint_madman(self, make_test_actor):
-        actor = make_test_actor("Setsu", "Madman")
-        actor.state.beliefs = {"SQ": Belief()}
-        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1, co_eligible=True)
-        assert "Madman" in prompt
-        assert "Seer" in prompt or "Medium" in prompt
-
-    def test_co_not_in_format_when_not_eligible(self, make_test_actor):
-        """Ensure the 4th choice is absent when co_eligible=False (default)."""
-        actor = make_test_actor("Setsu", "Seer")
-        actor.state.beliefs = {"SQ": Belief()}
-        prompt = build_judgment_prompt(actor, [], ["Setsu"], day=1)  # default co_eligible=False
-        assert '"co"' not in prompt
+    def test_memory_included(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: unit
+        Objective: actor.state.memory_summary の内容がプロンプトに含まれること。
+        """
+        actor = make_test_actor("Setsu")
+        actor.state.memory_summary = ["SQ changed vote on Day1"]
+        ctx = _make_ctx()
+        prompt = build_discussion_system_prompt(actor, ctx)
+        assert "SQ changed vote on Day1" in prompt

--- a/tests/unit/test_judgment_schema.py
+++ b/tests/unit/test_judgment_schema.py
@@ -1,7 +1,15 @@
 import pytest
 from pydantic import ValidationError
 
-from src.domain.schema import JudgmentOutput, SpeechEntry
+from src.domain.schema import (
+    ChallengeResult,
+    CoResult,
+    DiscussionResult,
+    SilentResult,
+    SpeakResult,
+    SpeechEntry,
+)
+from src.domain.roles import get_role
 
 
 class TestSpeechEntry:
@@ -15,67 +23,125 @@ class TestSpeechEntry:
             SpeechEntry(speech_id=1, agent="Setsu")
 
 
-class TestJudgmentOutput:
-    def test_challenge_with_reply_to(self):
-        j = JudgmentOutput(decision="challenge", reply_to=3)
-        assert j.decision == "challenge"
-        assert j.reply_to == 3
-
-    def test_speak_no_reply_to(self):
-        j = JudgmentOutput(decision="speak")
-        assert j.decision == "speak"
-        assert j.reply_to is None
-
-    def test_silent(self):
-        j = JudgmentOutput(decision="silent")
-        assert j.decision == "silent"
-
-    def test_co_decision(self):
-        j = JudgmentOutput(decision="co", claim_role="Medium")
-        assert j.decision == "co"
-        assert j.reply_to is None
-        assert j.claim_role.name == "Medium"
-
-    def test_invalid_decision_raises(self):
-        with pytest.raises(ValidationError):
-            JudgmentOutput(decision="attack")
-
-    def test_parse_from_dict(self):
-        j = JudgmentOutput.model_validate({"decision": "challenge", "reply_to": 2, "claim_role": None})
-        assert j.decision == "challenge"
-        assert j.reply_to == 2
-
-    def test_claim_role_defaults_to_none(self):
-        j = JudgmentOutput(decision="speak")
-        assert j.claim_role is None
-
-    def test_reasoning_defaults_to_empty_string(self):
+class TestSpeakResult:
+    def test_minimal_fields(self):
         """
-        SUT: JudgmentOutput
+        SUT: SpeakResult
         Mock: なし
         Level: unit
-        Objective: reasoning フィールドが省略されたとき空文字列になること（過去ログ互換）
+        Objective: thought と speech だけで生成でき、オプション項目はデフォルト値になること。
         """
-        j = JudgmentOutput(decision="speak")
-        assert j.reasoning == ""
+        r = SpeakResult(thought="t", speech="Hello!")
+        assert r.thought == "t"
+        assert r.speech == "Hello!"
+        assert r.co is None
+        assert r.memory_update == []
+        assert r.suspicion_scores is None
+        assert r.threat_scores is None
 
-    def test_reasoning_is_preserved(self):
+    def test_with_scores(self):
         """
-        SUT: JudgmentOutput
+        SUT: SpeakResult
         Mock: なし
         Level: unit
-        Objective: reasoning フィールドが指定されたとき保持されること
+        Objective: suspicion_scores / threat_scores が正しく保持されること。
         """
-        j = JudgmentOutput(decision="challenge", reply_to=1, reasoning="Alice looks suspicious.")
-        assert j.reasoning == "Alice looks suspicious."
+        r = SpeakResult(
+            thought="t",
+            speech="s",
+            suspicion_scores={"Bob": 0.7},
+            threat_scores={"Bob": 0.5},
+        )
+        assert r.suspicion_scores == {"Bob": 0.7}
+        assert r.threat_scores == {"Bob": 0.5}
 
-    def test_parse_from_json_without_reasoning(self):
+
+class TestChallengeResult:
+    def test_reply_to_required(self):
         """
-        SUT: JudgmentOutput
+        SUT: ChallengeResult
         Mock: なし
         Level: unit
-        Objective: reasoning を含まない旧フォーマットのJSONでもバリデーションが通ること（後方互換）
+        Objective: reply_to が必須フィールドとして保持されること。
         """
-        j = JudgmentOutput.model_validate_json('{"decision": "silent"}')
-        assert j.decision == "silent"
-        assert j.reasoning == ""
+        r = ChallengeResult(thought="t", speech="I disagree!", reply_to=3)
+        assert r.reply_to == 3
+        assert r.speech == "I disagree!"
+
+    def test_defaults(self):
+        """
+        SUT: ChallengeResult
+        Mock: なし
+        Level: unit
+        Objective: memory_update / suspicion_scores / threat_scores のデフォルトが正しいこと。
+        """
+        r = ChallengeResult(thought="t", speech="s", reply_to=1)
+        assert r.memory_update == []
+        assert r.suspicion_scores is None
+        assert r.threat_scores is None
+
+
+class TestCoResult:
+    def test_claim_role_preserved(self):
+        """
+        SUT: CoResult
+        Mock: なし
+        Level: unit
+        Objective: claim_role に Role インスタンスを渡して保持できること。
+        """
+        seer = get_role("Seer")
+        r = CoResult(thought="t", speech="I am Seer!", claim_role=seer)
+        assert r.claim_role.name == "Seer"
+
+    def test_defaults(self):
+        """
+        SUT: CoResult
+        Mock: なし
+        Level: unit
+        Objective: memory_update / suspicion_scores / threat_scores のデフォルトが正しいこと。
+        """
+        r = CoResult(thought="t", speech="s", claim_role=get_role("Seer"))
+        assert r.memory_update == []
+        assert r.suspicion_scores is None
+
+
+class TestSilentResult:
+    def test_reasoning_preserved(self):
+        """
+        SUT: SilentResult
+        Mock: なし
+        Level: unit
+        Objective: reasoning フィールドが保持されること。
+        """
+        r = SilentResult(reasoning="nothing to add")
+        assert r.reasoning == "nothing to add"
+
+
+class TestDiscussionResultUnion:
+    def test_speak_is_discussion_result(self):
+        """
+        SUT: DiscussionResult type alias
+        Mock: なし
+        Level: unit
+        Objective: SpeakResult が DiscussionResult の isinstance チェックを通ること。
+        """
+        r: DiscussionResult = SpeakResult(thought="t", speech="s")
+        assert isinstance(r, SpeakResult)
+        assert not isinstance(r, SilentResult)
+
+    def test_silent_guard_pattern(self):
+        """
+        SUT: DiscussionResult type alias
+        Mock: なし
+        Level: unit
+        Objective: isinstance(result, SilentResult) で SilentResult だけ選別できること。
+        """
+        results: list[DiscussionResult] = [
+            SpeakResult(thought="t", speech="s"),
+            SilentResult(reasoning="quiet"),
+            ChallengeResult(thought="t", speech="s", reply_to=1),
+        ]
+        silent = [r for r in results if isinstance(r, SilentResult)]
+        speaking = [r for r in results if not isinstance(r, SilentResult)]
+        assert len(silent) == 1
+        assert len(speaking) == 2


### PR DESCRIPTION
## Summary
- Replace 2-step DISCUSSION phase (`call_judgment()` + `call()`) with a single Claude tool use API call
- Add `src/llm/discussion_tools.py` module with tool definitions (speak/challenge/co/silent) and response parsing
- Add `DiscussionResult = SpeakResult | ChallengeResult | CoResult | SilentResult` union type to schema
- Add `call_discussion()` and `call_discussion_parallel()` to `LLMClient`
- Add `_apply_discussion_result()` and `_build_discussion_ctx_map()` to `GameEngine`
- Remove `call_judgment()`, `build_judgment_prompt()`, and related `JudgmentOutput` schema

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` passes (306 tests)
- [x] `TestCallDiscussion` — 5 tests covering all 4 tool variants + exception fallback
- [x] `TestBuildDiscussionSystemPrompt` — 8 tests covering prompt contents per role/co_eligible
- [x] `TestDiscussionResultUnion` + schema tests for all 4 result types
- [x] `TestDiscussionCoDecision` — CO/speak/silent/fake-CO wolf all covered
- [x] `TestApplyDiscussionResult` — suspicion_scores, threat_scores, memory_update branches

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)