### PR TITLE
feat: log raw LLM response on empty-speech fallback

### DIFF
--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -151,7 +151,7 @@ class LLMClient:
                     }
                 ],
             )
-            return parse_discussion_tool_result(message, actor.name)
+            return parse_discussion_tool_result(message, actor.name, message.model_dump_json())
         except Exception as e:
             _classify_and_log_error("call_discussion", actor.name, e, "")
             return SilentResult(reasoning="error fallback")

--- a/src/llm/discussion_tools.py
+++ b/src/llm/discussion_tools.py
@@ -120,73 +120,63 @@ def build_discussion_tools(co_eligible: bool) -> list[dict]:
     return tools
 
 
-def parse_discussion_tool_result(message: anthropic.types.Message, agent_name: str) -> DiscussionResult:
+def parse_discussion_tool_result(message: anthropic.types.Message, agent_name: str, raw_response: str = "") -> DiscussionResult:
     """Extract the tool use block from an LLM message and return a DiscussionResult."""
     for block in message.content:
         if block.type != "tool_use":
             continue
-        inp = block.input
+        inp: dict[str, object] = block.input
         name = block.name
+        if name == "silent":
+            return SilentResult(reasoning=str(inp.get("reasoning", "")))
+
+        speech = str(inp.get("speech", ""))
+        thought = str(inp.get("thought", ""))
+        _warn_xml_tags(agent_name, name, speech, thought)
+
+        if not speech:
+            _log_warning(agent_name, f"{name} tool returned empty speech; falling back to silent")
+            if raw_response:
+                _log_warning(agent_name, f"raw LLM response: {raw_response!r}")
+            return SilentResult(reasoning="empty speech fallback")
+
         if name == "speak":
-            speech = inp.get("speech", "")
-            thought = inp.get("thought", "")
-            _warn_xml_tags(agent_name, name, speech, thought)
-            if not speech:
-                _log_warning(agent_name, "speak tool returned empty speech; falling back to silent")
-                return SilentResult(reasoning="empty speech fallback")
             return SpeakResult(
                 thought=thought,
                 speech=speech,
-                memory_update=inp.get("memory_update", []),
-                suspicion_scores=inp.get("suspicion_scores"),
-                threat_scores=inp.get("threat_scores"),
+                memory_update=inp.get("memory_update", []),  # type: ignore[arg-type]
+                suspicion_scores=inp.get("suspicion_scores"),  # type: ignore[arg-type]
+                threat_scores=inp.get("threat_scores"),  # type: ignore[arg-type]
             )
         if name == "challenge":
-            speech = inp.get("speech", "")
-            thought = inp.get("thought", "")
-            _warn_xml_tags(agent_name, name, speech, thought)
-            if not speech:
-                _log_warning(agent_name, "challenge tool returned empty speech; falling back to silent")
-                return SilentResult(reasoning="empty speech fallback")
             return ChallengeResult(
                 thought=thought,
                 speech=speech,
-                reply_to=int(inp.get("reply_to", 0)),
-                memory_update=inp.get("memory_update", []),
-                suspicion_scores=inp.get("suspicion_scores"),
-                threat_scores=inp.get("threat_scores"),
+                reply_to=int(inp.get("reply_to", 0)),  # type: ignore[arg-type]
+                memory_update=inp.get("memory_update", []),  # type: ignore[arg-type]
+                suspicion_scores=inp.get("suspicion_scores"),  # type: ignore[arg-type]
+                threat_scores=inp.get("threat_scores"),  # type: ignore[arg-type]
             )
         if name == "co":
-            speech = inp.get("speech", "")
-            thought = inp.get("thought", "")
-            _warn_xml_tags(agent_name, name, speech, thought)
             raw_role = inp.get("claim_role")
             claim_role = normalize_role_field(raw_role)
             if claim_role is None:
                 _log_warning(agent_name, f"co tool missing valid claim_role: {raw_role!r}; falling back to speak")
-                if not speech:
-                    _log_warning(agent_name, "co fallback-to-speak also has empty speech; falling back to silent")
-                    return SilentResult(reasoning="empty speech fallback")
                 return SpeakResult(
                     thought=thought,
                     speech=speech,
-                    memory_update=inp.get("memory_update", []),
-                    suspicion_scores=inp.get("suspicion_scores"),
-                    threat_scores=inp.get("threat_scores"),
+                    memory_update=inp.get("memory_update", []),  # type: ignore[arg-type]
+                    suspicion_scores=inp.get("suspicion_scores"),  # type: ignore[arg-type]
+                    threat_scores=inp.get("threat_scores"),  # type: ignore[arg-type]
                 )
