### PR TITLE
refactor: unify PublicContext usage in vote prompt and move wolf chat to role

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,8 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#283 | tech-debt | ❌ | - | Refactor prompt.py: unify PublicContext usage and move night chat prompt to role | build_vote_prompt を PublicContext ベースに統一し past_deaths/past_votes の重複排除、build_wolf_chat_prompt を Role.night_chat_prompt() に移動 |
-| yukkie/AgentVillage#280 | enhancement | ❌ | - | Log raw LLM response on speak tool empty-speech fallback | speak ツールが空スピーチを返したときのフォールバック警告に raw レスポンスを含める |
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
 | yukkie/AgentVillage#274 | enhancement | 🟡 | - | Allow wolf to re-CO even after claimed_role is set | claimed_role 設定済みでも intended_co による再COを許可し、中盤での役職偽装切り替え戦略を可能にする |

--- a/src/domain/roles/role.py
+++ b/src/domain/roles/role.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
+
+if TYPE_CHECKING:
+    from src.domain.actor import Actor
+    from src.domain.schema import SpeechEntry
 
 
 class Role(ABC):
@@ -55,6 +62,13 @@ class Role(ABC):
         Override on Werewolf to inject the village_side / wolf_side choice.
         """
         return ""
+
+    def night_chat_prompt(self, _actor: Actor, _wolf_partners: list[str], _alive_players: list[str], _wolf_chat_log: list[SpeechEntry], _lang: str = "English") -> str | None:
+        """Build the night chat prompt for secret wolf coordination.
+
+        Default: None (only Werewolf participates in night chat).
+        """
+        return None
 
     def output_format_prompt(self, lang: str = "English") -> str:
         """Instruct LLM to output structured JSON for the speech phase.

--- a/src/domain/roles/werewolf.py
+++ b/src/domain/roles/werewolf.py
@@ -1,4 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from src.domain.roles.role import Role
+
+if TYPE_CHECKING:
+    from src.domain.actor import Actor
+    from src.domain.schema import SpeechEntry
 
 
 class Werewolf(Role):
