### PR TITLE
feat: add prompt caching and LLM usage logging (#243)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -14,7 +14,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
-| yukkie/AgentVillage#243 | enhancement | 🔴 | 3 | Add prompt cache control to reduce API cost and latency | 固定文字列比率を調査のうえ cache_control を付与しコスト・遅延を削減 |
 | yukkie/AgentVillage#266 | tech-debt | 🟡 | - | Replace intended_co flag with a typed scheduled-event model | intended_co をフラグから timing 付きスケジュール済みイベント型に置き換え、ライフサイクルを型で表現する |
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |
 | yukkie/AgentVillage#23 | enhancement | 🟡 | 3 | Auto-summarize memory_summary | 記憶が長くなったら LLM で自動要約 |

--- a/main.py
+++ b/main.py
@@ -9,8 +9,10 @@ Usage:
     uv run main.py --spectator --lang Japanese --players 7
     uv run main.py --replay                  # Replay mode (public)
     uv run main.py --replay --spectator      # Replay mode (spectator)
+    uv run main.py --verbose                 # Show LLM usage logs (DEBUG)
 """
 import argparse
+import logging
 import os
 import sys
 
@@ -51,7 +53,15 @@ def main() -> None:
         action="store_true",
         help="Replay a past game from state_archive/ (no LLM calls)",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG logging (shows LLM usage stats per API call)",
+    )
     args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
     spectator_mode: bool = args.spectator
 

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ Usage:
     uv run main.py --spectator --lang Japanese --players 7
     uv run main.py --replay                  # Replay mode (public)
     uv run main.py --replay --spectator      # Replay mode (spectator)
-    uv run main.py --verbose                 # Show LLM usage logs (DEBUG)
+    uv run main.py --info                    # Show LLM usage logs (INFO)
 """
 import argparse
 import logging
@@ -54,14 +54,14 @@ def main() -> None:
         help="Replay a past game from state_archive/ (no LLM calls)",
     )
     parser.add_argument(
-        "--verbose",
+        "--info",
         action="store_true",
-        help="Enable DEBUG logging (shows LLM usage stats per API call)",
+        help="Enable INFO logging (shows LLM usage stats per API call)",
     )
     args = parser.parse_args()
 
-    if args.verbose:
-        logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+    if args.info:
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     spectator_mode: bool = args.spectator
 

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -151,7 +151,7 @@ class LLMClient:
                 ],
             )
             u = message.usage
-            self._logger.debug("[LLM %s cached] input=%d hit=%d create=%d output=%d",
+            self._logger.info("[LLM %s cached] input=%d hit=%d create=%d output=%d",
                 actor.name, u.input_tokens, u.cache_read_input_tokens or 0,
                 u.cache_creation_input_tokens or 0, u.output_tokens)
             return parse_discussion_tool_result(message, actor.name, message.model_dump_json())
@@ -199,7 +199,7 @@ class LLMClient:
             )
             raw = message.content[0].text
             u = message.usage
-            self._logger.debug("[LLM %s no-cache] input=%d hit=%d create=%d output=%d",
+            self._logger.info("[LLM %s no-cache] input=%d hit=%d create=%d output=%d",
                 actor.name, u.input_tokens, u.cache_read_input_tokens or 0,
                 u.cache_creation_input_tokens or 0, u.output_tokens)
             return VoteOutput.model_validate_json(_extract_json(raw))
@@ -248,7 +248,7 @@ class LLMClient:
             )
             raw = message.content[0].text
             u = message.usage
-            self._logger.debug("[LLM %s no-cache] input=%d hit=%d create=%d output=%d",
+            self._logger.info("[LLM %s no-cache] input=%d hit=%d create=%d output=%d",
                 actor.name, u.input_tokens, u.cache_read_input_tokens or 0,
                 u.cache_creation_input_tokens or 0, u.output_tokens)
             return WolfChatOutput.model_validate_json(_extract_json(raw))
@@ -282,7 +282,7 @@ class LLMClient:
             )
             raw = message.content[0].text.strip()
             u = message.usage
