### PR TITLE
fix: patch os.environ.get in test_main_no_api_key_exits

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#271 | bug | 🔴 | - | test_main_no_api_key_exits fails after PR #269 merge | PR #269マージ後にmasterでデグレ。APIキー未設定時のSystemExitが検知されなくなった |
 | yukkie/AgentVillage#270 | bug | 🔴 | - | Improve diagnostics for wolf chat claim_role failures | LLMが日本語ロール名を返したときの無音失敗3箇所を修正: normalize_role_field警告・phase_night異常状態警告・プロンプトへの英語制約追加 |
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -65,15 +65,14 @@ def test_main_normal_game(mock_init, mock_engine_cls, mock_cli_cls, mock_writer_
 def test_main_no_api_key_exits():
     """
     SUT: main.main
-    Mock: patch.dict(os.environ) で ANTHROPIC_API_KEY を除去
+    Mock: os.environ.get("ANTHROPIC_API_KEY") が None を返すよう差し替え
     Level: unit
     Objective: ANTHROPIC_API_KEY が未設定のとき sys.exit(1) が呼ばれること
     """
     import sys
     import main
-    env_without_key = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
     with patch.object(sys, "argv", ["main.py"]), \
-         patch.dict(os.environ, env_without_key, clear=True), \
+         patch("main.os.environ.get", return_value=None), \
          pytest.raises(SystemExit) as exc_info:
         main.main()
     assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary
- `test_main_no_api_key_exits` was calling `main()` with `os.environ` cleared, but
  `load_dotenv()` inside `main()` re-populated `ANTHROPIC_API_KEY` from `.env`,
  so `sys.exit(1)` was never reached
- Fix: patch `main.os.environ.get` to return `None`, consistent with how other
  tests in the same file mock the environment via `patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})`

## Test plan
- [ ] `pytest tests/unit/test_main.py` passes (all 4 tests)
- [ ] `pytest` full suite passes

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)