@@ -106,6 +114,54 @@ Rules:
 - "threat_scores" maps each player by how threatening they are to your werewolf team (0.0=safe, 1.0=must eliminate — prioritize Seer, Knight, or anyone close to exposing you); omit players whose threat level has not changed
 - Do NOT include your real role in speech unless you are doing a CO
 """
+
+    def night_chat_prompt(self, actor: Actor, wolf_partners: list[str], alive_players: list[str], wolf_chat_log: list[SpeechEntry], lang: str = "English") -> str:
+        """Build prompt for werewolf team night chat (secret coordination before attack)."""
+        target_candidates = ", ".join(
+            p for p in alive_players if p != actor.name and p not in wolf_partners
+        )
+        lines = [
+            f"You are {actor.name}, a Werewolf in a social deduction game.",
+            f"Your wolf partners tonight: {', '.join(wolf_partners)}.",
+            f"Alive players (potential targets): {target_candidates}.",
+            "",
+            "It is night. You are meeting secretly with your wolf partner(s) to coordinate.",
+            "Your goal is not just to make an individual decision, but to reach a shared plan with your wolf partner(s).",
+            "Discuss who to attack tonight, react to what your partner says, and try to move the conversation toward agreement.",
+            "Also coordinate your deception plan for the next day: who should fake-CO, which role each wolf should claim, and whether anyone should wait instead.",
+            "You are allowed to decide that both wolves fake-CO, only one does, both wait, or even claim the same role if that fits your strategy.",
+        ]
+        if actor.state.threat_scores:
+            lines.append("\nYour current threat assessments (0.0=safe to ignore, 1.0=must eliminate soon):")
+            lines.append("Use these to prioritize tonight's attack target.")
+            for name, score in actor.state.threat_scores.items():
+                lines.append(f"  {name}: threat={score:.2f}")
+        if wolf_chat_log:
+            lines.append("\nWolf team conversation so far:")
+            for entry in wolf_chat_log:
+                lines.append(f"  {entry.agent}: {entry.text}")
+        lines.append(f"""
+--- OUTPUT FORMAT ---
+Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
+{{
+  "thought": "<your private reasoning>",
+  "speech": "<what you say to your wolf partner(s)>",
+  "attack_candidates": {{"<player_name>": <0.0-1.0>, ...}},
+  "self_co_decision": {{
+    "claim_role": "<role_name or null>",
+    "timing": "next_day" | "wait"
+  }}
+}}
+- "thought" and "speech" must be written in {lang}
+- "attack_candidates" lists your preferred attack targets tonight (highest score = most preferred)
+- Use "speech" to discuss and negotiate fake-CO ideas with your wolf partner(s)
+- "self_co_decision" is your own final personal decision after this discussion, even if the wolves do not fully agree
+- If you decide to fake-CO on the next day, set "timing" to "next_day" and set "claim_role" to the role name you will claim (must be an English role name, e.g. "Seer", "Knight", "Villager", "Medium", "Madman" — never use a translated name)
+- If you decide to wait, set "timing" to "wait" and "claim_role" to null
+- The engine will use only "self_co_decision" to decide your next-day intended fake-CO
+- The JSON must contain exactly these four fields and nothing else.
+- Note: "attack_candidates" is the night-attack target field; the daytime speech schema uses a separate "vote_candidates" field.""")
+        return "\n".join(lines)
 
     def vote_strategy_prompt(self) -> str:
         return (

--- a/src/engine/phase_day.py
+++ b/src/engine/phase_day.py
@@ -10,6 +10,7 @@ from src.domain.roles import Medium, Werewolf
 from src.engine.phase import Phase
 from src.engine.victory import check_victory
 from src.engine.vote import tally_votes
+from src.llm.prompt import PublicContext
 
 if TYPE_CHECKING:
     from src.engine.game import GameEngine
@@ -53,16 +54,17 @@ def _run_vote(engine: GameEngine) -> str | None:
             ]
         calls.append((actor, wolf_partners))
 
+    ctx = PublicContext(
+        today_log=list(engine.today_log),
+        alive_players=alive_names,
+        dead_players=engine._dead_names(),
+        day=engine.day,
+        all_agents=list(engine.agents),
+        past_votes=engine._past_votes,
+        past_deaths=engine._past_deaths,
+    )
     votes: dict[str, str] = {}
-    for actor, vote_output in engine._llm_client.call_vote_parallel(
-        calls,
-        list(engine.today_log),
-        alive_names,
-        engine.day,
-        engine._past_votes,
-        engine._past_deaths,
-        engine.lang,
-    ):
+    for actor, vote_output in engine._llm_client.call_vote_parallel(calls, ctx, engine.lang):
         if vote_output.target in alive_names and vote_output.target != actor.name:
             target = vote_output.target
         else:

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -19,14 +19,11 @@ from src.domain.schema import (
 )
 from src.llm.discussion_tools import build_discussion_tools, parse_discussion_tool_result
 from src.llm.prompt import (
-    PastDeath,
-    PastVote,
     PublicContext,
     RoleSpecificContext,
     build_discussion_system_prompt,
     build_night_action_prompt,
     build_vote_prompt,
-    build_wolf_chat_prompt,
 )
 
 
@@ -181,25 +178,12 @@ class LLMClient:
     def call_vote(
         self,
         actor: Actor,
-        today_log: list[SpeechEntry],
-        alive_players: list[str],
-        day: int,
-        past_votes: list[PastVote] | None = None,
-        past_deaths: list[PastDeath] | None = None,
+        ctx: PublicContext,
         wolf_partners: list[str] | None = None,
         lang: str = "English",
     ) -> VoteOutput:
         """Call LLM for the dedicated VOTE-phase decision."""
-        prompt = build_vote_prompt(
-            actor,
-            today_log,
-            alive_players,
-            day,
-            past_votes,
-            past_deaths,
-            wolf_partners,
-            lang,
-        )
+        prompt = build_vote_prompt(actor, ctx, wolf_partners, lang)
         raw = ""
         try:
             message = self._client.messages.create(
@@ -216,11 +200,7 @@ class LLMClient:
     def call_vote_parallel(
         self,
         calls: list[tuple[Actor, list[str] | None]],
-        today_log: list[SpeechEntry],
-        alive_players: list[str],
-        day: int,
-        past_votes: list[PastVote] | None = None,
-        past_deaths: list[PastDeath] | None = None,
+        ctx: PublicContext,
         lang: str = "English",
     ) -> Iterator[tuple[Actor, VoteOutput]]:
         """Run VOTE-phase calls for all actors in parallel; yield in completion order.
