### PR TITLE
Fix empty speech display when LLM misuses thought field

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -15,7 +15,6 @@
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#247 | bug | 🔴 | - | Fix: wolf intended_co not passed to discussion phase prompt (PR#242 regression) | DISCUSSIONフェーズのプロンプトに intended_co が渡されず、狼が翌日に偽CO作戦を実行できないデグレ |
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
-| yukkie/AgentVillage#244 | bug | 🔴 | 1 | Fix silent result displays empty speech instead of watching message | SilentResult 選択時に watching メッセージではなく空発言行が表示されるバグを修正 |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
 | yukkie/AgentVillage#261 | tech-debt | 🟡 | 1 | Move ANTHROPIC_API_KEY check inside main() to fix worktree test failures | モジュールレベルの APIキーチェックが worktree 環境（.env なし）で test_main.py を SystemExit で落とす。main() 内に移動して解消 |
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |

--- a/src/llm/discussion_tools.py
+++ b/src/llm/discussion_tools.py
@@ -1,5 +1,6 @@
 """Tool definitions and response parsing for DISCUSSION phase tool use calls."""
 
+import re
 import sys
 
 import anthropic
@@ -13,6 +14,8 @@ from src.domain.schema import (
 )
 from src.legacy.role_normalizer import normalize_role_field
 
+_XML_TAG_RE = re.compile(r"<(\w[\w:-]*)[^>]*>.*?</\1>", re.DOTALL)
+
 
 def build_discussion_tools(co_eligible: bool) -> list[dict]:
     """Build the tool definitions list for a DISCUSSION call."""
@@ -24,8 +27,8 @@ def build_discussion_tools(co_eligible: bool) -> list[dict]:
             "input_schema": {
                 "type": "object",
                 "properties": {
-                    "thought": {"type": "string", "description": "Your private reasoning (not shown to others)."},
-                    "speech": {"type": "string", "description": "What you say aloud to the group."},
+                    "speech": {"type": "string", "description": "What you say aloud to the group. Do not use XML tags."},
+                    "thought": {"type": "string", "description": "Your private reasoning (not shown to others). Do not use XML tags."},
                     "memory_update": {
                         "type": "array",
                         "items": {"type": "string"},
@@ -42,7 +45,7 @@ def build_discussion_tools(co_eligible: bool) -> list[dict]:
                         "additionalProperties": {"type": "number"},
                     },
                 },
-                "required": ["thought", "speech"],
+                "required": ["speech", "thought"],
             },
         },
         {
@@ -51,8 +54,8 @@ def build_discussion_tools(co_eligible: bool) -> list[dict]:
             "input_schema": {
                 "type": "object",
                 "properties": {
-                    "thought": {"type": "string", "description": "Your private reasoning."},
-                    "speech": {"type": "string", "description": "What you say aloud in response."},
+                    "speech": {"type": "string", "description": "What you say aloud in response. Do not use XML tags."},
+                    "thought": {"type": "string", "description": "Your private reasoning. Do not use XML tags."},
                     "reply_to": {"type": "integer", "description": "The speech_id of the entry you are challenging."},
                     "memory_update": {
                         "type": "array",
@@ -70,7 +73,7 @@ def build_discussion_tools(co_eligible: bool) -> list[dict]:
                         "additionalProperties": {"type": "number"},
                     },
                 },
-                "required": ["thought", "speech", "reply_to"],
+                "required": ["speech", "thought", "reply_to"],
             },
         },
         {
@@ -92,9 +95,9 @@ def build_discussion_tools(co_eligible: bool) -> list[dict]:
             "input_schema": {
                 "type": "object",
                 "properties": {
-                    "thought": {"type": "string", "description": "Your private reasoning."},
-                    "speech": {"type": "string", "description": "What you say aloud when declaring your role."},
+                    "speech": {"type": "string", "description": "What you say aloud when declaring your role. Do not use XML tags."},
                     "claim_role": {"type": "string", "description": f"The role name you are claiming ({role_names_hint})."},
+                    "thought": {"type": "string", "description": "Your private reasoning. Do not use XML tags."},
                     "memory_update": {
                         "type": "array",
                         "items": {"type": "string"},
@@ -111,7 +114,7 @@ def build_discussion_tools(co_eligible: bool) -> list[dict]:
                         "additionalProperties": {"type": "number"},
                     },
                 },
-                "required": ["thought", "speech", "claim_role"],
+                "required": ["speech", "claim_role", "thought"],
             },
         })
     return tools
