### PR TITLE
fix: improve diagnostics for wolf chat claim_role failures

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#270 | bug | 🔴 | - | Improve diagnostics for wolf chat claim_role failures | LLMが日本語ロール名を返したときの無音失敗3箇所を修正: normalize_role_field警告・phase_night異常状態警告・プロンプトへの英語制約追加 |
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
 | yukkie/AgentVillage#274 | enhancement | 🟡 | - | Allow wolf to re-CO even after claimed_role is set | claimed_role 設定済みでも intended_co による再COを許可し、中盤での役職偽装切り替え戦略を可能にする |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -16,6 +16,7 @@
 | yukkie/AgentVillage#270 | bug | 🔴 | - | Improve diagnostics for wolf chat claim_role failures | LLMが日本語ロール名を返したときの無音失敗3箇所を修正: normalize_role_field警告・phase_night異常状態警告・プロンプトへの英語制約追加 |
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
+| yukkie/AgentVillage#274 | enhancement | 🟡 | - | Allow wolf to re-CO even after claimed_role is set | claimed_role 設定済みでも intended_co による再COを許可し、中盤での役職偽装切り替え戦略を可能にする |
 | yukkie/AgentVillage#266 | tech-debt | 🟡 | - | Replace intended_co flag with a typed scheduled-event model | intended_co をフラグから timing 付きスケジュール済みイベント型に置き換え、ライフサイクルを型で表現する |
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
-from src.agent import memory as memory_mod, store
 from src.action.resolver import resolve_attack, resolve_inspect
 from src.action.types import Attack, Inspect
+from src.agent import memory as memory_mod, store
 from src.domain.actor import Actor, Belief
 from src.domain.event import EventType, LogEvent
 from src.domain.roles import Knight, Seer, Werewolf
@@ -15,6 +16,8 @@ from src.engine.victory import check_victory
 
 if TYPE_CHECKING:
     from src.engine.game import GameEngine
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -80,6 +83,15 @@ def _apply_wolf_self_decisions(
         ):
             wolf.state.intended_co = self_decision.claim_role
         else:
+            if (
+                self_decision is not None
+                and self_decision.timing == "next_day"
+                and self_decision.claim_role is None
+            ):
+                logger.warning(
+                    "%s: timing=next_day but claim_role is None — CO plan discarded",
+                    wolf.name,
+                )
             wolf.state.intended_co = None
         store.save(wolf)
 

--- a/src/legacy/role_normalizer.py
+++ b/src/legacy/role_normalizer.py
@@ -6,7 +6,11 @@ Handles role name strings stored in JSON before RoleField was introduced (pre-is
 Only adaptation logic lives here. No game logic, no domain behavior.
 """
 
+import logging
+
 from src.domain.roles import Role, get_role
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_role_field(v: object) -> Role | None:
@@ -18,4 +22,5 @@ def normalize_role_field(v: object) -> Role | None:
     try:
         return get_role(str(v))
     except ValueError:
+        logger.warning("normalize_role_field: unrecognized role string %r", v)
         return None

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -342,7 +342,7 @@ Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
 - "attack_candidates" lists your preferred attack targets tonight (highest score = most preferred)
 - Use "speech" to discuss and negotiate fake-CO ideas with your wolf partner(s)
 - "self_co_decision" is your own final personal decision after this discussion, even if the wolves do not fully agree
-- If you decide to fake-CO on the next day, set "timing" to "next_day" and set "claim_role" to the role name you will claim
+- If you decide to fake-CO on the next day, set "timing" to "next_day" and set "claim_role" to the role name you will claim (must be an English role name, e.g. "Seer", "Knight", "Villager", "Medium", "Madman" — never use a translated name)
 - If you decide to wait, set "timing" to "wait" and "claim_role" to null
 - The engine will use only "self_co_decision" to decide your next-day intended fake-CO
 - The JSON must contain exactly these four fields and nothing else.

--- a/tests/unit/legacy/test_role_normalizer.py
+++ b/tests/unit/legacy/test_role_normalizer.py
@@ -52,3 +52,18 @@ def test_unknown_string_returns_none():
     Objective: 未知のロール名文字列は ValueError を握り潰して None を返すこと。
     """
     assert normalize_role_field("UnknownRole") is None
+
+
+def test_unknown_string_logs_warning(caplog):
+    """
+    SUT: normalize_role_field
+    Mock: なし（caplog で logging をキャプチャ）
+    Level: unit
+    Objective: 未知のロール名文字列を受け取ったとき、その文字列を含む warning ログが出ること。
+    """
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="src.legacy.role_normalizer"):
+        normalize_role_field("占い師")
+
+    assert any("占い師" in r.message for r in caplog.records)

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -6,7 +6,7 @@ SUT: src/engine/phase_night — _run_wolf_chat, _resolve_night_outcomes, _publis
 from unittest.mock import patch
 
 from src.domain.event import EventType
-from src.domain.schema import WolfChatOutput
+from src.domain.schema import WolfChatOutput, WolfSelfCoDecision
 from src.engine.phase_night import (
     AttackDeclaration,
     GuardDeclaration,
@@ -14,6 +14,7 @@ from src.engine.phase_night import (
     InspectionResult,
     NightDeclarations,
     NightResolution,
+    _apply_wolf_self_decisions,
     _publish_inspection,
     _publish_night_results,
     _resolve_declared_inspection,
@@ -481,6 +482,34 @@ class TestPublishInspection:
 
         assert seer.state.beliefs["Alice"].suspicion == 0.0
         assert len([e for e in events if e.event_type == EventType.INSPECTION]) == 1
+
+
+class TestApplyWolfSelfDecisions:
+    def test_next_day_claim_role_none_logs_warning(self, caplog, make_test_actor, make_test_engine):
+        """
+        SUT: _apply_wolf_self_decisions
+        Mock: store.save — ファイルI/Oを回避; caplog で logging をキャプチャ
+        Level: unit
+        Objective: timing=next_day かつ claim_role=None のとき、狼の名前を含む warning ログが出ること。
+        """
+        import logging
+        from unittest.mock import patch
+
+        wolf = make_test_actor("Wolf1", "Werewolf")
+        engine, _ = make_test_engine([wolf])
+
+        output = WolfChatOutput(
+            thought="t",
+            speech="s",
+            attack_candidates={},
+            self_co_decision=WolfSelfCoDecision(claim_role=None, timing="next_day"),
+        )
+
+        with patch("src.engine.phase_night.store.save"), \
+             caplog.at_level(logging.WARNING, logger="src.engine.phase_night"):
+            _apply_wolf_self_decisions(engine, [wolf], {"Wolf1": output})
+
+        assert any("Wolf1" in r.message for r in caplog.records)
 
 
 class TestResolveDeclaredInspection:


### PR DESCRIPTION
## Summary
- `normalize_role_field`: unrecognized role string (e.g. Japanese "占い師") now emits a `logging.warning` including the raw value
- `_apply_wolf_self_decisions`: anomalous state (`timing=next_day` + `claim_role=None`) now emits a `logging.warning` with the wolf's name
- `build_wolf_chat_prompt`: added explicit English-only constraint for `claim_role` (with examples: "Seer", "Knight", "Villager", "Medium", "Madman")

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `test_unknown_string_logs_warning` — normalize_role_field の警告ログを検証
- [ ] `TestApplyWolfSelfDecisions::test_next_day_claim_role_none_logs_warning` — phase_night の異常状態警告を検証

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)