@@ -231,17 +211,7 @@ class LLMClient:
         """
         with ThreadPoolExecutor() as executor:
             future_to_actor = {
-                executor.submit(
-                    self.call_vote,
-                    actor,
-                    today_log,
-                    alive_players,
-                    day,
-                    past_votes,
-                    past_deaths,
-                    wolf_partners,
-                    lang,
-                ): actor
+                executor.submit(self.call_vote, actor, ctx, wolf_partners, lang): actor
                 for actor, wolf_partners in calls
             }
             for future in as_completed(future_to_actor):
@@ -256,7 +226,9 @@ class LLMClient:
         lang: str = "English",
     ) -> WolfChatOutput:
         """Call LLM for werewolf team night chat and return structured WolfChatOutput."""
-        prompt = build_wolf_chat_prompt(actor, wolf_partners, alive_players, wolf_chat_log, lang)
+        prompt = actor.role.night_chat_prompt(actor, wolf_partners, alive_players, wolf_chat_log, lang)
+        if prompt is None:
+            raise RuntimeError(f"call_wolf_chat called on non-wolf role: {actor.role.name!r}")
         raw = ""
         try:
             message = self._client.messages.create(

--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -105,7 +105,10 @@ def build_role_prompt(role: Role, wolf_partners: list[str] | None = None) -> str
     return role.role_prompt(wolf_partners)
 
 
-def build_public_info_prompt(ctx: PublicContext) -> str:
+def build_public_info_prompt(
+    ctx: PublicContext,
+    today_log_header: str = "Today's discussion so far:",
+) -> str:
     """Build prompt section with public game information."""
     lines = [f"\n--- PUBLIC INFORMATION (Day {ctx.day}) ---"]
 
@@ -141,7 +144,7 @@ def build_public_info_prompt(ctx: PublicContext) -> str:
             lines.append(f"Known role claims: {', '.join(claims)}")
 
     if ctx.today_log:
-        lines.append("\nToday's discussion so far:")
+        lines.append(f"\n{today_log_header}")
         for entry in ctx.today_log:
             lines.append(f"  [{entry.speech_id}] {entry.agent}: {entry.text}")
     else:
@@ -215,24 +218,19 @@ def build_discussion_system_prompt(
 
 def build_vote_prompt(
     actor: Actor,
-    today_log: list[SpeechEntry],
-    alive_players: list[str],
-    day: int,
-    past_votes: list[PastVote] | None = None,
-    past_deaths: list[PastDeath] | None = None,
+    ctx: PublicContext,
     wolf_partners: list[str] | None = None,
     lang: str = "English",
 ) -> str:
     """Build the dedicated VOTE-phase prompt.
 
