### PR TITLE
feat: allow wolf to re-CO even after claimed_role is set

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -15,7 +15,6 @@
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
-| yukkie/AgentVillage#274 | enhancement | 🟡 | - | Allow wolf to re-CO even after claimed_role is set | claimed_role 設定済みでも intended_co による再COを許可し、中盤での役職偽装切り替え戦略を可能にする |
 | yukkie/AgentVillage#266 | tech-debt | 🟡 | - | Replace intended_co flag with a typed scheduled-event model | intended_co をフラグから timing 付きスケジュール済みイベント型に置き換え、ライフサイクルを型で表現する |
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -71,11 +71,6 @@ def _apply_wolf_self_decisions(
         output = last_wolf_outputs.get(wolf.name)
         self_decision = output.self_co_decision if output is not None else None
 
-        if wolf.state.claimed_role is not None:
-            wolf.state.intended_co = None
-            store.save(wolf)
-            continue
-
         if (
             self_decision is not None
             and self_decision.timing == "next_day"

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -131,7 +131,7 @@ class LLMClient:
         role_ctx: RoleSpecificContext | None = None,
     ) -> DiscussionResult:
         """Call LLM for a DISCUSSION turn using tool use; return one DiscussionResult."""
-        co_eligible = actor.state.claimed_role is None and actor.role.can_co
+        co_eligible = actor.role.can_co
         system_prompt = build_discussion_system_prompt(actor, ctx, co_eligible, lang, role_ctx)
         tools = build_discussion_tools(co_eligible)
         try:

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -511,6 +511,34 @@ class TestApplyWolfSelfDecisions:
 
         assert any("Wolf1" in r.message for r in caplog.records)
 
+    def test_reco_allowed_when_claimed_role_already_set(self, make_test_actor, make_test_engine):
+        """
+        SUT: _apply_wolf_self_decisions
+        Mock: store.save — ファイルI/Oを回避
+        Level: unit
+        Objective: claimed_role が既にセットされた狼が timing=next_day で claim_role を指定したとき
+                   intended_co に新しい役職がセットされること（re-CO が許可されること）。
+        """
+        from src.domain.roles import Seer
+        from unittest.mock import patch
+
+        wolf = make_test_actor("Wolf1", "Werewolf")
+        wolf.state.claimed_role = Seer()
+        engine, _ = make_test_engine([wolf])
+
+        output = WolfChatOutput(
+            thought="t",
+            speech="s",
+            attack_candidates={},
+            self_co_decision=WolfSelfCoDecision(claim_role=Seer(), timing="next_day"),
+        )
+
+        with patch("src.engine.phase_night.store.save"):
+            _apply_wolf_self_decisions(engine, [wolf], {"Wolf1": output})
+
+        assert wolf.state.intended_co is not None
+        assert wolf.state.intended_co.name == "Seer"
+
 
 class TestResolveDeclaredInspection:
     def test_reasoning_is_preserved_after_target_resolution(self, make_test_actor, make_test_engine):


### PR DESCRIPTION
## Summary
- `_apply_wolf_self_decisions` の `claimed_role is not None` 早期リターンガードを削除し、既にCO済みの狼でも re-CO を許可
- `call_discussion` の `co_eligible` 判定を `claimed_role is None and role.can_co` → `role.can_co` に緩和

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `test_reco_allowed_when_claimed_role_already_set`: claimed_role 設定済みの狼が re-CO できることを確認

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)