### PR TITLE
refactor: remove DAY_OPENING phase (#245)

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -110,7 +110,7 @@ LLMの出力は自然文のパースに頼らず、常にPydanticモデルで検
 | `memory_summary` | 今回のゲームで蓄積された中期記憶 |
 | `is_alive` | 生存フラグ |
 | `claimed_role` | エージェントが公言した役職（CO済みなら設定。未COはNull） |
-| `intended_co` | 次の発言でCOする予定の役職。未予定なら `None`。前夜CO・議論中COともに、構造化出力の `claim_role` をここへ正規化して保持する |
+| `intended_co` | 次の発言でCOする予定の役職。未予定なら `None`。DISCUSSION判断で `decision="co"` が選ばれた際に `claim_role` をここへ正規化して保持し、発言生成後にクリアされる |
 
 静的な `name`, `model`, `persona` は `ActorProfile` に分離される。真の役職は保存JSON上では `role` 文字列、ランタイムでは `Actor.role`（`Role` instance）として扱う。
 
@@ -118,16 +118,12 @@ LLMの出力は自然文のパースに頼らず、常にPydanticモデルで検
 - `claimed_role` は **Public情報** として全エージェントのプロンプトに渡す
 - UIのカラー表示も `claimed_role` を参照（真の役職で色付けしない）
 
-CO が成立する経路は現状2つある:
+CO が成立する経路:
 
-1. **前夜CO（Day 1 OPENING）**: `intended_co` に役職が設定されたエージェントが Day 1 OPENING で公言（§16.1）
-2. **議論中CO（DISCUSSION・全Day）**: 判断フェーズで `decision="co"` を選んだ適格エージェントがその場で公言（§16.2）
+- **議論中CO（DISCUSSION・全Day）**: 判断フェーズで `decision="co"` を選んだ適格エージェントがその場で公言
    - 適格条件: `claimed_role is None` かつ `role != "Villager"`
    - `claim_role` が指定されていればその役職を採用し、未指定なら `default_claim_role` にフォールバックする
-   - 発言生成プロンプトは前夜CO経路と同じ「CO指示ブロック」を再利用する（`build_system_prompt` の `intended_co is not None` 分岐）
-   - エンジンは判断結果を `AgentState.intended_co` に直接書き込み、発言後に clear する
-
-なお Day 2+ OPENING には現状構造化された CO 判断ステップがなく、LLM が通常発言中に自発的に `intent.co` を返したケースのみ受動的に成立する。Day 2+ にも前夜判断相当のフェーズを設ける拡張案は Ideas.md §16.2a を参照。
+   - エンジンは判断結果を `ActorState.intended_co` に直接書き込み、発言生成後にクリアする
 
 #### COフォールバックと狂人の扱い
 
@@ -158,7 +154,6 @@ CO には2種類のフォールバックがある。
 
 | 関数 | 用途 | プロンプト | 出力モデル |
 |---|---|---|---|
-| `call()` | 発言生成（OPENING） | フル（役職・性格・記憶・当日ログ・他者のCO情報・狼仲間（狼のみ）） | `AgentOutput` |
 | `call_discussion()` | 発言生成（DISCUSSION 単体） | フル + tool use（`speak` / `challenge` / `co` / `silent` の4 tool） | `DiscussionResult`（`SpeakResult \| ChallengeResult \| CoResult \| SilentResult`） |
 | `call_vote()` | 投票（VOTE フェーズ専用） | 役職・性格・当日議論ログ・past_votes・past_deaths・最終 vote_candidates・狼仲間／VOTE STRATEGY（狼のみ） | `VoteOutput` (`target` + `reasoning` + `strategy`) |
 | `call_night_action()` | 夜行動 | 夜フェーズ専用 | `NightActionOutput` (`target` + `reasoning`) |
@@ -173,15 +168,9 @@ CO には2種類のフォールバックがある。
 
 | 並列関数 | 用途 |
 |---|---|
-| `call_speech_parallel()` | DAY_OPENING — 全員発言を並列実行 |
 | `call_pre_night_parallel()` | PRE_NIGHT — CO判断を並列実行 |
 | `call_discussion_parallel()` | DAY_DISCUSSION — 発言（tool use 1ステップ）を並列実行 |
 | `call_vote_parallel()` | DAY_VOTE — 全員の投票判断を並列実行 |
-
-#### Extended thinking
-
-占い師COへの反応・投票前詰め等、重要局面では `call()` に `extended_thinking=True` を渡せるようにする。
-（MVP では任意フラグ。デフォルトはoff）
 
 ### 3.4 Legacy Adapter（`src/legacy/`）
 

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -12,7 +12,7 @@
 |---|---|
 | `game.py` | ゲーム全体の状態マシン。フェーズモジュールを呼び出すオーケストレーター |
 | `phase_pre_night.py` | 前夜フェーズ。CO 判断を実行し、観戦者向けログを残す |
-| `phase_day.py` | 昼フェーズ。OPENING / DISCUSSION / VOTE を進行する |
+| `phase_day.py` | 昼フェーズ。DISCUSSION / VOTE を進行する |
 | `phase_night.py` | 夜フェーズ。狼会話の後、夜行動を「宣言」「解決」「公表」に分けて進行する |
 | `setup.py` | ゲーム初期化（エージェント生成・役職割り当て・永続化） |
 | `phase.py` | フェーズ定義（昼/夜/開始/終了）と遷移ロジック |
@@ -142,8 +142,8 @@ def get_role(role: str) -> Role:
 
 | モジュール | 責務 |
 |---|---|
-| `client.py` | anthropic SDKのラッパー。APIコールと `AgentOutput` へのパース |
-| `prompt.py` | 性格プロンプト・役職プロンプトを組み合わせてシステムプロンプトを生成。`build_system_prompt(agent, ctx, direction, role_ctx)` の4引数シグネチャ。公開情報は `PublicContext`、発言制御は `SpeechDirection`、役職固有情報は `RoleSpecificContext` サブクラス（現在は `WolfSpecificContext` のみ）で渡す。役職固有のプロンプト生成は `src/domain/role.py` の `Role` クラスに委譲する |
+| `client.py` | anthropic SDKのラッパー。APIコールと構造化出力へのパース |
+| `prompt.py` | 性格プロンプト・役職プロンプトを組み合わせてシステムプロンプトを生成。公開情報は `PublicContext`、役職固有情報は `RoleSpecificContext` サブクラス（現在は `WolfSpecificContext` のみ）で渡す。役職固有のプロンプト生成は `src/domain/role.py` の `Role` クラスに委譲する |
 
 Pydanticモデル（`AgentOutput`, `SpeechEntry` 等）は `src/domain/schema.py` に移動。
 
@@ -161,12 +161,6 @@ class PublicContext:
     past_deaths: list[PastDeath] | None = None  # TypedDict: {day, name, cause}
 
 @dataclass
-class SpeechDirection:
-    lang: str = "English"
-    reply_to_entry: SpeechEntry | None = None   # challenge 対象
-    intended_co: Role | None = None
-
-@dataclass
 class RoleSpecificContext:
     """役職固有コンテキストの基底クラス"""
     pass
@@ -179,16 +173,6 @@ class WolfSpecificContext(RoleSpecificContext):
 - `PublicContext` は1フェーズ内で全エージェント共通のため1回構築して使い回せる
 - `SpeechDirection` はエージェントごとに異なる（reply_to, co フラグ）
 - `RoleSpecificContext` サブクラスは役職固有のランタイム情報を型安全に渡す手段。Seer/Knight/Medium 向けサブクラスは Issue #36 実装時に追加予定
-
-### AgentOutput スキーマ
-
-```python
-class AgentOutput(BaseModel):
-    thought: str
-    speech: str
-    intent: Intent
-    memory_update: list[str]
-```
 
 ### DiscussionResult — tool use 結果 dataclass 群
 
@@ -259,7 +243,6 @@ class VoteOutput(BaseModel):
 
 | 関数 | 用途 | max_tokens | 理由 |
 |---|---|---|---|
-| `call()` | 昼フェーズの発言生成（OPENING） | 2048 | thought が日本語で長くなりやすい |
 | `call_discussion()` | 昼フェーズの発言生成（DISCUSSION、tool use） | 2048 | thought + speech を tool use で1回に統合。日本語で長くなりやすい |
 | `call_vote()` | 昼フェーズの投票判断（VOTE） | 512 | `target` + `reasoning` + `strategy`（狼のみ）。reasoning が日本語で多少長くなることを見込む |
 | `call_wolf_chat()` | 夜フェーズの狼チーム会話 | 2048 | thought + speech + attack_candidates + self_co_decision。日本語で長くなりやすい |
@@ -361,7 +344,7 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 | `WOLF_CHAT` | False | 狼チャット（観戦者のみ） |
 | `PRE_NIGHT_DECISION` | False | 前夜CO判断（観戦者のみ） |
 | `CO_ANNOUNCEMENT` | True | 役職公言。`claimed_role` フィールドに公言した役職名を格納 |
-| `VOTE_CANDIDATES` | False | 発言フェーズ（OPENING / DISCUSSION）での vote_candidates スナップショット（観戦者のみ）。`intent.vote_candidates` が非空のとき各発言後に emit される |
+| `VOTE_CANDIDATES` | False | 発言フェーズ（DISCUSSION）での vote_candidates スナップショット（観戦者のみ）。発言後に emit される |
 | `SUSPICION_UPDATE` | False | 発言フェーズで村人視点の疑惑スコアが更新されたとき（観戦者のみ・dim cyan） |
 | `THREAT_UPDATE` | False | 発言フェーズで人狼視点の脅威スコアが更新されたとき（観戦者のみ・dim red） |
 | `PHASE_START` | True / False | フェーズ開始通知 |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -16,10 +16,8 @@
 | yukkie/AgentVillage#247 | bug | 🔴 | - | Fix: wolf intended_co not passed to discussion phase prompt (PR#242 regression) | DISCUSSIONフェーズのプロンプトに intended_co が渡されず、狼が翌日に偽CO作戦を実行できないデグレ |
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#244 | bug | 🔴 | 1 | Fix silent result displays empty speech instead of watching message | SilentResult 選択時に watching メッセージではなく空発言行が表示されるバグを修正 |
-| yukkie/AgentVillage#245 | tech-debt | 🔴 | 3 | Remove DAY_OPENING phase | OPENING を削除し DAY を DISCUSSION→VOTE のみに。#21 も同時クローズ |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
-| yukkie/AgentVillage#21 | enhancement | 🟡 | 5 | Day 2+ pre-night judgment phase | 昼開始前の判断フェーズを Day 2+ にも拡張 |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |
 | yukkie/AgentVillage#227 | enhancement | 🟡 | 2 | Add early exit for wolf night chat consensus | 全狼の最新攻撃候補が一致したら夜会話を早期終了し、未合意時は既存ラウンド継続を維持する |
 | yukkie/AgentVillage#26 | enhancement | 🟢 | 2 | Thought log display mode switching | 思考ログの表示モード切り替え |

--- a/doc/Spec.md
+++ b/doc/Spec.md
@@ -56,14 +56,9 @@ LLMエージェント同士が自律的に人狼ゲームをプレイする社�
   村人以外の役職（占い師・人狼等）が「初日からCOするか / 様子を見るか」を非公開で判断する
   - 結果は非公開（観戦者のみ閲覧可能）
   - COすると決めた場合、構造化出力の `claim_role` で公言予定役職を指定できる
-  - 指定された役職は `intended_co` に保持され、Day 1 OPENINGプロンプトに CO前提の指示を追加する
-  - `claim_role` が未指定の場合は役職ごとの安全なデフォルトにフォールバックする
 
 [昼フェーズ]
-  1. 最初の一巡（OPENING）
-       全エージェントがランダム順で所感・自己紹介的な発言を行う
-       各発言に通し番号（speech_id）を付与する
-  2. 判断→発言ターン × 最大2回（DISCUSSION × 2）
+  1. 判断→発言ターン × 最大2回（DISCUSSION × 2）
        a. 全エージェントが並列で「判断」する（最大4択）
             - "challenge": 特定の発言（speech_id指定）に突っ込む
             - "speak":     追加で発言する
@@ -75,16 +70,16 @@ LLMエージェント同士が自律的に人狼ゲームをプレイする社�
           challenge の場合、どの speech_id への反応かを発言に含める
           co の場合、発言生成プロンプトに役職公言の指示が追加され、発言後に
           claimed_role が更新される
-  3. 投票（VOTE）
+  2. 投票（VOTE）
        各エージェントに投票専用の LLM 呼び出し（call_vote）を行う
        投票プロンプトには議論ログ全体・past_votes・past_deaths・発言フェーズ
        で蓄積された最終 vote_candidates・狼の場合は仲間情報＋VOTE STRATEGY を含む
        LLM が返す VoteOutput.target を投票先として採用
        システムが多数決を集計 → 最多得票者を追放
-  4. 霊媒結果の解決
+  3. 霊媒結果の解決
        霊媒師が生存している場合、処刑直後に処刑者の真の役職を霊媒師へ通知する
        この情報は非公開で、観戦者ログにのみ記録される
-  5. 勝利判定
+  4. 勝利判定
 
 [夜フェーズ]
   1. 宣言フェーズ
@@ -133,33 +128,48 @@ LLMエージェント同士が自律的に人狼ゲームをプレイする社�
 
 ### 3.3 LLM出力フォーマット
 
-LLMの出力は必ずJSONで受け取る。フェーズによって2種類のフォーマットを使い分ける。
+LLMの出力は必ずJSONで受け取る。フェーズによって複数のフォーマットを使い分ける。
 
-#### (A) 発言フォーマット（OPENING・DISCUSSIONの発言生成）
+#### (A) 発言フォーマット（DISCUSSIONの発言生成・tool use）
+
+DISCUSSION では Claude の tool use を使い、判断と発言を1回の API コールで生成する。
+LLM は `speak` / `challenge` / `co` / `silent` の4 tool から1つを選び、そのパラメータに発言内容を格納する。
+
+**speak / challenge tool（発言・反論）**
 
 ```json
 {
   "thought": "SQは昨日の票替えが不自然。おそらく人狼。",
   "speech": "今日はSQを疑っています。昨日の票替えが不自然でした。",
-  "reasoning": "SQの票替えとタイミングから人狼濃厚と判断。",
-  "intent": {
-    "vote_candidates": [
-      {"target": "SQ", "score": 0.74},
-      {"target": "Raqio", "score": 0.42}
-    ],
-    "co": null,
-    "strategy": "wolf_side"
-  },
-  "memory_update": ["SQの票替えを黒要素として維持"]
+  "memory_update": ["SQの票替えを黒要素として維持"],
+  "suspicion_scores": {"SQ": 0.74, "Raqio": 0.42},
+  "threat_scores": null
 }
 ```
 
-| フィールド | 型 | 内容 |
-|---|---|---|
-| `intent.vote_candidates` | `list` | 投票意向のヒント（target と score のリスト）。VOTE フェーズの専用 LLM 呼び出しへの入力として渡される |
-| `intent.co` | `str \| null` | 公言する役職（CO 時のみ） |
+challenge の場合は追加で `reply_to: int`（反論対象の speech_id）を含む。
 
-#### (D) 投票フォーマット（VOTE フェーズ専用）
+**co tool（役職公言）**
+
+```json
+{
+  "thought": "今日CO宣言すべきタイミング。",
+  "speech": "私は占い師です。昨夜SQを占い、人狼と出ました。",
+  "claim_role": "Seer",
+  "memory_update": [],
+  "suspicion_scores": {"SQ": 0.9}
+}
+```
+
+**silent tool（沈黙）**
+
+```json
+{
+  "reasoning": "まだ情報が少ないので様子を見る。"
+}
+```
+
+#### (B) 投票フォーマット（VOTE フェーズ専用）
 
 ```json
 {
@@ -195,7 +205,7 @@ LLMの出力は必ずJSONで受け取る。フェーズによって2種類のフ
 
 人狼・狂人は `claim_role` で偽CO先を明示できる。よくある候補は占い師・霊媒師だが、役職配分や盤面に応じて他の役職名を選んでもよい。
 
-#### (B) 判断フォーマット（DISCUSSIONの判断フェーズ・軽量）
+#### (D) 判断フォーマット（DISCUSSIONの判断フェーズ・軽量）
 
 ```json
 {

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -121,10 +121,6 @@ class WolfSelfCoDecision(BaseModel):
     timing: Literal["next_day", "wait"] = "wait"
 
 
-class Intent(BaseModel):
-    co: RoleField = None
-
-
 class VoteOutput(BaseModel):
     """LLM response schema for the dedicated VOTE phase prompt.
 
@@ -141,23 +137,6 @@ class VoteOutput(BaseModel):
     target: str
     reasoning: str = ""
     strategy: Literal["village_side", "wolf_side"] | None = None
-
-
-class AgentOutput(BaseModel):
-    """LLM response schema for a regular speech turn.
-
-    Mock-Policy: Forbidden
-        LLM I/O contract. See ``PreNightOutput`` and
-        ``tests/TestStrategy.md`` §5.
-    """
-
-    thought: str
-    speech: str
-    reasoning: str
-    intent: Intent
-    memory_update: list[str] = []
-    suspicion_scores: dict[str, float] | None = None
-    threat_scores: dict[str, float] | None = None
 
 
 class WolfChatOutput(BaseModel):

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -9,8 +9,8 @@ from src.engine.phase_night import run_night_phase
 from src.engine.phase_pre_night import run_pre_night_phase
 from src.llm import factory as llm_factory
 from src.llm.client import LLMClient
-from src.llm.prompt import PastDeath, PastVote, PublicContext, RoleSpecificContext, SpeechDirection, WolfSpecificContext
-from src.domain.schema import AgentOutput, ChallengeResult, CoResult, DiscussionResult, SilentResult, SpeechEntry
+from src.llm.prompt import PastDeath, PastVote, PublicContext, RoleSpecificContext, WolfSpecificContext
+from src.domain.schema import ChallengeResult, CoResult, DiscussionResult, SilentResult, SpeechEntry
 from src.action.types import ActionType, Vote
 from src.action.validator import validate
 from src.domain.event import LogEvent, EventType
@@ -33,11 +33,10 @@ class GameEngine:
         self.lang = lang
         self._llm_client = llm_client or llm_factory.create_client()
         self.day = 1
-        self.phase = Phase.DAY_OPENING
+        self.phase = Phase.DAY_DISCUSSION
         self.today_log: list[SpeechEntry] = []
         self._speech_id_counter: int = 0
         self._day_turn: int = 0
-        self._day_outputs: dict[str, AgentOutput] = {}
         # Public history passed to agent prompts
         self._past_votes: list[PastVote] = []
         self._past_deaths: list[PastDeath] = []
@@ -85,7 +84,7 @@ class GameEngine:
             self._emit(event)
 
     def _phase_start(self, phase: Phase) -> None:
-        if phase in (Phase.DAY_OPENING, Phase.DAY_DISCUSSION):
+        if phase == Phase.DAY_DISCUSSION:
             self._day_turn += 1
             label = f"DAY {self.day}  TURN {self._day_turn}"
         elif phase == Phase.DAY_VOTE:
@@ -139,109 +138,10 @@ class GameEngine:
             self.today_log = []
             self._speech_id_counter = 0
             self._day_turn = 0
-            self._day_outputs = {}
 
     def _next_speech_id(self) -> int:
         self._speech_id_counter += 1
         return self._speech_id_counter
-
-    def _apply_speech_output(
-        self,
-        actor: Actor,
-        output: AgentOutput,
-        phase: Phase,
-        reply_to_entry: SpeechEntry | None = None,
-    ) -> SpeechEntry:
-        """Post-process a speech output: emit events, update memory, append to today_log."""
-        self._day_outputs[actor.name] = output
-
-        # If the actor intended to CO but did not declare in speech, clear the flag.
-        if actor.state.intended_co is not None and not output.intent.co:
-            missed_co_role = actor.state.intended_co
-            actor.state.intended_co = None
-            store.save(actor)
-            if phase == Phase.DAY_OPENING:
-                self._emit(LogEvent.make(
-                    day=self.day,
-                    phase=phase.value,
-                    event_type=EventType.PRE_NIGHT_DECISION,
-                    agent=actor.name,
-                    content=f"{actor.name} decided to CO as {missed_co_role.name} but did not declare in speech",
-                    is_public=False,
-                ))
-
-        # Update claimed_role BEFORE emitting the speech so the CO speech itself
-        # is rendered with the correct role color.
-        if output.intent.co and actor.state.claimed_role != output.intent.co:
-            actor.state.claimed_role = output.intent.co
-            actor.state.intended_co = None  # clear once CO is made
-            store.save(actor)
-            self._emit(LogEvent.make(
-                day=self.day,
-                phase=phase.value,
-                event_type=EventType.CO_ANNOUNCEMENT,
-                agent=actor.name,
-                content=f"{actor.name} claims to be {actor.state.claimed_role.name}",
-                is_public=True,
-                claimed_role=actor.state.claimed_role,
-            ))
-
-        speech_id = self._next_speech_id()
-        entry = SpeechEntry(speech_id=speech_id, agent=actor.name, text=output.speech)
-        self.today_log.append(entry)
-
-        self._emit(LogEvent.make(
-            day=self.day,
-            phase=phase.value,
-            event_type=EventType.SPEECH,
-            agent=actor.name,
-            content=output.speech,
-            is_public=True,
-            speech_id=speech_id,
-            reply_to=reply_to_entry.speech_id if reply_to_entry else None,
-        ))
-        self._emit(LogEvent.make(
-            day=self.day,
-            phase=phase.value,
-            event_type=EventType.SPEECH,
-            agent=actor.name,
-            content=f"[THINK] {output.thought}",
-            is_public=False,
-            speech_id=speech_id,
-        ))
-
-        if output.suspicion_scores:
-            memory_mod.update_beliefs(actor, output.suspicion_scores)
-            scores_str = ", ".join(
-                f"{name}={score:.2f}" for name, score in output.suspicion_scores.items()
-            )
-            self._emit(LogEvent.make(
-                day=self.day,
-                phase=phase.value,
-                event_type=EventType.SUSPICION_UPDATE,
-                agent=actor.name,
-                content=f"{actor.name} suspicion update: {scores_str}",
-                is_public=False,
-            ))
-
-        if output.threat_scores:
-            memory_mod.update_threat_scores(actor, output.threat_scores)
-            scores_str = ", ".join(
-                f"{name}={score:.2f}" for name, score in output.threat_scores.items()
-            )
-            self._emit(LogEvent.make(
-                day=self.day,
-                phase=phase.value,
-                event_type=EventType.THREAT_UPDATE,
-                agent=actor.name,
-                content=f"{actor.name} threat update: {scores_str}",
-                is_public=False,
-            ))
-
-        if output.memory_update:
-            memory_mod.update_memory(actor, output.memory_update)
-
-        return entry
 
     def _build_discussion_ctx_map(
         self,
@@ -373,36 +273,6 @@ class GameEngine:
             memory_mod.update_memory(actor, result.memory_update)
 
         return entry
-
-    def _build_speech_args(
-        self,
-        actor: Actor,
-        reply_to_entry: SpeechEntry | None = None,
-        today_log_snapshot: list[SpeechEntry] | None = None,
-    ) -> tuple:
-        ctx = PublicContext(
-            today_log=list(today_log_snapshot) if today_log_snapshot is not None else list(self.today_log),
-            alive_players=self._alive_names(),
-            dead_players=self._dead_names(),
-            day=self.day,
-            all_agents=self.agents,
-            past_votes=self._past_votes,
-            past_deaths=self._past_deaths,
-        )
-        direction = SpeechDirection(
-            lang=self.lang,
-            reply_to_entry=reply_to_entry,
-            intended_co=actor.state.intended_co,
-        )
-        # TODO(#36): Add SeerSpecificContext / KnightSpecificContext / MediumSpecificContext
-        role_ctx = (
-            WolfSpecificContext(
-                wolf_partners=[a.name for a in self._alive_agents() if isinstance(a.role, Werewolf) and a.name != actor.name]
-            )
-            if isinstance(actor.role, Werewolf)
-            else None
-        )
-        return ctx, direction, role_ctx
 
     def _run_pre_night(self) -> None:
         run_pre_night_phase(self)

--- a/src/engine/phase.py
+++ b/src/engine/phase.py
@@ -3,7 +3,6 @@ from enum import Enum
 
 class Phase(Enum):
     PRE_NIGHT = "pre_night"
-    DAY_OPENING = "day_opening"
     DAY_DISCUSSION = "day_discussion"
     DAY_VOTE = "day_vote"
     NIGHT = "night"

--- a/src/engine/phase_day.py
+++ b/src/engine/phase_day.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 from typing import TYPE_CHECKING
 
 from src.agent import memory as memory_mod
@@ -14,18 +13,6 @@ from src.engine.vote import tally_votes
 
 if TYPE_CHECKING:
     from src.engine.game import GameEngine
-
-
-def _run_opening(engine: GameEngine) -> None:
-    engine.phase = Phase.DAY_OPENING
-    engine._phase_start(Phase.DAY_OPENING)
-
-    opening_order = engine._alive_agents()
-    random.shuffle(opening_order)
-
-    opening_calls = [(actor, *engine._build_speech_args(actor)) for actor in opening_order]
-    for actor, output in engine._llm_client.call_speech_parallel(opening_calls):
-        engine._apply_speech_output(actor, output, Phase.DAY_OPENING)
 
 
 def _run_discussion(engine: GameEngine) -> None:
@@ -136,9 +123,6 @@ def _resolve_post_vote(engine: GameEngine, eliminated: str) -> None:
 
 
 def run_day_phase(engine: GameEngine) -> str | None:
-    engine._day_outputs = {}
-
-    _run_opening(engine)
     _run_discussion(engine)
     eliminated = _run_vote(engine)
     if eliminated:

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -10,9 +10,7 @@ from src.config import MAX_TOKENS
 from src.domain.actor import Actor
 from src.domain.roles import Role
 from src.domain.schema import (
-    AgentOutput,
     DiscussionResult,
-    Intent,
     NightActionOutput,
     PreNightOutput,
     SilentResult,
@@ -26,11 +24,9 @@ from src.llm.prompt import (
     PastVote,
     PublicContext,
     RoleSpecificContext,
-    SpeechDirection,
     build_discussion_system_prompt,
     build_night_action_prompt,
     build_pre_night_prompt,
-    build_system_prompt,
     build_vote_prompt,
     build_wolf_chat_prompt,
 )
@@ -60,17 +56,6 @@ def resolve_claim_role(actor: Actor, claim_role: Role | None) -> Role | None:
         return None
 
     return None
-
-
-def _default_output(actor: Actor) -> AgentOutput:
-    """Fallback AgentOutput when LLM call or parse fails."""
-    return AgentOutput(
-        thought="...",
-        speech="I need to think more carefully.",
-        reasoning="I'm not sure who to suspect yet.",
-        intent=Intent(co=None),
-        memory_update=[],
-    )
 
 
 def _classify_error(e: Exception) -> str:
@@ -143,34 +128,6 @@ class LLMClient:
     def __init__(self, client: anthropic.Anthropic) -> None:
         self._client = client
 
-    def call(
-        self,
-        actor: Actor,
-        ctx: PublicContext,
-        direction: SpeechDirection,
-        role_ctx: RoleSpecificContext | None = None,
-    ) -> AgentOutput:
-        """Call LLM for day-phase speech and return structured AgentOutput."""
-        system_prompt = build_system_prompt(actor, ctx, direction, role_ctx)
-        raw = ""
-        try:
-            message = self._client.messages.create(
-                model=actor.model,
-                max_tokens=MAX_TOKENS["call_speech"],
-                system=system_prompt,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": "It's your turn. Provide your response in the required JSON format.",
-                    }
-                ],
-            )
-            raw = message.content[0].text
-            return AgentOutput.model_validate_json(_extract_json(raw))
-        except Exception as e:
-            _classify_and_log_error("call", actor.name, e, raw)
-            return _default_output(actor)
-
     def call_discussion(
         self,
         actor: Actor,
@@ -200,19 +157,6 @@ class LLMClient:
         except Exception as e:
             _classify_and_log_error("call_discussion", actor.name, e, "")
             return SilentResult(reasoning="error fallback")
-
-    def call_speech_parallel(
-        self,
-        calls: list[tuple[Actor, PublicContext, SpeechDirection, RoleSpecificContext | None]],
-    ) -> Iterator[tuple[Actor, AgentOutput]]:
-        """Fire all speech calls in parallel; yield results in completion order."""
-        with ThreadPoolExecutor() as executor:
-            future_to_actor = {
-                executor.submit(self.call, actor, ctx, direction, role_ctx): actor
-                for actor, ctx, direction, role_ctx in calls
-            }
-            for future in as_completed(future_to_actor):
-                yield future_to_actor[future], future.result()
 
     def call_pre_night_action(
         self,

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -4,7 +4,6 @@ from typing import Literal, TypedDict
 
 from src.domain.actor import Actor
 from src.domain.roles import Role, Werewolf
-from src.domain.schema import RoleField
 from src.domain.schema import SpeechEntry
 
 
@@ -28,13 +27,6 @@ class PublicContext:
     all_agents: list[Actor] | None = None
     past_votes: list[PastVote] | None = None
     past_deaths: list[PastDeath] | None = None
-
-
-@dataclass
-class SpeechDirection:
-    lang: str = "English"
-    reply_to_entry: SpeechEntry | None = None
-    intended_co: RoleField = None
 
 
 @dataclass
@@ -175,36 +167,6 @@ def build_personal_info_prompt(actor: Actor) -> str:
                 lines.append(f"    Reasons: {'; '.join(belief.reason)}")
 
     return "\n".join(lines)
-
-
-def build_system_prompt(
-    actor: Actor,
-    ctx: PublicContext,
-    direction: SpeechDirection,
-    role_ctx: RoleSpecificContext | None = None,
-) -> str:
-    """Assemble full system prompt for an actor."""
-    wolf_partners = role_ctx.wolf_partners if isinstance(role_ctx, WolfSpecificContext) else None
-    parts = [
-        build_persona_prompt(actor),
-        "\n",
-        build_role_prompt(actor.role, wolf_partners),
-        build_public_info_prompt(ctx),
-        build_personal_info_prompt(actor),
-    ]
-    if direction.reply_to_entry is not None:
-        parts.append(
-            f"\n--- YOUR TURN (CHALLENGE) ---\n"
-            f"You decided to challenge speech [{direction.reply_to_entry.speech_id}] by {direction.reply_to_entry.agent}:\n"
-            f'  "{direction.reply_to_entry.text}"\n'
-            f"Respond directly to this statement in your speech."
-        )
-    if direction.intended_co:
-        co_text = direction.intended_co.co_prompt()
-        if co_text:
-            parts.append(co_text)
-    parts.append(actor.role.output_format_prompt(direction.lang))
-    return "\n".join(parts)
 
 
 def build_pre_night_prompt(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 from src.domain.actor import Actor, ActorProfile, ActorState, Persona, make_actor
 from src.domain.event import LogEvent
-from src.domain.schema import AgentOutput, Intent, PreNightOutput, SilentResult, VoteOutput
+from src.domain.schema import PreNightOutput, SilentResult, VoteOutput
 from src.engine.game import GameEngine
 from src.llm.client import LLMClient
 from src.logger.writer import LogWriter
@@ -91,24 +91,6 @@ def make_failing_llm_client() -> LLMClient:
 
 
 # ── Shared Mock Builders for GameEngine ──────────────────────────────────
-
-
-def make_agent_output(name: str, speech: str = "Hello.") -> AgentOutput:
-    """Build AgentOutput with standard defaults for test side_effect."""
-    return AgentOutput(
-        thought="thinking",
-        speech=speech,
-        reasoning="reasoning",
-        intent=Intent(),
-        memory_update=[],
-    )
-
-
-def make_speech_parallel_side_effect():
-    """Side effect for call_speech_parallel: each actor returns standard AgentOutput."""
-    def _side_effect(calls):
-        return iter([(a, make_agent_output(a.name)) for a, *_ in calls])
-    return _side_effect
 
 
 def make_silent_discussion_side_effect():
@@ -215,15 +197,6 @@ def make_wolf_chat_side_effect(score: float = 0.8) -> callable:
 
 
 # ── Shared JSON Constants for Client Tests ──────────────────────────────
-
-
-AGENT_OUTPUT_JSON = json.dumps({
-    "thought": "thinking",
-    "speech": "Hello village.",
-    "reasoning": "just a test",
-    "intent": {},
-    "memory_update": [],
-})
 
 
 PRE_NIGHT_OUTPUT_JSON = json.dumps({

--- a/tests/contract/test_engine_orchestration_contract.py
+++ b/tests/contract/test_engine_orchestration_contract.py
@@ -17,10 +17,8 @@ from unittest.mock import patch
 import pytest
 
 from src.domain.event import EventType
-from src.domain.roles import Seer
-from src.domain.schema import AgentOutput, Intent
+from src.domain.schema import SpeakResult
 from src.engine.phase import Phase
-from tests.conftest import make_agent_output
 
 
 # ── run() loop contract ───────────────────────────────────────────────────────
@@ -139,74 +137,12 @@ class TestGetAgentMissContract:
         assert attack_events == []
 
 
-# ── intended-CO miss contract ─────────────────────────────────────────────────
-
-
-@pytest.mark.unit
-class TestIntendedCoMissContract:
-    """SUT: GameEngine._apply_speech_output()
-    Mock: store.save をパッチ（ファイルI/O回避）
-    Level: unit
-    Objective: DAY_OPENING で intended_co を持つエージェントが CO しなかった際の
-               PRE_NIGHT_DECISION emit と intended_co クリアの契約を検証する。
-    """
-
-    def test_opening_co_miss_emits_pre_night_decision_and_clears_flag(
-        self, make_test_actor, make_test_engine
-    ):
-        """
-        SUT: GameEngine._apply_speech_output()
-        Mock: store.save をパッチ
-        Level: unit
-        Objective: DAY_OPENING で intent.co=None のとき PRE_NIGHT_DECISION が emit され
-                   intended_co が None にクリアされること。
-        """
-        seer = make_test_actor("Seer1", "Seer")
-        seer.state.intended_co = Seer()
-        engine, events = make_test_engine([seer])
-
-        output = make_agent_output("Seer1", "I will stay quiet.")  # intent.co is None
-
-        with patch("src.agent.store.save"):
-            engine._apply_speech_output(seer, output, Phase.DAY_OPENING)
-
-        assert seer.state.intended_co is None
-
-        co_miss_events = [e for e in events if e.event_type == EventType.PRE_NIGHT_DECISION]
-        assert len(co_miss_events) == 1
-        assert seer.name in co_miss_events[0].content
-        assert co_miss_events[0].is_public is False
-
-    def test_non_opening_co_miss_does_not_emit_pre_night_decision(
-        self, make_test_actor, make_test_engine
-    ):
-        """
-        SUT: GameEngine._apply_speech_output()
-        Mock: store.save をパッチ
-        Level: unit
-        Objective: DAY_OPENING 以外のフェーズでは intended_co miss が PRE_NIGHT_DECISION を emit しないこと。
-        """
-        seer = make_test_actor("Seer1", "Seer")
-        seer.state.intended_co = Seer()
-        engine, events = make_test_engine([seer])
-
-        output = make_agent_output("Seer1", "Just talking.")
-
-        with patch("src.agent.store.save"):
-            engine._apply_speech_output(seer, output, Phase.DAY_DISCUSSION)
-
-        assert seer.state.intended_co is None
-
-        co_miss_events = [e for e in events if e.event_type == EventType.PRE_NIGHT_DECISION]
-        assert co_miss_events == []
-
-
 # ── post-speech memory update contract ───────────────────────────────────────
 
 
 @pytest.mark.unit
 class TestMemoryUpdateContract:
-    """SUT: GameEngine._apply_speech_output() -> memory_mod.update_memory()
+    """SUT: GameEngine._apply_discussion_result() -> memory_mod.update_memory()
     Mock: memory_mod.update_memory をパッチ、store.save をパッチ
     Level: unit
     Objective: memory_update フィールドが非空のときのみ update_memory が呼ばれる契約を検証する。
@@ -216,19 +152,17 @@ class TestMemoryUpdateContract:
         self, make_test_actor, make_test_engine
     ):
         """
-        SUT: GameEngine._apply_speech_output()
+        SUT: GameEngine._apply_discussion_result()
         Mock: memory_mod.update_memory をパッチ、store.save をパッチ
         Level: unit
-        Objective: output.memory_update が非空のとき memory_mod.update_memory(actor, updates) が呼ばれること。
+        Objective: SpeakResult.memory_update が非空のとき memory_mod.update_memory(actor, updates) が呼ばれること。
         """
         actor = make_test_actor("Alice")
         engine, _ = make_test_engine([actor])
 
-        output = AgentOutput(
+        result = SpeakResult(
             thought="thinking",
             speech="Bob looks suspicious.",
-            reasoning="r",
-            intent=Intent(),
             memory_update=["Bob seems suspicious."],
         )
 
@@ -236,7 +170,7 @@ class TestMemoryUpdateContract:
             patch("src.engine.game.memory_mod.update_memory") as mock_update,
             patch("src.agent.store.save"),
         ):
-            engine._apply_speech_output(actor, output, Phase.DAY_DISCUSSION)
+            engine._apply_discussion_result(actor, result, Phase.DAY_DISCUSSION)
 
         mock_update.assert_called_once_with(actor, ["Bob seems suspicious."])
 
@@ -244,20 +178,20 @@ class TestMemoryUpdateContract:
         self, make_test_actor, make_test_engine
     ):
         """
-        SUT: GameEngine._apply_speech_output()
+        SUT: GameEngine._apply_discussion_result()
         Mock: memory_mod.update_memory をパッチ、store.save をパッチ
         Level: unit
-        Objective: output.memory_update が空リストのとき memory_mod.update_memory が呼ばれないこと。
+        Objective: SpeakResult.memory_update が空リストのとき memory_mod.update_memory が呼ばれないこと。
         """
         actor = make_test_actor("Alice")
         engine, _ = make_test_engine([actor])
 
-        output = make_agent_output("Alice")  # memory_update=[]
+        result = SpeakResult(thought="thinking", speech="Hello.")  # memory_update=[]
 
         with (
             patch("src.engine.game.memory_mod.update_memory") as mock_update,
             patch("src.agent.store.save"),
         ):
-            engine._apply_speech_output(actor, output, Phase.DAY_DISCUSSION)
+            engine._apply_discussion_result(actor, result, Phase.DAY_DISCUSSION)
 
         mock_update.assert_not_called()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -7,11 +7,10 @@ import pytest
 
 from unittest.mock import MagicMock
 
-from src.domain.schema import AgentOutput, ChallengeResult, CoResult, NightActionOutput, PreNightOutput, SilentResult, SpeakResult, VoteOutput, WolfChatOutput
+from src.domain.schema import ChallengeResult, CoResult, NightActionOutput, PreNightOutput, SilentResult, SpeakResult, VoteOutput, WolfChatOutput
 from src.domain.roles import get_role
 from src.llm.client import LLMClient, _classify_error, resolve_claim_role
 from tests.conftest import (
-    AGENT_OUTPUT_JSON,
     NIGHT_ACTION_OUTPUT_JSON,
     PRE_NIGHT_CO_OUTPUT_JSON,
     PRE_NIGHT_OUTPUT_JSON,
@@ -21,28 +20,6 @@ from tests.conftest import (
     make_failing_llm_client,
     make_llm_client_with_response,
 )
-
-
-class TestCall:
-    def test_returns_agent_output(self, make_test_actor):
-        actor = make_test_actor("Alice")
-        llm = make_llm_client_with_response(AGENT_OUTPUT_JSON)
-        from src.llm.prompt import PublicContext, SpeechDirection
-        ctx = PublicContext(alive_players=["Alice"], dead_players=[], day=1, today_log=[])
-        direction = SpeechDirection()
-        result = llm.call(actor, ctx, direction)
-        assert isinstance(result, AgentOutput)
-        assert result.speech == "Hello village."
-
-    def test_returns_fallback_on_exception(self, make_test_actor):
-        actor = make_test_actor("Alice")
-        llm = make_failing_llm_client()
-        from src.llm.prompt import PublicContext, SpeechDirection
-        ctx = PublicContext(alive_players=["Alice"], dead_players=[], day=1, today_log=[])
-        direction = SpeechDirection()
-        result = llm.call(actor, ctx, direction)
-        assert isinstance(result, AgentOutput)
-        assert result.speech == "I need to think more carefully."
 
 
 def _make_tool_use_message(tool_name: str, tool_input: dict):

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -10,7 +10,7 @@ from src.engine.phase_day import run_day_phase
 from src.engine.phase_night import run_night_phase
 from src.engine.phase_pre_night import run_pre_night_phase
 from src.engine.phase import Phase
-from src.domain.schema import AgentOutput, ChallengeResult, CoResult, Intent, SilentResult, SpeakResult
+from src.domain.schema import ChallengeResult, CoResult, SilentResult, SpeakResult
 from src.domain.event import EventType
 from src.domain.roles import Seer
 from src.llm.client import LLMClient
@@ -18,7 +18,6 @@ from src.logger.writer import LogWriter
 from tests.conftest import (
     make_night_action_side_effect,
     make_silent_discussion_side_effect,
-    make_speech_parallel_side_effect,
     make_vote_parallel_side_effect,
 )
 
@@ -45,10 +44,9 @@ class TestGameEngineLlmInjection:
 
 
 class TestRunDayPhaseOrder:
-    def test_opening_then_discussion_then_vote(self, make_test_actor, make_test_engine):
+    def test_discussion_then_vote(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("A"), make_test_actor("B"), make_test_actor("C", "Werewolf")]
         engine, events = make_test_engine(agents)
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
 
         with patch("src.agent.store.save"):
@@ -56,16 +54,13 @@ class TestRunDayPhaseOrder:
 
         phase_starts = [e for e in events if e.event_type == EventType.PHASE_START]
         phases = [e.phase for e in phase_starts]
-        assert Phase.DAY_OPENING.value in phases
         assert Phase.DAY_DISCUSSION.value in phases
         assert Phase.DAY_VOTE.value in phases
-        assert phases.index(Phase.DAY_OPENING.value) < phases.index(Phase.DAY_DISCUSSION.value)
         assert phases.index(Phase.DAY_DISCUSSION.value) < phases.index(Phase.DAY_VOTE.value)
 
     def test_speech_ids_are_sequential(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("A"), make_test_actor("B")]
         engine, events = make_test_engine(agents)
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
 
         with patch("src.agent.store.save"):
@@ -80,21 +75,28 @@ class TestRunDayPhaseOrder:
         assert ids == list(range(1, len(ids) + 1))
 
     def test_challenge_reply_to_recorded(self, make_test_actor, make_test_engine):
-        agents = [make_test_actor("A"), make_test_actor("B")]
-        engine, events = make_test_engine(agents)
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
+        actors_list = [make_test_actor("A"), make_test_actor("B")]
+        engine, events = make_test_engine(actors_list)
 
-        # B challenges speech_id=1 (A's opening speech)
+        # B challenges speech_id=1 (A's first discussion speech)
+        call_count = [0]
+
         def discussion_with_challenge(actors, *_, **__):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return iter([
+                    (actors_list[0], SpeakResult(thought="t", speech="Hello")),
+                    (actors_list[1], SilentResult(reasoning="quiet")),
+                ])
             return iter([
-                (make_test_actor("A"), SilentResult(reasoning="quiet")),
-                (make_test_actor("B"), ChallengeResult(thought="t", speech="I disagree!", reply_to=1)),
+                (actors_list[0], SilentResult(reasoning="quiet")),
+                (actors_list[1], ChallengeResult(thought="t", speech="I disagree!", reply_to=1)),
             ])
 
         engine._llm_client.call_discussion_parallel.side_effect = discussion_with_challenge
 
         with (
-            patch("src.engine.phase_day.DISCUSSION_ROUNDS", 1),
+            patch("src.engine.phase_day.DISCUSSION_ROUNDS", 2),
             patch("src.agent.store.save"),
         ):
             engine._run_day()
@@ -106,7 +108,6 @@ class TestRunDayPhaseOrder:
     def test_all_silent_does_not_raise(self, make_test_actor, make_test_engine):
         agents = [make_test_actor("A"), make_test_actor("B", "Werewolf")]
         engine, _ = make_test_engine(agents)
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
 
         with patch("src.agent.store.save"):
@@ -129,7 +130,6 @@ class TestDiscussionCoDecision:
         assert seer.state.claimed_role is None
         engine, _ = make_test_engine([seer])
 
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
             (seer, CoResult(thought="CO now", speech="I am the Seer!", claim_role=seer.role)),
         ])
@@ -149,7 +149,6 @@ class TestDiscussionCoDecision:
         seer = make_test_actor("Seer1", "Seer")
         engine, _ = make_test_engine([seer])
 
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
             (seer, SpeakResult(thought="t", speech="Just speaking.")),
         ])
@@ -169,7 +168,6 @@ class TestDiscussionCoDecision:
         villager = make_test_actor("V1", "Villager")
         engine, events = make_test_engine([villager])
 
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
             (villager, SilentResult(reasoning="nothing")),
         ])
@@ -196,7 +194,6 @@ class TestDiscussionCoDecision:
         from src.domain.roles import get_role
         medium_role = get_role("Medium")
 
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
             (wolf, CoResult(thought="fake", speech="I am the Medium.", claim_role=medium_role)),
         ])
@@ -221,7 +218,6 @@ class TestVoteOutputFlow:
         seer = make_test_actor("Seer1", "Seer")
         engine, events = make_test_engine([wolf, seer])
 
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
         engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
             targets={"Wolf1": "Seer1", "Seer1": "Wolf1"},
@@ -249,7 +245,6 @@ class TestVoteOutputFlow:
         target = make_test_actor("V2", "Villager")
         engine, events = make_test_engine([villager, target])
 
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
         engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
             targets={"V1": "V2", "V2": "V1"},
@@ -274,7 +269,6 @@ class TestVoteOutputFlow:
         wolf2 = make_test_actor("Wolf2", "Werewolf")
         engine, events = make_test_engine([wolf1, wolf2])
 
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
         engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
             targets={"Wolf1": "Wolf2", "Wolf2": "Wolf1"},
@@ -290,29 +284,17 @@ class TestVoteOutputFlow:
         assert wolf1_votes[0].target == "Wolf2"
         assert wolf1_votes[0].decision == "village_side"
 
-    def test_vote_event_reasoning_comes_from_vote_output_not_speech(self, make_test_actor, make_test_engine):
+    def test_vote_event_reasoning_comes_from_vote_output(self, make_test_actor, make_test_engine):
         """
         SUT: _run_vote
-        Mock: call_speech_parallel emits AgentOutput with reasoning="speech-side"; call_vote_parallel emits VoteOutput with reasoning="vote-side"
+        Mock: call_discussion_parallel returns SpeakResult; call_vote_parallel returns VoteOutput with reasoning="vote-side"
         Level: unit
-        Objective: ⚠️unit test mandatory — VOTE LogEvent の reasoning が VoteOutput.reasoning から取られ、AgentOutput.reasoning（発言用）は流用されないこと（AC）。
+        Objective: ⚠️unit test mandatory — VOTE LogEvent の reasoning が VoteOutput.reasoning から取られること（AC）。
         """
         a = make_test_actor("A")
         b = make_test_actor("B")
         engine, events = make_test_engine([a, b])
 
-        speech_output = AgentOutput(
-            thought="t",
-            speech="s",
-            reasoning="speech-side reasoning that must NOT leak into the vote event",
-            intent=Intent(),
-            memory_update=[],
-        )
-
-        def speech_side_effect(calls):
-            return iter([(actor, speech_output) for actor, *_ in calls])
-
-        engine._llm_client.call_speech_parallel.side_effect = speech_side_effect
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
         engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
             targets={"A": "B", "B": "A"},
@@ -325,7 +307,6 @@ class TestVoteOutputFlow:
         a_votes = [e for e in events if e.event_type == EventType.VOTE and e.agent == "A"]
         assert len(a_votes) == 1
         assert a_votes[0].reasoning == "vote-side reasoning"
-        assert "speech-side" not in a_votes[0].reasoning
 
     def test_invalid_target_falls_back_to_first_other(self, make_test_actor, make_test_engine):
         """
@@ -338,7 +319,6 @@ class TestVoteOutputFlow:
         b = make_test_actor("B")
         engine, events = make_test_engine([a, b])
 
-        engine._llm_client.call_speech_parallel.side_effect = make_speech_parallel_side_effect()
         engine._llm_client.call_discussion_parallel.side_effect = make_silent_discussion_side_effect()
         engine._llm_client.call_vote_parallel.side_effect = make_vote_parallel_side_effect(
             targets={"A": "Ghost", "B": "A"},
@@ -409,30 +389,28 @@ class TestRunNightPhaseOrder:
         assert seer.state.beliefs == {}
         assert not any(e.event_type == EventType.INSPECTION for e in events)
 
-    def test_apply_speech_output_threat_scores_updates_state_and_emits_event(
+    def test_apply_discussion_result_threat_scores_updates_state_and_emits_event(
         self, make_test_actor, make_test_engine
     ):
         """
-        SUT: GameEngine._apply_speech_output()
-        Mock: monkeypatch で store.save を no-op に差し替え（make_test_engine 経由）
+        SUT: GameEngine._apply_discussion_result()
+        Mock: store.save をパッチ
         Level: unit
-        Objective: AgentOutput.threat_scores が非 None のとき actor.state.threat_scores が
+        Objective: SpeakResult.threat_scores が非 None のとき actor.state.threat_scores が
                    更新され THREAT_UPDATE イベントが emit されること。
         """
         wolf = make_test_actor("Wolf", "Werewolf")
         villager = make_test_actor("Alice")
         engine, events = make_test_engine([wolf, villager])
 
-        output = AgentOutput(
+        result = SpeakResult(
             thought="thinking",
             speech="Hello.",
-            reasoning="reasoning",
-            intent=Intent(),
             threat_scores={"Alice": 0.85},
         )
 
         with patch("src.agent.store.save"):
-            engine._apply_speech_output(wolf, output, Phase.DAY_OPENING)
+            engine._apply_discussion_result(wolf, result, Phase.DAY_DISCUSSION)
 
         assert wolf.state.threat_scores["Alice"] == pytest.approx(0.85)
         threat_events = [e for e in events if e.event_type == EventType.THREAT_UPDATE]
@@ -440,30 +418,28 @@ class TestRunNightPhaseOrder:
         assert "Alice=0.85" in threat_events[0].content
         assert threat_events[0].is_public is False
 
-    def test_apply_speech_output_no_threat_scores_emits_no_threat_event(
+    def test_apply_discussion_result_no_threat_scores_emits_no_threat_event(
         self, make_test_actor, make_test_engine
     ):
         """
-        SUT: GameEngine._apply_speech_output()
-        Mock: patch で store.save を no-op に差し替え
+        SUT: GameEngine._apply_discussion_result()
+        Mock: store.save をパッチ
         Level: unit
-        Objective: AgentOutput.threat_scores が None のとき THREAT_UPDATE イベントが
+        Objective: SpeakResult.threat_scores が None のとき THREAT_UPDATE イベントが
                    emit されないこと。
         """
         wolf = make_test_actor("Wolf", "Werewolf")
         villager = make_test_actor("Alice")
         engine, events = make_test_engine([wolf, villager])
 
-        output = AgentOutput(
+        result = SpeakResult(
             thought="thinking",
             speech="Hello.",
-            reasoning="reasoning",
-            intent=Intent(),
             threat_scores=None,
         )
 
         with patch("src.agent.store.save"):
-            engine._apply_speech_output(wolf, output, Phase.DAY_OPENING)
+            engine._apply_discussion_result(wolf, result, Phase.DAY_DISCUSSION)
 
         assert not any(e.event_type == EventType.THREAT_UPDATE for e in events)
 

--- a/tests/unit/test_pre_night.py
+++ b/tests/unit/test_pre_night.py
@@ -1,14 +1,12 @@
 """
 前夜フェーズ（PRE_NIGHT）のテスト。
 - build_pre_night_prompt の内容
-- build_system_prompt の intended_co 反映
 - _run_pre_night のフロー（LLM・store.save をモック）
 """
 from unittest.mock import patch
 
 from src.engine.phase import Phase
-from src.domain.roles import get_role
-from src.llm.prompt import PublicContext, SpeechDirection, WolfSpecificContext, build_pre_night_prompt, build_system_prompt
+from src.llm.prompt import build_pre_night_prompt
 from src.domain.event import EventType
 from tests.conftest import make_pre_night_parallel_side_effect
 
@@ -42,38 +40,6 @@ class TestBuildPreNightPrompt:
         prompt = build_pre_night_prompt(agent, players)
         for p in players:
             assert p in prompt
-
-
-# ── build_system_prompt (intended_co) ─────────────────────────────────────
-
-
-class TestBuildSystemPromptIntendedCo:
-    def test_no_intended_co_section_by_default(self, make_test_actor):
-        agent = make_test_actor("Gina", "Seer")
-        ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
-        prompt = build_system_prompt(agent, ctx, SpeechDirection())
-        assert "CO DECISION" not in prompt
-
-    def test_seer_intended_co_adds_true_co_instruction(self, make_test_actor):
-        agent = make_test_actor("Gina", "Seer")
-        ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
-        prompt = build_system_prompt(agent, ctx, SpeechDirection(intended_co=agent.role))
-        assert "CO DECISION" in prompt
-        assert "Seer" in prompt
-        assert "intent.co" in prompt
-        # Must NOT instruct Seer to fake
-        assert "fake" not in prompt.lower()
-
-    def test_werewolf_intended_co_adds_fake_co_instruction(self, make_test_actor):
-        agent = make_test_actor("SQ", "Werewolf")
-        ctx = PublicContext(today_log=[], alive_players=["Gina", "SQ"], dead_players=[], day=1)
-        role_ctx = WolfSpecificContext(wolf_partners=[])
-        prompt = build_system_prompt(agent, ctx, SpeechDirection(intended_co=get_role("Medium")), role_ctx)
-        assert "CO DECISION" in prompt
-        assert "Medium" in prompt
-        assert "intent.co" in prompt
-        # Must NOT tell werewolf to reveal true role
-        assert "Werewolf" not in prompt.split("--- YOUR CO DECISION ---")[1]
 
 
 # ── _run_pre_night ──────────────────────────────────────────────────────────

--- a/tests/unit/test_vote_candidates_event.py
+++ b/tests/unit/test_vote_candidates_event.py
@@ -4,24 +4,21 @@ SUSPICION_UPDATE イベントの emit と Renderer 描画テスト（Issue #36�
 from unittest.mock import patch
 
 from src.domain.event import EventType, LogEvent
-from src.domain.schema import AgentOutput, Intent
+from src.domain.schema import SpeakResult
 from src.engine.phase import Phase
 from src.ui.renderer import Renderer
 
 
-def _make_output(suspicion_scores: dict[str, float] | None) -> AgentOutput:
-    return AgentOutput(
+def _make_speak_result(suspicion_scores: dict[str, float] | None) -> SpeakResult:
+    return SpeakResult(
         thought="thinking",
         speech="Hello.",
-        reasoning="reason",
-        intent=Intent(),
-        memory_update=[],
         suspicion_scores=suspicion_scores,
     )
 
 
 def _make_event(event_type: EventType, **kwargs) -> LogEvent:
-    return LogEvent.make(day=1, phase="day_opening", event_type=event_type, **kwargs)
+    return LogEvent.make(day=1, phase="day_discussion", event_type=event_type, **kwargs)
 
 
 # ── emit tests ────────────────────────────────────────────────────────────────
@@ -30,51 +27,51 @@ def _make_event(event_type: EventType, **kwargs) -> LogEvent:
 class TestSuspicionUpdateEmit:
     def test_event_emitted_when_scores_non_empty(self, make_test_actor, make_test_engine):
         """
-        SUT: GameEngine._apply_speech_output
+        SUT: GameEngine._apply_discussion_result
         Mock: LogWriter.write (via make_test_engine), store.save
         Level: unit
         Objective: suspicion_scores が非空のとき SUSPICION_UPDATE イベントが emit されること。
         """
         actor = make_test_actor("Alice", "Villager")
         engine, events = make_test_engine([actor])
-        output = _make_output({"Bob": 0.7, "Carol": 0.3})
+        result = _make_speak_result({"Bob": 0.7, "Carol": 0.3})
 
         with patch("src.agent.store.save"):
-            engine._apply_speech_output(actor, output, Phase.DAY_OPENING)
+            engine._apply_discussion_result(actor, result, Phase.DAY_DISCUSSION)
 
         su_events = [e for e in events if e.event_type == EventType.SUSPICION_UPDATE]
         assert len(su_events) == 1
 
     def test_event_not_emitted_when_scores_none(self, make_test_actor, make_test_engine):
         """
-        SUT: GameEngine._apply_speech_output
+        SUT: GameEngine._apply_discussion_result
         Mock: LogWriter.write (via make_test_engine), store.save
         Level: unit
         Objective: suspicion_scores が None のとき SUSPICION_UPDATE イベントが emit されないこと。
         """
         actor = make_test_actor("Alice", "Villager")
         engine, events = make_test_engine([actor])
-        output = _make_output(None)
+        result = _make_speak_result(None)
 
         with patch("src.agent.store.save"):
-            engine._apply_speech_output(actor, output, Phase.DAY_OPENING)
+            engine._apply_discussion_result(actor, result, Phase.DAY_DISCUSSION)
 
         su_events = [e for e in events if e.event_type == EventType.SUSPICION_UPDATE]
         assert len(su_events) == 0
 
     def test_event_contains_agent_name_and_scores(self, make_test_actor, make_test_engine):
         """
-        SUT: GameEngine._apply_speech_output
+        SUT: GameEngine._apply_discussion_result
         Mock: LogWriter.write (via make_test_engine), store.save
         Level: unit
         Objective: SUSPICION_UPDATE イベントに agent 名とスコア文字列が含まれること。
         """
         actor = make_test_actor("Alice", "Villager")
         engine, events = make_test_engine([actor])
-        output = _make_output({"Bob": 0.74, "Carol": 0.42})
+        result = _make_speak_result({"Bob": 0.74, "Carol": 0.42})
 
         with patch("src.agent.store.save"):
-            engine._apply_speech_output(actor, output, Phase.DAY_OPENING)
+            engine._apply_discussion_result(actor, result, Phase.DAY_DISCUSSION)
 
         su_event = next(e for e in events if e.event_type == EventType.SUSPICION_UPDATE)
         assert su_event.agent == "Alice"
@@ -83,17 +80,17 @@ class TestSuspicionUpdateEmit:
 
     def test_event_is_not_public(self, make_test_actor, make_test_engine):
         """
-        SUT: GameEngine._apply_speech_output
+        SUT: GameEngine._apply_discussion_result
         Mock: LogWriter.write (via make_test_engine), store.save
         Level: unit
         Objective: SUSPICION_UPDATE イベントが is_public=False であること（観戦者専用）。
         """
         actor = make_test_actor("Alice", "Villager")
         engine, events = make_test_engine([actor])
-        output = _make_output({"Bob": 0.9})
+        result = _make_speak_result({"Bob": 0.9})
 
         with patch("src.agent.store.save"):
-            engine._apply_speech_output(actor, output, Phase.DAY_OPENING)
+            engine._apply_discussion_result(actor, result, Phase.DAY_DISCUSSION)
 
         su_event = next(e for e in events if e.event_type == EventType.SUSPICION_UPDATE)
         assert su_event.is_public is False


### PR DESCRIPTION
## Summary
- `Phase.DAY_OPENING` と `_run_opening()` を完全削除し、昼フェーズを DISCUSSION → VOTE のみに簡略化
- OPENING 専用の `AgentOutput` / `Intent` スキーマ、`SpeechDirection` dataclass、`build_system_prompt()` / `call()` / `call_speech_parallel()` を削除
- `_apply_speech_output()` / `_build_speech_args()` メソッド削除（計 566 行削除）
- テスト・ドキュメント（Spec.md / Architecture.md / DetailDesign.md）を DISCUSSION ベースに更新

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス
- [x] OPENING 削除に伴うテストを DISCUSSION 相当に書き換え済み（test_game_day_loop / test_vote_candidates_event / test_pre_night / test_engine_orchestration_contract / test_client）

Closes #245
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)