@@ -125,37 +128,58 @@ def parse_discussion_tool_result(message: anthropic.types.Message, agent_name: s
         inp = block.input
         name = block.name
         if name == "speak":
+            speech = inp.get("speech", "")
+            thought = inp.get("thought", "")
+            _warn_xml_tags(agent_name, name, speech, thought)
+            if not speech:
+                _log_warning(agent_name, "speak tool returned empty speech; falling back to silent")
+                return SilentResult(reasoning="empty speech fallback")
             return SpeakResult(
-                thought=inp.get("thought", ""),
-                speech=inp.get("speech", ""),
+                thought=thought,
+                speech=speech,
                 memory_update=inp.get("memory_update", []),
                 suspicion_scores=inp.get("suspicion_scores"),
                 threat_scores=inp.get("threat_scores"),
             )
         if name == "challenge":
+            speech = inp.get("speech", "")
+            thought = inp.get("thought", "")
+            _warn_xml_tags(agent_name, name, speech, thought)
+            if not speech:
+                _log_warning(agent_name, "challenge tool returned empty speech; falling back to silent")
+                return SilentResult(reasoning="empty speech fallback")
             return ChallengeResult(
-                thought=inp.get("thought", ""),
-                speech=inp.get("speech", ""),
+                thought=thought,
+                speech=speech,
                 reply_to=int(inp.get("reply_to", 0)),
                 memory_update=inp.get("memory_update", []),
                 suspicion_scores=inp.get("suspicion_scores"),
                 threat_scores=inp.get("threat_scores"),
             )
         if name == "co":
+            speech = inp.get("speech", "")
+            thought = inp.get("thought", "")
+            _warn_xml_tags(agent_name, name, speech, thought)
             raw_role = inp.get("claim_role")
             claim_role = normalize_role_field(raw_role)
             if claim_role is None:
                 _log_warning(agent_name, f"co tool missing valid claim_role: {raw_role!r}; falling back to speak")
+                if not speech:
+                    _log_warning(agent_name, "co fallback-to-speak also has empty speech; falling back to silent")
+                    return SilentResult(reasoning="empty speech fallback")
                 return SpeakResult(
-                    thought=inp.get("thought", ""),
-                    speech=inp.get("speech", ""),
+                    thought=thought,
+                    speech=speech,
                     memory_update=inp.get("memory_update", []),
                     suspicion_scores=inp.get("suspicion_scores"),
                     threat_scores=inp.get("threat_scores"),
                 )
+            if not speech:
+                _log_warning(agent_name, "co tool returned empty speech; falling back to silent")
+                return SilentResult(reasoning="empty speech fallback")
             return CoResult(
-                thought=inp.get("thought", ""),
-                speech=inp.get("speech", ""),
+                thought=thought,
+                speech=speech,
                 claim_role=claim_role,
                 memory_update=inp.get("memory_update", []),
                 suspicion_scores=inp.get("suspicion_scores"),
@@ -167,6 +191,12 @@ def parse_discussion_tool_result(message: anthropic.types.Message, agent_name: s
     # No tool_use block found — fall back to silent
     _log_warning(agent_name, "no tool_use block in response; falling back to silent")
     return SilentResult(reasoning="no tool use block")
+
+
+def _warn_xml_tags(agent_name: str, tool_name: str, speech: str, thought: str) -> None:
+    for field_name, value in (("speech", speech), ("thought", thought)):
+        for match in _XML_TAG_RE.finditer(value):
+            _log_warning(agent_name, f"{tool_name}.{field_name} contains XML tag: {match.group()!r}")
 
 
 def _log_warning(agent_name: str, message: str) -> None:

--- a/tests/unit/test_discussion_tools.py
+++ b/tests/unit/test_discussion_tools.py
@@ -1,0 +1,210 @@
+"""Unit tests for src/llm/discussion_tools.py — parse_discussion_tool_result."""
+
+from unittest.mock import MagicMock
+
+from src.domain.schema import ChallengeResult, CoResult, SilentResult, SpeakResult
+from src.llm.discussion_tools import parse_discussion_tool_result
+
+
+def _make_message(tool_name: str, tool_input: dict):
+    """Build a MagicMock simulating anthropic.types.Message with a single tool_use block."""
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = tool_name
+    block.input = tool_input
+    msg = MagicMock()
+    msg.content = [block]
+    return msg
+
+
+class TestParseSpeakEmptySpeech:
+    def test_speak_with_empty_speech_returns_silent(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with speak tool and empty speech
+        Level: unit
+        Objective: speak ツールで speech="" のとき SilentResult を返すこと（空発言行表示を防ぐ）。
+        """
+        msg = _make_message("speak", {"speech": "", "thought": "I have nothing to say"})
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SilentResult)
+
+    def test_speak_with_nonempty_speech_returns_speak_result(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with speak tool and non-empty speech
+        Level: unit
+        Objective: speak ツールで speech が入っているとき SpeakResult を返すこと。
+        """
+        msg = _make_message("speak", {"speech": "Hello everyone.", "thought": "Let me speak"})
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SpeakResult)
+        assert result.speech == "Hello everyone."
+
+    def test_challenge_with_empty_speech_returns_silent(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with challenge tool and empty speech
+        Level: unit
+        Objective: challenge ツールで speech="" のとき SilentResult を返すこと。
+        """
+        msg = _make_message("challenge", {"speech": "", "thought": "...", "reply_to": 3})
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SilentResult)
+
+    def test_challenge_with_nonempty_speech_returns_challenge_result(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with challenge tool and non-empty speech
+        Level: unit
+        Objective: challenge ツールで speech が入っているとき ChallengeResult を返すこと。
+        """
+        msg = _make_message("challenge", {"speech": "I disagree.", "thought": "...", "reply_to": 3})
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, ChallengeResult)
+        assert result.speech == "I disagree."
+        assert result.reply_to == 3
+
+
+class TestParseSilentTool:
+    def test_silent_tool_returns_silent_result(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with silent tool
+        Level: unit
+        Objective: silent ツール選択時に SilentResult を返すこと。
+        """
+        msg = _make_message("silent", {"reasoning": "I have nothing to add."})
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SilentResult)
+
+    def test_no_tool_use_block_returns_silent(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with no tool_use block
+        Level: unit
+        Objective: tool_use ブロックが存在しない場合に SilentResult にフォールバックすること。
+        """
+        block = MagicMock()
+        block.type = "text"
+        msg = MagicMock()
+        msg.content = [block]
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SilentResult)
+
+    def test_non_tool_use_block_is_skipped(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with text block followed by tool_use block
+        Level: unit
+        Objective: tool_use でないブロックをスキップし、後続の tool_use ブロックを処理すること。
+        """
+        text_block = MagicMock()
+        text_block.type = "text"
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.name = "silent"
+        tool_block.input = {"reasoning": "skipping"}
+        msg = MagicMock()
+        msg.content = [text_block, tool_block]
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SilentResult)
+
+
+class TestParseCoTool:
+    def test_co_with_valid_role_and_speech_returns_co_result(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with co tool, valid role, non-empty speech
+        Level: unit
+        Objective: co ツールで valid role と speech が揃っているとき CoResult を返すこと。
+        """
+        msg = _make_message("co", {"speech": "I am the Seer!", "claim_role": "Seer", "thought": "..."})
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, CoResult)
+        assert result.speech == "I am the Seer!"
+
+    def test_co_with_empty_speech_returns_silent(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with co tool, valid role, empty speech
+        Level: unit
+        Objective: co ツールで speech="" のとき SilentResult を返すこと。
+        """
+        msg = _make_message("co", {"speech": "", "claim_role": "Seer", "thought": "..."})
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SilentResult)
+
+    def test_co_with_invalid_role_and_speech_falls_back_to_speak(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with co tool, invalid role, non-empty speech
+        Level: unit
+        Objective: co ツールで claim_role が無効のとき SpeakResult にフォールバックすること。
+        """
+        msg = _make_message("co", {"speech": "I claim something.", "claim_role": "InvalidRole", "thought": "..."})
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SpeakResult)
+        assert result.speech == "I claim something."
+
+    def test_co_with_invalid_role_and_empty_speech_returns_silent(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with co tool, invalid role, empty speech
+        Level: unit
+        Objective: co ツールで claim_role が無効かつ speech="" のとき SilentResult を返すこと。
+        """
+        msg = _make_message("co", {"speech": "", "claim_role": "InvalidRole", "thought": "..."})
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SilentResult)
+
+
+class TestParseXmlTagWarning:
+    def test_xml_tag_in_speech_logs_warning(self, capsys):
+        """
+        SUT: parse_discussion_tool_result (via _warn_xml_tags)
+        Mock: anthropic.types.Message (MagicMock) with XML tag embedded in speech
+        Level: unit
+        Objective: speech フィールドに XML タグが含まれるとき警告が stderr に出力されること。
+        """
+        msg = _make_message(
+            "speak",
+            {
+                "speech": "<thinking>some thought</thinking>",
+                "thought": "normal thought",
+            },
+        )
+        parse_discussion_tool_result(msg, "TestAgent")
+        captured = capsys.readouterr()
+        assert "XML tag" in captured.err
+        assert "<thinking>some thought</thinking>" in captured.err
+
+    def test_parameter_tag_in_thought_logs_warning(self, capsys):
+        """
+        SUT: parse_discussion_tool_result (via _warn_xml_tags)
+        Mock: anthropic.types.Message (MagicMock) with <parameter> tag in thought
+        Level: unit
+        Objective: thought フィールドに <parameter> タグが含まれるとき警告が stderr に出力されること。
+        """
+        msg = _make_message(
+            "speak",
+            {
+                "speech": "Hello!",
+                "thought": 'my reasoning <parameter name="speech">actual speech</parameter>',
+            },
+        )
+        parse_discussion_tool_result(msg, "TestAgent")
+        captured = capsys.readouterr()
+        assert "XML tag" in captured.err
+
+    def test_no_xml_tags_produces_no_warning(self, capsys):
+        """
+        SUT: parse_discussion_tool_result (via _warn_xml_tags)
+        Mock: anthropic.types.Message (MagicMock) with clean fields
+        Level: unit
+        Objective: XML タグが含まれない正常なレスポンスでは警告が出ないこと。
+        """
+        msg = _make_message("speak", {"speech": "I think it's Alice.", "thought": "My reasoning."})
+        parse_discussion_tool_result(msg, "TestAgent")
+        captured = capsys.readouterr()
+        assert "XML tag" not in captured.err


### PR DESCRIPTION
## Summary
- speak/challenge/co ツールのプロパティ順を `speech → thought` に変更し、LLM が speech を先に埋めるよう誘導
- speech / thought 両フィールドの description に「Do not use XML tags.」を追記
- speak/challenge/co で `speech == ""` の場合に SilentResult へフォールバック（空発言行の表示を防止）
- `_warn_xml_tags()` を追加：`<tag>...</tag>` パターンを検知して stderr に警告とマッチ文字列を出力

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（302テスト）
- [x] `speak` / `challenge` / `co` ツールで `speech=""` → `SilentResult` になることを単体テストで確認
- [x] `silent` ツール、no-tool_use block フォールバック、XML tag 警告も単体テストでカバー

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)