-    Independent from build_system_prompt: the vote decision needs the full
-    day discussion + history + the speaker's own vote_candidates hint, not
-    the full speech-context (persona color, CO direction, etc.).
+    Independent from build_discussion_system_prompt: the vote decision needs
+    the full day discussion + history, not the speech-context (persona, CO direction, etc.).
+    Delegates past_deaths/past_votes rendering to build_public_info_prompt.
     """
-    candidates = [p for p in alive_players if p != actor.name]
+    candidates = [p for p in ctx.alive_players if p != actor.name]
     lines = [
-        f"You are {actor.name} ({actor.role.name}) in a Werewolf game. Day {day}.",
-        f"Alive players: {', '.join(alive_players)}",
+        f"You are {actor.name} ({actor.role.name}) in a Werewolf game. Day {ctx.day}.",
         f"You must vote for one of: {', '.join(candidates)} (cannot vote for yourself).",
     ]
 
@@ -243,30 +241,13 @@ def build_vote_prompt(
     if actor.state.memory_summary:
         lines.append(f"\nYour memory: {'; '.join(actor.state.memory_summary)}")
 
-    if past_deaths:
-        lines.append("\nPast deaths:")
-        for d in past_deaths:
-            cause = "executed" if d["cause"] == "execution" else "killed by werewolves"
-            lines.append(f"  Day {d['day']}: {d['name']} was {cause}")
-
-    if past_votes:
-        lines.append("\nPast votes:")
-        for v in past_votes:
-            vote_str = ", ".join(f"{voter}→{target}" for voter, target in v["votes"].items())
-            lines.append(f"  Day {v['day']}: {vote_str}")
-
-    if today_log:
-        lines.append("\nToday's full discussion:")
-        for entry in today_log:
-            lines.append(f"  [{entry.speech_id}] {entry.agent}: {entry.text}")
-    else:
-        lines.append("\nNo discussion yet today.")
+    lines.append(build_public_info_prompt(ctx, today_log_header="Today's full discussion:"))
 
     if actor.state.beliefs:
         suspicion_str = ", ".join(
             f"{name}={b.suspicion:.2f}"
             for name, b in actor.state.beliefs.items()
-            if name in alive_players
+            if name in ctx.alive_players
         )
         if suspicion_str:
             lines.append(
@@ -292,61 +273,6 @@ Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
         lines.append('- "strategy" must be exactly "village_side" or "wolf_side" (always English, see VOTE STRATEGY above)')
     else:
         lines.append('- "strategy" must be null (only Werewolves use this field)')
-    return "\n".join(lines)
-
-
-def build_wolf_chat_prompt(
-    actor: Actor,
-    wolf_partners: list[str],
-    alive_players: list[str],
-    wolf_chat_log: list[SpeechEntry],
-    lang: str = "English",
-) -> str:
-    """Build prompt for werewolf team night chat (secret coordination before attack)."""
-    target_candidates = ", ".join(
-        p for p in alive_players if p != actor.name and p not in wolf_partners
-    )
-    lines = [
-        f"You are {actor.name}, a Werewolf in a social deduction game.",
-        f"Your wolf partners tonight: {', '.join(wolf_partners)}.",
-        f"Alive players (potential targets): {target_candidates}.",
-        "",
-        "It is night. You are meeting secretly with your wolf partner(s) to coordinate.",
-        "Your goal is not just to make an individual decision, but to reach a shared plan with your wolf partner(s).",
-        "Discuss who to attack tonight, react to what your partner says, and try to move the conversation toward agreement.",
-        "Also coordinate your deception plan for the next day: who should fake-CO, which role each wolf should claim, and whether anyone should wait instead.",
-        "You are allowed to decide that both wolves fake-CO, only one does, both wait, or even claim the same role if that fits your strategy.",
-    ]
-    if actor.state.threat_scores:
-        lines.append("\nYour current threat assessments (0.0=safe to ignore, 1.0=must eliminate soon):")
-        lines.append("Use these to prioritize tonight's attack target.")
-        for name, score in actor.state.threat_scores.items():
-            lines.append(f"  {name}: threat={score:.2f}")
-    if wolf_chat_log:
-        lines.append("\nWolf team conversation so far:")
-        for entry in wolf_chat_log:
-            lines.append(f"  {entry.agent}: {entry.text}")
-    lines.append(f"""
---- OUTPUT FORMAT ---
-Respond with ONLY valid JSON. No extra fields, no explanation, no other text.
-{{
-  "thought": "<your private reasoning>",
-  "speech": "<what you say to your wolf partner(s)>",
-  "attack_candidates": {{"<player_name>": <0.0-1.0>, ...}},
-  "self_co_decision": {{
-    "claim_role": "<role_name or null>",
-    "timing": "next_day" | "wait"
-  }}
-}}
-- "thought" and "speech" must be written in {lang}
-- "attack_candidates" lists your preferred attack targets tonight (highest score = most preferred)
-- Use "speech" to discuss and negotiate fake-CO ideas with your wolf partner(s)
-- "self_co_decision" is your own final personal decision after this discussion, even if the wolves do not fully agree
-- If you decide to fake-CO on the next day, set "timing" to "next_day" and set "claim_role" to the role name you will claim (must be an English role name, e.g. "Seer", "Knight", "Villager", "Medium", "Madman" — never use a translated name)
-- If you decide to wait, set "timing" to "wait" and "claim_role" to null
-- The engine will use only "self_co_decision" to decide your next-day intended fake-CO
-- The JSON must contain exactly these four fields and nothing else.
-- Note: "attack_candidates" is the night-attack target field; the daytime speech schema uses a separate "vote_candidates" field.""")
     return "\n".join(lines)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,12 +114,12 @@ def make_vote_parallel_side_effect(
     reasonings = reasonings or {}
     strategies = strategies or {}
 
-    def _side_effect(calls, today_log, alive_players, day, *args, **kwargs):
+    def _side_effect(calls, ctx, *args, **kwargs):
         results = []
         for actor, _wolf_partners in calls:
             target = targets.get(actor.name)
             if target is None:
-                others = [n for n in alive_players if n != actor.name]
+                others = [n for n in ctx.alive_players if n != actor.name]
                 target = others[0] if others else ""
             results.append((
                 actor,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -148,6 +148,35 @@ class TestCallWolfChat:
         assert result.self_co_decision.timing == "wait"
         assert result.self_co_decision.claim_role is None
 
+    def test_raises_when_night_chat_prompt_is_none(self, make_test_actor):
+        """
+        SUT: LLMClient.call_wolf_chat
+        Mock: actor.role.night_chat_prompt を None 返却にモック
+        Level: unit
+        Objective: role.night_chat_prompt() が None を返したとき RuntimeError が送出されること（非狼役職への誤呼び出し検知）。
+        """
+        from unittest.mock import patch
+        import pytest
+        actor = make_test_actor("Alice", "Villager")
+        llm = make_failing_llm_client()
+        with patch.object(actor.role, "night_chat_prompt", return_value=None):
+            with pytest.raises(RuntimeError, match="non-wolf role"):
+                llm.call_wolf_chat(actor, [], ["Alice", "Bob"], [])
+
+    def test_delegates_to_role_night_chat_prompt(self, make_test_actor):
+        """
+        SUT: LLMClient.call_wolf_chat
+        Mock: anthropic SDK、actor.role.night_chat_prompt をスパイ
+        Level: unit
+        Objective: call_wolf_chat が actor.role.night_chat_prompt() に委譲してプロンプトを構築すること。
+        """
+        from unittest.mock import patch
+        actor = make_test_actor("Wolf", "Werewolf")
+        llm = make_llm_client_with_response(WOLF_CHAT_OUTPUT_JSON)
+        with patch.object(actor.role, "night_chat_prompt", wraps=actor.role.night_chat_prompt) as spy:
+            llm.call_wolf_chat(actor, ["OtherWolf"], ["Alice", "Wolf", "OtherWolf"], [])
+            spy.assert_called_once()
+
 
 class TestCallVote:
     def test_returns_vote_output(self, make_test_actor):
@@ -157,14 +186,11 @@ class TestCallVote:
         Level: unit
         Objective: VOTE プロンプトの応答が VoteOutput としてパースされること。
         """
