### PR TITLE
fix: render wolf chat thought in dim red style

### DIFF
--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -24,7 +24,6 @@ class Renderer:
     # PRE_NIGHT_DECISION, INSPECTION, GUARD, GAME_OVER) are handled separately in ``on_event``.
     _SIMPLE_EVENT_STYLES: dict[EventType, tuple[str, str]] = {
         EventType.NIGHT_ATTACK: ("[NIGHT] ", "red"),
-        EventType.WOLF_CHAT: ("[WOLF] ", "red"),
         EventType.GUARD_BLOCK: ("[GUARD BLOCK] ", "bold bright_green"),
         EventType.CO_ANNOUNCEMENT: ("[CO] ", "bold white"),
         EventType.MEDIUM_RESULT: ("[MEDIUM] ", "cyan"),
@@ -68,6 +67,12 @@ class Renderer:
 
         elif event.event_type == EventType.ELIMINATION:
             text.append(f"\n{event.content}\n", style="bold red")
+
+        elif event.event_type == EventType.WOLF_CHAT:
+            if event.content.startswith("[THINK]"):
+                text.append(f"[WOLF] {event.content}", style="dim red")
+            else:
+                text.append(f"[WOLF] {event.content}", style="red")
 
         elif event.event_type == EventType.NIGHT_ATTACK:
             # Spectator only — render attacker/target explicitly when available.

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -408,3 +408,49 @@ def test_threat_update_hidden_in_public_mode() -> None:
     result = renderer.on_event(event)
 
     assert result is None
+
+
+def test_wolf_chat_speech_renders_red(make_test_actor) -> None:
+    """
+    SUT: Renderer.on_event (WOLF_CHAT)
+    Mock: なし
+    Level: unit
+    Objective: WOLF_CHAT の speech イベントが red スタイルで描画されること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.WOLF_CHAT,
+        agent="Wolf1",
+        content="Wolf1: let's attack Alice",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "let's attack Alice" in result.plain
+    spans = [s for s in result._spans if s.style == "red"]
+    assert len(spans) > 0
+
+
+def test_wolf_chat_thought_renders_dim_red(make_test_actor) -> None:
+    """
+    SUT: Renderer.on_event (WOLF_CHAT thought)
+    Mock: なし
+    Level: unit
+    Objective: WOLF_CHAT の thought ([THINK] プレフィックス) が dim red スタイルで描画されること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.WOLF_CHAT,
+        agent="Wolf1",
+        content="[THINK] secret plan",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "secret plan" in result.plain
+    spans = [s for s in result._spans if s.style == "dim red"]
+    assert len(spans) > 0


### PR DESCRIPTION
## Summary
- WOLF_CHAT の thought（`[THINK]` プレフィックス付き）を `dim red` で描画するよう修正
- speech は従来通り `red`
- `_SIMPLE_EVENT_STYLES` から `WOLF_CHAT` を外し、`on_event` で個別処理

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（312件）
- [ ] speech → red / thought → dim red のスタイルをそれぞれ unit テストで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)