### PR TITLE
docs: add issues #247, #248 to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,6 +13,8 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
+| yukkie/AgentVillage#247 | bug | 🔴 | - | Fix: wolf intended_co not passed to discussion phase prompt (PR#242 regression) | DISCUSSIONフェーズのプロンプトに intended_co が渡されず、狼が翌日に偽CO作戦を実行できないデグレ |
+| yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#244 | bug | 🔴 | 1 | Fix silent result displays empty speech instead of watching message | SilentResult 選択時に watching メッセージではなく空発言行が表示されるバグを修正 |
 | yukkie/AgentVillage#245 | tech-debt | 🔴 | 3 | Remove DAY_OPENING phase | OPENING を削除し DAY を DISCUSSION→VOTE のみに。#21 も同時クローズ |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |


### PR DESCRIPTION
## Summary
- Issue #247（wolf intended_co デグレ）を Ideas.md に追加
- Issue #248（wolf CO reasoning 追加）を Ideas.md に追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)