### PR TITLE
refactor: move ANTHROPIC_API_KEY check inside main()

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -16,7 +16,6 @@
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
 | yukkie/AgentVillage#266 | tech-debt | 🟡 | - | Replace intended_co flag with a typed scheduled-event model | intended_co をフラグから timing 付きスケジュール済みイベント型に置き換え、ライフサイクルを型で表現する |
-| yukkie/AgentVillage#261 | tech-debt | 🟡 | 1 | Move ANTHROPIC_API_KEY check inside main() to fix worktree test failures | モジュールレベルの APIキーチェックが worktree 環境（.env なし）で test_main.py を SystemExit で落とす。main() 内に移動して解消 |
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |
 | yukkie/AgentVillage#227 | enhancement | 🟡 | 2 | Add early exit for wolf night chat consensus | 全狼の最新攻撃候補が一致したら夜会話を早期終了し、未合意時は既存ラウンド継続を維持する |

--- a/main.py
+++ b/main.py
@@ -16,20 +16,19 @@ import sys
 
 from dotenv import load_dotenv
 
-load_dotenv()
-
-if not os.environ.get("ANTHROPIC_API_KEY"):
-    print("Error: ANTHROPIC_API_KEY is not set.")
-    print("Copy .env.example to .env and add your API key.")
-    sys.exit(1)
-
-from src.engine.setup import initialize_agents  # noqa: E402
-from src.engine.game import GameEngine  # noqa: E402
-from src.logger.writer import LogWriter, archive_state  # noqa: E402
-from src.ui.cli import CLI  # noqa: E402
+from src.engine.setup import initialize_agents
+from src.engine.game import GameEngine
+from src.logger.writer import LogWriter, archive_state
+from src.ui.cli import CLI
 
 
 def main() -> None:
+    load_dotenv()
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("Error: ANTHROPIC_API_KEY is not set.")
+        print("Copy .env.example to .env and add your API key.")
+        sys.exit(1)
+
     parser = argparse.ArgumentParser(description="AgentVillage — LLM Werewolf Game")
     parser.add_argument(
         "--spectator",

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,13 +1,40 @@
 """main.py の main() 関数のテスト。"""
+import os
+import pytest
 from unittest.mock import MagicMock, patch
 
 
 def _run_main(argv: list[str]) -> None:
     """sys.argv を差し替えて main() を呼び出すヘルパー。"""
     import sys
-    with patch.object(sys, "argv", ["main.py"] + argv):
+    with patch.object(sys, "argv", ["main.py"] + argv), \
+         patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
         import main
         main.main()
+
+
+@patch("main.archive_state", return_value="state_archive/game_20240101.json")
+@patch("main.LogWriter")
+@patch("main.CLI")
+@patch("main.GameEngine")
+@patch("main.initialize_agents")
+def test_main_prints_archive_path(mock_init, mock_engine_cls, mock_cli_cls, mock_writer_cls, mock_archive, capsys):
+    """
+    SUT: main.main
+    Mock: archive_state が実パスを返す
+    Level: unit
+    Objective: archive_state がパスを返したとき "Game archived to: ..." が出力されること
+    """
+    mock_init.return_value = [MagicMock()]
+    fake_engine = MagicMock()
+    fake_engine.run.return_value = "Villagers"
+    mock_engine_cls.return_value = fake_engine
+    mock_cli_cls.return_value = MagicMock()
+
+    _run_main([])
+
+    captured = capsys.readouterr()
+    assert "Game archived to: state_archive/game_20240101.json" in captured.out
 
 
 @patch("main.archive_state", return_value=None)
@@ -33,6 +60,23 @@ def test_main_normal_game(mock_init, mock_engine_cls, mock_cli_cls, mock_writer_
     mock_engine_cls.assert_called_once()
     fake_engine.run.assert_called_once()
     fake_cli.show_winner.assert_called_once_with("Villagers")
+
+
+def test_main_no_api_key_exits():
+    """
+    SUT: main.main
+    Mock: patch.dict(os.environ) で ANTHROPIC_API_KEY を除去
+    Level: unit
+    Objective: ANTHROPIC_API_KEY が未設定のとき sys.exit(1) が呼ばれること
+    """
+    import sys
+    import main
+    env_without_key = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    with patch.object(sys, "argv", ["main.py"]), \
+         patch.dict(os.environ, env_without_key, clear=True), \
+         pytest.raises(SystemExit) as exc_info:
+        main.main()
+    assert exc_info.value.code == 1
 
 
 @patch("main.archive_state", return_value=None)


### PR DESCRIPTION
## Summary
- `load_dotenv()` と `ANTHROPIC_API_KEY` チェックをモジュールレベルから `main()` 内に移動
- `from src.xxx import yyy` をトップレベルに持ち上げ、`# noqa: E402` を削除
- `test_main.py` に `patch.dict(os.environ, {ANTHROPIC_API_KEY: test-key})` を追加（`.env` なしの worktree 環境でもテストが通る）
- `ANTHROPIC_API_KEY` 未設定時の `sys.exit(1)` パスと `archive_state` 実パス返却時の出力パスのテストを追加

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（worktree 環境で `tests/unit/test_main.py` が通ることを確認）

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)