### PR TITLE
docs: remove #256 from Ideas.md (closed — survey found no actionable clones)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -17,7 +17,6 @@
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#244 | bug | 🔴 | 1 | Fix silent result displays empty speech instead of watching message | SilentResult 選択時に watching メッセージではなく空発言行が表示されるバグを修正 |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
-| yukkie/AgentVillage#256 | tech-debt | 🟡 | 3 | Review and eliminate semantic clone code across phase modules | #245リファクタで発覚したOPENING/DISCUSSIONクローンをきっかけに、フェーズ間の意味的重複（プロンプトビルダー・後処理・並列呼び出しboilerplate）を棚卸しして整理 |
 | yukkie/AgentVillage#252 | tech-debt | 🟡 | 1 | Add unit tests for uncovered paths in phase_day and game modules | #245リファクタ時のカバレッジ確認で判明した未テストパス（_game_over / vote target=None / _resolve_post_vote）を補完 |
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |


### PR DESCRIPTION
## Summary
- #256 をサーベイした結果、全候補（G1〜G4）がコード変更不要と判断されたためIssueをクローズ
- Ideas.md から該当行を削除

## Test plan
- [x] ドキュメント変更のみ（コード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)