### PR TITLE
fix: include intended_co in discussion prompt (closes #247)

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -121,17 +121,16 @@ Contract test: `tests/contract/test_day_phase_contract.py`, `tests/contract/test
 
 CO が成立する経路:
 
-- **議論中CO（DISCUSSION・全Day）**: 判断フェーズで `decision="co"` を選んだ適格エージェントがその場で公言
-   - 適格条件: `claimed_role is None` かつ `role != "Villager"`
-   - `claim_role` が指定されていればその役職を採用し、未指定なら `default_claim_role` にフォールバックする
-   - エンジンは判断結果を `ActorState.intended_co` に直接書き込み、発言生成後にクリアする
+- **議論中CO（DISCUSSION・全Day）**: 夜会話で `timing == "next_day"` の `WolfSelfCoDecision` が返った場合、`ActorState.intended_co` に計画役職を保持する
+   - 翌日 DISCUSSION フェーズで `build_personal_info_prompt()` が `intended_co` を参照してプロンプトに偽CO指示を含める
+   - LLM が `co` ツールを使って CO を宣言したとき `_apply_discussion_result()` が `claimed_role` に反映し `intended_co` をクリアする
+   - 適格条件: `claimed_role is None` かつ `role.can_co == True`
 
 #### COフォールバックと狂人の扱い
 
-CO には2種類のフォールバックがある。
+CO には以下のフォールバックがある。
 
-1. **claim_role 解決時のフォールバック**: `decision="co"` なのに `claim_role` が未指定だった場合、`default_claim_role` を使って `intended_co` を補完する
-2. **発言生成後のフォールバック**: Day 1 OPENINGで `intended_co` が設定されているのにLLMがCOを出力しなかった場合、役職ごとのセーフティネットを適用する
+1. **claim_role 解決時のフォールバック**: `WolfSelfCoDecision` の `claim_role` が未指定だった場合、`default_claim_role` を使って `intended_co` を補完する
 
 `claim_role` 未指定時のデフォルトは以下：
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -16,6 +16,7 @@
 | yukkie/AgentVillage#247 | bug | 🔴 | - | Fix: wolf intended_co not passed to discussion phase prompt (PR#242 regression) | DISCUSSIONフェーズのプロンプトに intended_co が渡されず、狼が翌日に偽CO作戦を実行できないデグレ |
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
+| yukkie/AgentVillage#266 | tech-debt | 🟡 | - | Replace intended_co flag with a typed scheduled-event model | intended_co をフラグから timing 付きスケジュール済みイベント型に置き換え、ライフサイクルを型で表現する |
 | yukkie/AgentVillage#264 | tech-debt | 🟡 | 1 | Add "delete before justifying uncovered code" rule to TestStrategy | カバー不可の承認前に「コード削除で解消できないか」を問うルールを TestStrategy.md に追加 |
 | yukkie/AgentVillage#261 | tech-debt | 🟡 | 1 | Move ANTHROPIC_API_KEY check inside main() to fix worktree test failures | モジュールレベルの APIキーチェックが worktree 環境（.env なし）で test_main.py を SystemExit で落とす。main() 内に移動して解消 |
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -153,6 +153,12 @@ def build_personal_info_prompt(actor: Actor) -> str:
     """Build prompt section with actor's personal beliefs and memory."""
     lines = ["\n--- YOUR PERSONAL INFORMATION ---"]
 
+    if actor.state.intended_co is not None:
+        lines.append(
+            f"You planned to fake-CO as {actor.state.intended_co.name} today. "
+            "Execute this plan in your speech unless something unexpected has happened."
+        )
+
     if actor.state.memory_summary:
         lines.append("Your memory from previous days:")
         for mem in actor.state.memory_summary:

--- a/tests/contract/test_day_phase_contract.py
+++ b/tests/contract/test_day_phase_contract.py
@@ -6,6 +6,7 @@ from src.domain.event import EventType
 from src.domain.roles import Seer, get_role
 from src.domain.schema import ChallengeResult, CoResult, SilentResult, SpeakResult
 from src.engine.phase import Phase
+from src.llm.prompt import PublicContext, WolfSpecificContext
 from tests.conftest import make_silent_discussion_side_effect, make_vote_parallel_side_effect
 
 
@@ -258,3 +259,81 @@ class TestVoteOutputFlowContract:
         a_votes = [e for e in events if e.event_type == EventType.VOTE and e.agent == "A"]
         assert len(a_votes) == 1
         assert a_votes[0].target == "B"
+
+
+class TestIntendedCoLifecycleContract:
+    def test_intended_co_included_in_discussion_prompt(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: contract
+        Architecture ref: doc/Architecture.md §3.2
+        Objective: 夜にセットされた intended_co が翌日 DISCUSSION フェーズの LLM プロンプトに含まれる契約を検証する。
+        """
+        from src.llm.prompt import build_discussion_system_prompt
+
+        wolf = make_test_actor("Wolf1", "Werewolf")
+        seer_role = get_role("Seer")
+        wolf.state.intended_co = seer_role
+
+        ctx = PublicContext(
+            today_log=[],
+            alive_players=["Wolf1", "Alice"],
+            dead_players=[],
+            day=2,
+        )
+        role_ctx = WolfSpecificContext(wolf_partners=[])
+        prompt = build_discussion_system_prompt(wolf, ctx, co_eligible=True, lang="English", role_ctx=role_ctx)
+
+        assert "planned to fake" in prompt.lower() or "fake-co as seer" in prompt.lower() or "planned to" in prompt.lower()
+        assert wolf.state.intended_co is not None  # intended_co はプロンプト生成では消えない
+
+    def test_intended_co_absent_from_prompt_when_none(self, make_test_actor):
+        """
+        SUT: build_discussion_system_prompt()
+        Mock: なし
+        Level: contract
+        Architecture ref: doc/Architecture.md §3.2
+        Objective: intended_co が None のとき偽CO指示がプロンプトに混入しない契約を検証する。
+        """
+        from src.llm.prompt import build_discussion_system_prompt
+
+        villager = make_test_actor("Alice", "Villager")
+        assert villager.state.intended_co is None
+
+        ctx = PublicContext(
+            today_log=[],
+            alive_players=["Alice", "Wolf1"],
+            dead_players=[],
+            day=2,
+        )
+        prompt = build_discussion_system_prompt(villager, ctx, co_eligible=False, lang="English")
+
+        assert "fake" not in prompt.lower()
+        assert "planned to" not in prompt.lower()
+
+    def test_intended_co_cleared_after_co_result(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result()
+        Mock: call_discussion_parallel returns CoResult for wolf
+        Level: contract
+        Architecture ref: doc/Architecture.md §3.2
+        Objective: CoResult が返ったあと intended_co がクリアされる（夜セット→昼DISCUSSION参照→クリア）ライフサイクル契約を検証する。
+        """
+        wolf = make_test_actor("Wolf1", "Werewolf")
+        villager = make_test_actor("Alice")
+        seer_role = get_role("Seer")
+        wolf.state.intended_co = seer_role
+
+        engine, _ = make_test_engine([wolf, villager])
+        engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
+            (wolf, CoResult(thought="fake CO", speech="I am the Seer!", claim_role=seer_role)),
+            (villager, SilentResult(reasoning="nothing")),
+        ])
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        assert wolf.state.intended_co is None
+        assert wolf.state.claimed_role is not None
+        assert wolf.state.claimed_role.name == "Seer"


### PR DESCRIPTION
## Summary
- `build_personal_info_prompt()` に `actor.state.intended_co` の参照を追加し、
  夜会話で計画した偽CO役職を翌日 DISCUSSION フェーズのプロンプトに含めるよう修正
- `doc/Architecture.md` §3.2 の `intended_co` に関する記述を実装と一致させた
- `intended_co` ライフサイクル（夜セット→昼DISCUSSION参照→クリア）を検証する
  contract テスト 3件を `tests/contract/test_day_phase_contract.py` に追加

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（305 tests）
- [ ] `test_intended_co_included_in_discussion_prompt` — プロンプトに偽CO指示が含まれる
- [ ] `test_intended_co_absent_from_prompt_when_none` — None のとき余計な行が出ない
- [ ] `test_intended_co_cleared_after_co_result` — CoResult後に intended_co がクリアされる

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)