+        from src.llm.prompt import PublicContext
         actor = make_test_actor("Alice", "Villager")
         llm = make_llm_client_with_response(VOTE_OUTPUT_JSON)
-        result = llm.call_vote(
-            actor,
-            today_log=[],
-            alive_players=["Alice", "Bob"],
-            day=1,
-        )
+        ctx = PublicContext(today_log=[], alive_players=["Alice", "Bob"], dead_players=[], day=1)
+        result = llm.call_vote(actor, ctx=ctx)
         assert isinstance(result, VoteOutput)
         assert result.target == "Alice"
         assert result.reasoning == "Her speech contradicts the seer claim."
@@ -177,15 +203,11 @@ class TestCallVote:
         Level: unit
         Objective: 狼が strategy フィールド付きで返したとき VoteOutput.strategy として保持されること。
         """
+        from src.llm.prompt import PublicContext
         actor = make_test_actor("Wolf", "Werewolf")
         llm = make_llm_client_with_response(VOTE_OUTPUT_WOLF_JSON)
-        result = llm.call_vote(
-            actor,
-            today_log=[],
-            alive_players=["Wolf", "Seer1"],
-            day=1,
-            wolf_partners=[],
-        )
+        ctx = PublicContext(today_log=[], alive_players=["Wolf", "Seer1"], dead_players=[], day=1)
+        result = llm.call_vote(actor, ctx=ctx, wolf_partners=[])
         assert result.strategy == "wolf_side"
         assert result.target == "Seer1"
 
@@ -196,14 +218,11 @@ class TestCallVote:
         Level: unit
         Objective: API 失敗時に target="" の VoteOutput が返ること（_run_vote 側でフォールバック処理）。
         """
+        from src.llm.prompt import PublicContext
         actor = make_test_actor("Alice", "Villager")
         llm = make_failing_llm_client()
-        result = llm.call_vote(
-            actor,
-            today_log=[],
-            alive_players=["Alice", "Bob"],
-            day=1,
-        )
+        ctx = PublicContext(today_log=[], alive_players=["Alice", "Bob"], dead_players=[], day=1)
+        result = llm.call_vote(actor, ctx=ctx)
         assert result.target == ""
         assert result.strategy is None
 

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -1,8 +1,9 @@
 import pytest
 
 from src.domain.actor import Belief
-from src.llm.prompt import build_personal_info_prompt, build_role_prompt, build_wolf_chat_prompt
 from src.domain.roles import get_role
+from src.domain.roles.werewolf import Werewolf
+from src.llm.prompt import build_personal_info_prompt, build_public_info_prompt, build_role_prompt, PublicContext
 
 
 def test_build_role_prompt_wolf_partners_non_none_for_non_werewolf_raises():
