### PR TITLE
fix: emit wolf chat thought as spectator-only log event

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#276 | bug | 🔴 | - | Emit wolf chat thought as spectator-only log event | 夜の狼会話で thought を取得しているのに spectator ログとして emit していない |
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
 | yukkie/AgentVillage#274 | enhancement | 🟡 | - | Allow wolf to re-CO even after claimed_role is set | claimed_role 設定済みでも intended_co による再COを許可し、中盤での役職偽装切り替え戦略を可能にする |

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -128,6 +128,14 @@ def _run_wolf_chat(engine: GameEngine) -> str | None:
                 content=f"{wolf.name}: {output.speech}",
                 is_public=False,
             ))
+            engine._emit(LogEvent.make(
+                day=engine.day,
+                phase=Phase.NIGHT_WOLF_CHAT.value,
+                event_type=EventType.WOLF_CHAT,
+                agent=wolf.name,
+                content=f"[THINK] {output.thought}",
+                is_public=False,
+            ))
 
     _apply_wolf_self_decisions(engine, wolves, last_wolf_outputs)
 

--- a/tests/contract/test_night_phase_contract.py
+++ b/tests/contract/test_night_phase_contract.py
@@ -222,3 +222,35 @@ class TestWolfChatContract:
         assert wolf1.state.intended_co is not None
         assert wolf1.state.intended_co.name == "Seer"
         assert wolf2.state.intended_co is None
+
+    def test_wolf_chat_emits_thought_as_non_public_event(self, make_test_actor, make_test_engine):
+        """
+        SUT: _run_wolf_chat()
+        Mock: call_wolf_chat returns WolfChatOutput with a specific thought string
+        Level: contract
+        Objective: wolf chat の thought が is_public=False の WOLF_CHAT イベントとして emit される契約を検証する。
+        """
+        from src.domain.schema import WolfChatOutput
+        from src.engine.phase_night import _run_wolf_chat
+
+        wolf1 = make_test_actor("Wolf1", "Werewolf")
+        wolf2 = make_test_actor("Wolf2", "Werewolf")
+        villager = make_test_actor("Alice")
+        engine, emitted = make_test_engine([wolf1, wolf2, villager])
+        engine._wolf_chat_rounds = 1
+
+        engine._llm_client.call_wolf_chat.return_value = WolfChatOutput(
+            thought="secret plan",
+            speech="let's attack Alice",
+            attack_candidates={"Alice": 0.9},
+        )
+
+        with patch("src.engine.phase_night.store.save"):
+            _run_wolf_chat(engine)
+
+        thought_events = [
+            e for e in emitted
+            if not e.is_public and "[THINK]" in e.content and e.event_type == EventType.WOLF_CHAT
+        ]
+        assert len(thought_events) == 2  # one per wolf
+        assert all("secret plan" in e.content for e in thought_events)

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -60,7 +60,7 @@ class TestRunWolfChat:
 
         assert result == "Alice"
         wolf_chat_events = [e for e in events if e.event_type == EventType.WOLF_CHAT]
-        assert len(wolf_chat_events) == 2  # one per wolf per round
+        assert len(wolf_chat_events) == 4  # speech + thought per wolf per round
 
     def test_multi_wolf_chat_empty_candidates_returns_none(self, make_test_actor, make_test_engine):
         """


### PR DESCRIPTION
## Summary
- `_run_wolf_chat` で `WolfChatOutput.thought` を `is_public=False` の `WOLF_CHAT` イベントとして emit するよう修正
- content フォーマットは昼フェーズと統一して `[THINK] {thought}`

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（310件）
- [ ] contract テスト: thought イベントが2件（狼2体 × 1ラウンド）emit されること
- [ ] thought イベントの `is_public=False` を検証

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)