-            self._logger.debug("[LLM %s no-cache] input=%d hit=%d create=%d output=%d",
+            self._logger.info("[LLM %s no-cache] input=%d hit=%d create=%d output=%d",
                 actor.name, u.input_tokens, u.cache_read_input_tokens or 0,
                 u.cache_creation_input_tokens or 0, u.output_tokens)
             parsed = NightActionOutput.model_validate_json(_extract_json(raw))

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import re
 import sys
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -90,7 +92,6 @@ def _extract_json(text: str) -> str:
        false matches on set-notation like {SQ, Jonas, Lumi} in prose.
     2. Fall back to bracket counting when no fence is present.
     """
-    import re
     m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
     if m:
         return m.group(1)
@@ -122,6 +123,7 @@ class LLMClient:
 
     def __init__(self, client: anthropic.Anthropic) -> None:
         self._client = client
+        self._logger = logging.getLogger(__name__)
 
     def call_discussion(
         self,
@@ -138,7 +140,7 @@ class LLMClient:
             message = self._client.messages.create(
                 model=actor.model,
                 max_tokens=MAX_TOKENS["call_discussion"],
-                system=system_prompt,
+                system=[{"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}],
                 tools=tools,
                 tool_choice={"type": "any"},
                 messages=[
@@ -148,6 +150,10 @@ class LLMClient:
                     }
                 ],
             )
+            u = message.usage
+            self._logger.debug("[LLM %s cached] input=%d hit=%d create=%d output=%d",
+                actor.name, u.input_tokens, u.cache_read_input_tokens or 0,
+                u.cache_creation_input_tokens or 0, u.output_tokens)
             return parse_discussion_tool_result(message, actor.name, message.model_dump_json())
         except Exception as e:
             _classify_and_log_error("call_discussion", actor.name, e, "")
@@ -192,6 +198,10 @@ class LLMClient:
                 messages=[{"role": "user", "content": prompt}],
             )
             raw = message.content[0].text
+            u = message.usage
+            self._logger.debug("[LLM %s no-cache] input=%d hit=%d create=%d output=%d",
+                actor.name, u.input_tokens, u.cache_read_input_tokens or 0,
+                u.cache_creation_input_tokens or 0, u.output_tokens)
             return VoteOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
             _classify_and_log_error("call_vote", actor.name, e, raw)
@@ -237,6 +247,10 @@ class LLMClient:
                 messages=[{"role": "user", "content": prompt}],
             )
             raw = message.content[0].text
+            u = message.usage
+            self._logger.debug("[LLM %s no-cache] input=%d hit=%d create=%d output=%d",
+                actor.name, u.input_tokens, u.cache_read_input_tokens or 0,
+                u.cache_creation_input_tokens or 0, u.output_tokens)
             return WolfChatOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
             _classify_and_log_error("call_wolf_chat", actor.name, e, raw)
@@ -267,6 +281,10 @@ class LLMClient:
                 ],
             )
             raw = message.content[0].text.strip()
+            u = message.usage
+            self._logger.debug("[LLM %s no-cache] input=%d hit=%d create=%d output=%d",
+                actor.name, u.input_tokens, u.cache_read_input_tokens or 0,
+                u.cache_creation_input_tokens or 0, u.output_tokens)
             parsed = NightActionOutput.model_validate_json(_extract_json(raw))
         except Exception as e:
             _classify_and_log_error("call_night_action", actor.name, e, raw)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,10 +74,26 @@ def make_test_engine():
 # ── Shared Mock Builders for LLM Client ──────────────────────────────────
 
 
+def make_usage_mock(
+    input_tokens: int = 100,
+    cache_read_input_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+    output_tokens: int = 50,
+) -> MagicMock:
+    """Build a MagicMock simulating anthropic.types.Usage."""
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.cache_read_input_tokens = cache_read_input_tokens
+    usage.cache_creation_input_tokens = cache_creation_input_tokens
+    usage.output_tokens = output_tokens
+    return usage
+
+
 def make_llm_client_with_response(response_text: str) -> LLMClient:
     """Build LLMClient mock that returns a specific response."""
     msg = MagicMock()
     msg.content = [MagicMock(text=response_text)]
+    msg.usage = make_usage_mock()
     anthropic_client = MagicMock(spec=anthropic.Anthropic)
     anthropic_client.messages.create.return_value = msg
     return LLMClient(anthropic_client)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -130,10 +130,10 @@ class TestCallDiscussion:
         llm = _make_discussion_llm_client("speak", {"thought": "t", "speech": "Hi!"})
         from src.llm.prompt import PublicContext
         ctx = PublicContext(alive_players=["Alice", "Bob"], dead_players=[], day=1, today_log=[])
-        with patch.object(llm._logger, "debug") as mock_debug:
+        with patch.object(llm._logger, "info") as mock_info:
             llm.call_discussion(actor, ctx)
-        mock_debug.assert_called_once()
-        assert "cached" in mock_debug.call_args.args[0]
+        mock_info.assert_called_once()
+        assert "cached" in mock_info.call_args.args[0]
 
 
 class TestCallWolfChat:
@@ -257,10 +257,10 @@ class TestCallVote:
         actor = make_test_actor("Alice", "Villager")
         llm = make_llm_client_with_response(VOTE_OUTPUT_JSON)
         ctx = PublicContext(today_log=[], alive_players=["Alice", "Bob"], dead_players=[], day=1)
-        with patch.object(llm._logger, "debug") as mock_debug:
+        with patch.object(llm._logger, "info") as mock_info:
             llm.call_vote(actor, ctx=ctx)
-        mock_debug.assert_called_once()
-        assert "no-cache" in mock_debug.call_args.args[0]
+        mock_info.assert_called_once()
+        assert "no-cache" in mock_info.call_args.args[0]
 
 
 class TestCallNightAction:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -17,6 +17,7 @@ from tests.conftest import (
     WOLF_CHAT_OUTPUT_JSON,
     make_failing_llm_client,
     make_llm_client_with_response,
+    make_usage_mock,
 )
 
 
@@ -28,6 +29,7 @@ def _make_tool_use_message(tool_name: str, tool_input: dict):
     block.input = tool_input
     msg = MagicMock()
     msg.content = [block]
+    msg.usage = make_usage_mock()
     return msg
 
 
@@ -115,6 +117,23 @@ class TestCallDiscussion:
         ctx = PublicContext(alive_players=["Alice", "Bob"], dead_players=[], day=1, today_log=[])
         result = llm.call_discussion(actor, ctx)
         assert isinstance(result, SilentResult)
+
+    def test_logs_usage_with_cached_label(self, make_test_actor):
+        """
+        SUT: LLMClient.call_discussion
+        Mock: anthropic SDK — returns tool_use block for "speak"; _logger patched
+        Level: unit
+        Objective: API 呼び出し後に _logger.debug が "[LLM {name} cached]" で呼ばれること。
+        """
+        from unittest.mock import patch
+        actor = make_test_actor("Alice")
+        llm = _make_discussion_llm_client("speak", {"thought": "t", "speech": "Hi!"})
+        from src.llm.prompt import PublicContext
+        ctx = PublicContext(alive_players=["Alice", "Bob"], dead_players=[], day=1, today_log=[])
+        with patch.object(llm._logger, "debug") as mock_debug:
+            llm.call_discussion(actor, ctx)
+        mock_debug.assert_called_once()
+        assert "cached" in mock_debug.call_args.args[0]
 
 
 class TestCallWolfChat:
@@ -225,6 +244,23 @@ class TestCallVote:
         result = llm.call_vote(actor, ctx=ctx)
         assert result.target == ""
         assert result.strategy is None
+
+    def test_logs_usage_with_no_cache_label(self, make_test_actor):
+        """
+        SUT: LLMClient.call_vote
+        Mock: anthropic SDK — returns VOTE_OUTPUT_JSON; _logger patched
+        Level: unit
+        Objective: API 呼び出し後に _logger.debug が "[LLM {name} no-cache]" で呼ばれること。
+        """
+        from unittest.mock import patch
+        from src.llm.prompt import PublicContext
+        actor = make_test_actor("Alice", "Villager")
+        llm = make_llm_client_with_response(VOTE_OUTPUT_JSON)
+        ctx = PublicContext(today_log=[], alive_players=["Alice", "Bob"], dead_players=[], day=1)
+        with patch.object(llm._logger, "debug") as mock_debug:
+            llm.call_vote(actor, ctx=ctx)
+        mock_debug.assert_called_once()
+        assert "no-cache" in mock_debug.call_args.args[0]
 
 
 class TestCallNightAction:


### PR DESCRIPTION
## Summary
- `call_discussion` の system プロンプトに `cache_control: ephemeral` を付与（tools+system を一括キャッシュ）
- 各APIコール後に usage（input/cache_hit/cache_creation/output tokens）を `_logger.debug` で出力
- `cached` / `no-cache` ラベルでキャッシュ対象か否かをログで明示
- `--verbose` フラグで DEBUG ログを有効化

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（329 passed）
- [x] `call_discussion`: `_logger.debug` が `"cached"` ラベルで呼ばれることを確認
- [x] `call_vote`: `_logger.debug` が `"no-cache"` ラベルで呼ばれることを確認

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)