@@ -75,31 +76,112 @@ def test_personal_info_prompt_omits_suspicion_section_when_no_beliefs(make_test_
     assert "suspicion levels" not in prompt
 
 
-def test_wolf_chat_prompt_shows_threat_scores_when_present(make_test_actor):
+def test_build_public_info_prompt_custom_today_log_header(make_test_actor):
     """
-    SUT: build_wolf_chat_prompt()
+    SUT: build_public_info_prompt
     Mock: なし
     Level: unit
-    Objective: actor.state.threat_scores が非空のとき脅威スコアとガイダンスがプロンプトに含まれること。
+    Objective: today_log_header 引数を渡すと今日の議論セクションの見出しが置き換わること。
     """
-    actor = make_test_actor("Wolf", "Werewolf")
-    actor.state.threat_scores = {"Seer": 0.9, "Knight": 0.6}
-    prompt = build_wolf_chat_prompt(actor, [], ["Seer", "Knight", "Villager"], [])
-    assert "threat" in prompt.lower()
-    assert "Seer" in prompt
-    assert "0.90" in prompt
-    assert "Knight" in prompt
-    assert "0.60" in prompt
+    from src.domain.schema import SpeechEntry
+    entry = SpeechEntry(speech_id=1, agent="Alice", text="hello")
+    ctx = PublicContext(
+        today_log=[entry],
+        alive_players=["Alice", "Bob"],
+        dead_players=[],
+        day=1,
+    )
+    prompt = build_public_info_prompt(ctx, today_log_header="Today's full discussion:")
+    assert "Today's full discussion:" in prompt
+    assert "Today's discussion so far:" not in prompt
 
 
-def test_wolf_chat_prompt_omits_threat_section_when_empty(make_test_actor):
+def test_build_public_info_prompt_default_header(make_test_actor):
     """
-    SUT: build_wolf_chat_prompt()
+    SUT: build_public_info_prompt
     Mock: なし
     Level: unit
-    Objective: actor.state.threat_scores が空のとき脅威スコアセクションが含まれないこと。
+    Objective: today_log_header を省略したときデフォルト見出しが使われること。
     """
-    actor = make_test_actor("Wolf", "Werewolf")
-    actor.state.threat_scores = {}
-    prompt = build_wolf_chat_prompt(actor, [], ["Alice", "Bob"], [])
-    assert "threat assessments" not in prompt
+    from src.domain.schema import SpeechEntry
+    entry = SpeechEntry(speech_id=1, agent="Alice", text="hello")
+    ctx = PublicContext(
+        today_log=[entry],
+        alive_players=["Alice", "Bob"],
+        dead_players=[],
+        day=1,
+    )
+    prompt = build_public_info_prompt(ctx)
+    assert "Today's discussion so far:" in prompt
+
+
+class TestRoleNightChatPrompt:
+    def test_non_werewolf_role_returns_none(self, make_test_actor):
+        """
+        SUT: Role.night_chat_prompt
+        Mock: なし
+        Level: unit
+        Objective: 非狼役職の night_chat_prompt() は None を返すこと。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        for role_name in ("Villager", "Seer", "Knight", "Medium", "Madman"):
+            role = get_role(role_name)
+            assert role.night_chat_prompt(actor, [], [], []) is None, f"{role_name} should return None"
+
+    def test_werewolf_night_chat_prompt_returns_string(self, make_test_actor):
+        """
+        SUT: Werewolf.night_chat_prompt
+        Mock: なし
+        Level: unit
+        Objective: Werewolf.night_chat_prompt() が文字列を返すこと。
+        """
+        actor = make_test_actor("Wolf", "Werewolf")
+        role = Werewolf()
+        result = role.night_chat_prompt(actor, [], ["Alice", "Bob"], [])
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_werewolf_night_chat_prompt_shows_threat_scores_when_present(self, make_test_actor):
+        """
+        SUT: Werewolf.night_chat_prompt
+        Mock: なし
+        Level: unit
+        Objective: actor.state.threat_scores が非空のとき脅威スコアとガイダンスがプロンプトに含まれること。
+        """
+        actor = make_test_actor("Wolf", "Werewolf")
+        actor.state.threat_scores = {"Seer": 0.9, "Knight": 0.6}
+        role = Werewolf()
+        prompt = role.night_chat_prompt(actor, [], ["Seer", "Knight", "Villager"], [])
+        assert "threat" in prompt.lower()
+        assert "Seer" in prompt
+        assert "0.90" in prompt
+        assert "Knight" in prompt
+        assert "0.60" in prompt
+
+    def test_werewolf_night_chat_prompt_omits_threat_section_when_empty(self, make_test_actor):
+        """
+        SUT: Werewolf.night_chat_prompt
+        Mock: なし
+        Level: unit
+        Objective: actor.state.threat_scores が空のとき脅威スコアセクションが含まれないこと。
+        """
+        actor = make_test_actor("Wolf", "Werewolf")
+        actor.state.threat_scores = {}
+        role = Werewolf()
+        prompt = role.night_chat_prompt(actor, [], ["Alice", "Bob"], [])
+        assert "threat assessments" not in prompt
+
+    def test_werewolf_night_chat_prompt_includes_wolf_chat_log(self, make_test_actor):
+        """
+        SUT: Werewolf.night_chat_prompt
+        Mock: なし
+        Level: unit
+        Objective: wolf_chat_log が非空のときその発言内容がプロンプトに含まれること。
+        """
+        from src.domain.schema import SpeechEntry
+        actor = make_test_actor("Wolf", "Werewolf")
+        log = [SpeechEntry(speech_id=1, agent="Wolf", text="Let's attack Alice.")]
+        role = Werewolf()
+        prompt = role.night_chat_prompt(actor, ["OtherWolf"], ["Alice", "Wolf", "OtherWolf"], log)
+        assert "Wolf team conversation so far" in prompt
+        assert "Let's attack Alice." in prompt

--- a/tests/unit/test_vote_prompt.py
+++ b/tests/unit/test_vote_prompt.py
@@ -1,11 +1,31 @@
-"""build_vote_prompt のプロンプト組立テスト（Issue #216）。"""
+"""build_vote_prompt のプロンプト組立テスト（Issue #283）。"""
 from src.domain.actor import Belief
 from src.domain.schema import SpeechEntry
-from src.llm.prompt import build_vote_prompt
+from src.llm.prompt import PublicContext, build_vote_prompt
 
 
 def _log(*texts: str) -> list[SpeechEntry]:
     return [SpeechEntry(speech_id=i + 1, agent=f"A{i}", text=t) for i, t in enumerate(texts)]
+
+
+def _ctx(
+    today_log=None,
+    alive_players=None,
+    dead_players=None,
+    day=1,
+    past_votes=None,
+    past_deaths=None,
+    all_agents=None,
+) -> PublicContext:
+    return PublicContext(
+        today_log=today_log or [],
+        alive_players=alive_players or [],
+        dead_players=dead_players or [],
+        day=day,
+        past_votes=past_votes,
+        past_deaths=past_deaths,
+        all_agents=all_agents,
+    )
 
 
 class TestBuildVotePrompt:
@@ -19,9 +39,7 @@ class TestBuildVotePrompt:
         actor = make_test_actor("Alice", "Villager")
         prompt = build_vote_prompt(
             actor,
-            today_log=[],
-            alive_players=["Alice", "Bob", "Carol"],
-            day=1,
+            ctx=_ctx(alive_players=["Alice", "Bob", "Carol"]),
         )
         assert "must vote for one of: Bob, Carol" in prompt
 
@@ -35,9 +53,7 @@ class TestBuildVotePrompt:
         actor = make_test_actor("Alice", "Villager")
         prompt = build_vote_prompt(
             actor,
-            today_log=_log("hello", "I suspect Bob"),
-            alive_players=["Alice", "Bob"],
-            day=1,
+            ctx=_ctx(today_log=_log("hello", "I suspect Bob"), alive_players=["Alice", "Bob"]),
         )
         assert "Today's full discussion" in prompt
         assert "[1] A0: hello" in prompt
@@ -57,9 +73,7 @@ class TestBuildVotePrompt:
         }
         prompt = build_vote_prompt(
             actor,
-            today_log=[],
-            alive_players=["Alice", "Bob", "Carol"],
-            day=1,
+            ctx=_ctx(alive_players=["Alice", "Bob", "Carol"]),
         )
         assert "suspicion" in prompt
         assert "Bob=0.74" in prompt