-            if not speech:
-                _log_warning(agent_name, "co tool returned empty speech; falling back to silent")
-                return SilentResult(reasoning="empty speech fallback")
             return CoResult(
                 thought=thought,
                 speech=speech,
                 claim_role=claim_role,
-                memory_update=inp.get("memory_update", []),
-                suspicion_scores=inp.get("suspicion_scores"),
-                threat_scores=inp.get("threat_scores"),
+                memory_update=inp.get("memory_update", []),  # type: ignore[arg-type]
+                suspicion_scores=inp.get("suspicion_scores"),  # type: ignore[arg-type]
+                threat_scores=inp.get("threat_scores"),  # type: ignore[arg-type]
             )
-        if name == "silent":
-            return SilentResult(reasoning=inp.get("reasoning", ""))
 
     # No tool_use block found — fall back to silent
     _log_warning(agent_name, "no tool_use block in response; falling back to silent")

--- a/tests/unit/test_discussion_tools.py
+++ b/tests/unit/test_discussion_tools.py
@@ -159,6 +159,68 @@ class TestParseCoTool:
         assert isinstance(result, SilentResult)
 
 
+class TestEmptySpeechRawResponseLogging:
+    def test_speak_empty_speech_logs_raw_response(self, capsys):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with speak tool and empty speech
+        Level: unit
+        Objective: speak ツールで empty-speech fallback 時、raw_response が stderr に出力されること。
+        """
+        msg = _make_message("speak", {"speech": "", "thought": "..."})
+        parse_discussion_tool_result(msg, "TestAgent", raw_response='{"raw": "llm_output"}')
+        captured = capsys.readouterr()
+        assert '{"raw": "llm_output"}' in captured.err
+
+    def test_challenge_empty_speech_logs_raw_response(self, capsys):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with challenge tool and empty speech
+        Level: unit
+        Objective: challenge ツールで empty-speech fallback 時、raw_response が stderr に出力されること。
+        """
+        msg = _make_message("challenge", {"speech": "", "thought": "...", "reply_to": 1})
+        parse_discussion_tool_result(msg, "TestAgent", raw_response="raw challenge response")
+        captured = capsys.readouterr()
+        assert "raw challenge response" in captured.err
+
+    def test_co_empty_speech_logs_raw_response(self, capsys):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with co tool, valid role, empty speech
+        Level: unit
+        Objective: co ツールで empty-speech fallback 時、raw_response が stderr に出力されること。
+        """
+        msg = _make_message("co", {"speech": "", "claim_role": "Seer", "thought": "..."})
+        parse_discussion_tool_result(msg, "TestAgent", raw_response="raw co response")
+        captured = capsys.readouterr()
+        assert "raw co response" in captured.err
+
+    def test_nonempty_speech_does_not_log_raw_response(self, capsys):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with speak tool and non-empty speech
+        Level: unit
+        Objective: speech が空でない場合、raw_response がログに出力されないこと。
+        """
+        msg = _make_message("speak", {"speech": "Hello!", "thought": "..."})
+        parse_discussion_tool_result(msg, "TestAgent", raw_response="should_not_appear")
+        captured = capsys.readouterr()
+        assert "should_not_appear" not in captured.err
+
+    def test_empty_raw_response_not_logged(self, capsys):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with speak tool and empty speech, no raw
+        Level: unit
+        Objective: raw_response が空文字のとき raw response ログ行が出力されないこと。
+        """
+        msg = _make_message("speak", {"speech": "", "thought": "..."})
+        parse_discussion_tool_result(msg, "TestAgent", raw_response="")
+        captured = capsys.readouterr()
+        assert "raw LLM response" not in captured.err
+
+
 class TestParseXmlTagWarning:
     def test_xml_tag_in_speech_logs_warning(self, capsys):
         """


### PR DESCRIPTION
## Summary
- `parse_discussion_tool_result` に `raw_response` 引数を追加
- speak / challenge / co のいずれかで empty-speech fallback 時、raw LLM response を警告ログに出力
- speech/thought 抽出と `_warn_xml_tags` を分岐前に共通化し、重複を除去

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] empty-speech fallback 時に raw response が stderr に出力されること（`TestEmptySpeechRawResponseLogging`）

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)