@@ -76,9 +90,7 @@ class TestBuildVotePrompt:
         actor.state.beliefs = {}
         prompt = build_vote_prompt(
             actor,
-            today_log=[],
-            alive_players=["Alice", "Bob"],
-            day=1,
+            ctx=_ctx(alive_players=["Alice", "Bob"]),
         )
         assert "suspicion scores" not in prompt
 
@@ -92,11 +104,12 @@ class TestBuildVotePrompt:
         actor = make_test_actor("Alice", "Villager")
         prompt = build_vote_prompt(
             actor,
-            today_log=[],
-            alive_players=["Alice", "Bob"],
-            day=2,
-            past_votes=[{"day": 1, "votes": {"Alice": "Bob", "Bob": "Carol"}}],
-            past_deaths=[{"day": 1, "name": "Carol", "cause": "execution"}],
+            ctx=_ctx(
+                alive_players=["Alice", "Bob"],
+                day=2,
+                past_votes=[{"day": 1, "votes": {"Alice": "Bob", "Bob": "Carol"}}],
+                past_deaths=[{"day": 1, "name": "Carol", "cause": "execution"}],
+            ),
         )
         assert "Past votes" in prompt
         assert "Alice→Bob" in prompt
@@ -113,9 +126,7 @@ class TestBuildVotePrompt:
         actor = make_test_actor("Alice", "Villager")
         prompt = build_vote_prompt(
             actor,
-            today_log=[],
-            alive_players=["Alice", "Bob"],
-            day=1,
+            ctx=_ctx(alive_players=["Alice", "Bob"]),
         )
         assert "VOTE STRATEGY" not in prompt
         assert "must be null" in prompt
@@ -130,9 +141,7 @@ class TestBuildVotePrompt:
         actor = make_test_actor("Wolf1", "Werewolf")
         prompt = build_vote_prompt(
             actor,
-            today_log=[],
-            alive_players=["Wolf1", "Wolf2", "Seer1"],
-            day=1,
+            ctx=_ctx(alive_players=["Wolf1", "Wolf2", "Seer1"]),
             wolf_partners=["Wolf2"],
         )
         assert "VOTE STRATEGY" in prompt
@@ -151,9 +160,7 @@ class TestBuildVotePrompt:
         actor.state.memory_summary = ["Bob changed vote on Day1", "Carol stayed silent"]
         prompt = build_vote_prompt(
             actor,
-            today_log=[],
-            alive_players=["Alice", "Bob", "Carol"],
-            day=2,
+            ctx=_ctx(alive_players=["Alice", "Bob", "Carol"], day=2),
         )
         assert "Bob changed vote on Day1" in prompt
         assert "Carol stayed silent" in prompt
@@ -168,9 +175,43 @@ class TestBuildVotePrompt:
         actor = make_test_actor("Wolf1", "Werewolf")
         prompt = build_vote_prompt(
             actor,
-            today_log=[],
-            alive_players=["Wolf1", "Seer1"],
-            day=2,
+            ctx=_ctx(alive_players=["Wolf1", "Seer1"], day=2),
             wolf_partners=[],
         )
         assert "last wolf" in prompt
+
+    def test_includes_known_role_claims_from_all_agents(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: all_agents に claimed_role があるとき Known role claims が VOTE プロンプトに含まれること。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        seer = make_test_actor("Bob", "Seer")
+        from src.domain.roles import get_role
+        seer.state.claimed_role = get_role("Seer")
+        prompt = build_vote_prompt(
+            actor,
+            ctx=_ctx(
+                alive_players=["Alice", "Bob"],
+                all_agents=[actor, seer],
+            ),
+        )
+        assert "Known role claims" in prompt
+        assert "Bob claims Seer" in prompt
+
+    def test_public_info_header_uses_full_discussion_label(self, make_test_actor):
+        """
+        SUT: build_vote_prompt
+        Mock: なし
+        Level: unit
+        Objective: VOTE プロンプトの今日の議論セクション見出しが "Today's full discussion" であること。
+        """
+        actor = make_test_actor("Alice", "Villager")
+        prompt = build_vote_prompt(
+            actor,
+            ctx=_ctx(today_log=_log("hello"), alive_players=["Alice", "Bob"]),
+        )
+        assert "Today's full discussion" in prompt
+        assert "Today's discussion so far" not in prompt


### PR DESCRIPTION
## Summary
- `build_vote_prompt` のシグネチャを個別引数から `PublicContext` に統一し、`past_deaths`/`past_votes` の重複レンダリングを `build_public_info_prompt` に一本化
- `build_public_info_prompt` に `today_log_header` 引数を追加し、VOTE フェーズでは `"Today's full discussion:"` を使用
- `build_wolf_chat_prompt` を `prompt.py` から削除し、`Role.night_chat_prompt()` / `Werewolf.night_chat_prompt()` に移動（Strategy パターンで統一）
- `call_wolf_chat` が `actor.role.night_chat_prompt()` に委譲するよう変更。非狼役職への誤呼び出しは `RuntimeError` で即検知
- VOTE プロンプトに `Known role claims` と `Role distribution` が含まれるようになった（情報量の向上）

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（326テスト）
- [ ] `build_vote_prompt` が `PublicContext` を受け取ること
- [ ] `build_public_info_prompt` の `today_log_header` が VOTE / DISCUSSION で使い分けられること
- [ ] 非狼役職の `night_chat_prompt()` が `None` を返すこと
- [ ] `Werewolf.night_chat_prompt()` が狼チャットプロンプトを返すこと
- [ ] `call_wolf_chat` が非狼役職で呼ばれたとき `RuntimeError` が送出されること

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)