### PR TITLE
feat: show role composition summary at game start in public and replay modes

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -13,7 +13,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#290 | enhancement | ❌ | - | Show role composition summary at game start in public and replay modes | Public/Replayモード開始時に役職構成サマリー（人数のみ）を表示。Spectatorは変更なし |
 | yukkie/AgentVillage#248 | enhancement | 🔴 | - | Feat: pass wolf CO reasoning to discussion phase prompt | 夜の偽CO決定時の reasoning を翌日 DISCUSSION フェーズのプロンプトに含め、狼の発言一貫性を高める |
 | yukkie/AgentVillage#266 | tech-debt | 🟡 | - | Replace intended_co flag with a typed scheduled-event model | intended_co をフラグから timing 付きスケジュール済みイベント型に置き換え、ライフサイクルを型で表現する |
 | yukkie/AgentVillage#207 | tech-debt | 🔴 | 1 | Add 'Why' rationale to project-discipline.md for key development process decisions | 主要プロセス決定の Why を project-discipline.md に記載し SKILL.md から参照する |

--- a/src/domain/roles/madman.py
+++ b/src/domain/roles/madman.py
@@ -7,6 +7,10 @@ class Madman(Role):
         return "Madman"
 
     @property
+    def plural(self) -> str:
+        return "Madmen"
+
+    @property
     def color(self) -> str:
         return "orange3"
 

--- a/src/domain/roles/role.py
+++ b/src/domain/roles/role.py
@@ -27,6 +27,10 @@ class Role(ABC):
     def faction(self) -> str: ...
 
     @property
+    def plural(self) -> str:
+        return self.name + "s"
+
+    @property
     @abstractmethod
     def night_action(self) -> str | None: ...
 

--- a/src/domain/roles/werewolf.py
+++ b/src/domain/roles/werewolf.py
@@ -15,6 +15,10 @@ class Werewolf(Role):
         return "Werewolf"
 
     @property
+    def plural(self) -> str:
+        return "Werewolves"
+
+    @property
     def color(self) -> str:
         return "red"
 

--- a/src/ui/cli.py
+++ b/src/ui/cli.py
@@ -4,6 +4,7 @@ from rich.panel import Panel
 from src.domain.event import LogEvent
 from src.domain.actor import Actor
 from src.ui.renderer import Renderer
+from src.ui.roster import build_roster_full, build_roster_summary
 
 console = Console()
 
@@ -51,11 +52,12 @@ class CLI:
         )
 
     def show_agent_roles(self) -> None:
-        """Display agent roles (spectator only)."""
-        if not self.spectator_mode:
-            return
-        console.print("\n[bold cyan]Agent Roster:[/bold cyan]")
-        for actor in self.agents:
-            role_style = actor.role.color
-            console.print(f"  [{role_style}]{actor.name}[/{role_style}] — {actor.role.name} ({actor.persona.style})")
-        console.print()
+        """Display agent roles: full list in spectator mode, count summary in public mode."""
+        if self.spectator_mode:
+            console.print("\n[bold cyan]Agent Roster:[/bold cyan]")
+            for name, role_name, style in build_roster_full(self.agents):
+                role_style = next(a.role.color for a in self.agents if a.name == name)
+                console.print(f"  [{role_style}]{name}[/{role_style}] — {role_name} ({style})")
+            console.print()
+        else:
+            console.print(f"\n[bold cyan]{build_roster_summary(self.agents)}[/bold cyan]\n")

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -17,6 +17,7 @@ from src.domain.actor import Actor, actor_from_dict, load_agent_catalog, make_ac
 from src.domain.event import EventType, LogEvent
 from src.logger.reader import load_events
 from src.ui.renderer import Renderer
+from src.ui.roster import build_roster_full, build_roster_summary
 
 ARCHIVE_DIR = Path("state_archive")
 
@@ -135,6 +136,16 @@ class ReplayPager:
 
         renderer = Renderer(list(dynamic_actors.values()), self._spectator)
         all_lines: list[str] = []
+
+        if self._spectator:
+            roster_header = "\nAgent Roster:"
+            all_lines.append(roster_header)
+            for name, role_name, style in build_roster_full(self._agents):
+                all_lines.append(f"  {name} — {role_name} ({style})")
+            all_lines.append("")
+        else:
+            all_lines.append(f"\n{build_roster_summary(self._agents)}\n")
+
         for event in events:
             # Use event.claimed_role (structured field) rather than parsing content text.
             if event.event_type == EventType.CO_ANNOUNCEMENT and event.agent and event.claimed_role:

--- a/src/ui/roster.py
+++ b/src/ui/roster.py
@@ -1,0 +1,20 @@
+"""Pure functions for building role roster display strings."""
+from collections import Counter
+
+from src.domain.actor import Actor
+
+
+def build_roster_summary(agents: list[Actor]) -> str:
+    """Return a role count summary string, e.g. '3 Villagers · 1 Seer · 1 Werewolf'."""
+    counts: Counter[str] = Counter(a.role.name for a in agents)
+    role_map = {a.role.name: a.role for a in agents}
+    parts = [
+        f"{count} {role_map[name].plural if count > 1 else name}"
+        for name, count in sorted(counts.items())
+    ]
+    return "This village has " + " · ".join(parts)
+
+
+def build_roster_full(agents: list[Actor]) -> list[tuple[str, str, str]]:
+    """Return a list of (name, role_name, style) tuples for full spectator display."""
+    return [(a.name, a.role.name, a.persona.style) for a in agents]

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -1,0 +1,89 @@
+"""Tests for src/ui/roster.py"""
+
+from src.ui.roster import build_roster_full, build_roster_summary
+
+
+class TestBuildRosterSummary:
+    def test_single_role(self, make_test_actor):
+        """
+        SUT: build_roster_summary
+        Mock: なし
+        Level: unit
+        Objective: 1種類の役職のみのとき単数形が使われること
+        """
+        agents = [make_test_actor("Sora", "Villager")]
+        result = build_roster_summary(agents)
+        assert result == "This village has 1 Villager"
+
+    def test_multiple_same_role_uses_plural(self, make_test_actor):
+        """
+        SUT: build_roster_summary
+        Mock: なし
+        Level: unit
+        Objective: 同じ役職が複数いるとき複数形が使われること
+        """
+        agents = [make_test_actor("Sora", "Villager"), make_test_actor("Vael", "Villager")]
+        result = build_roster_summary(agents)
+        assert "2 Villagers" in result
+
+    def test_werewolf_plural_is_werewolves(self, make_test_actor):
+        """
+        SUT: build_roster_summary
+        Mock: なし
+        Level: unit
+        Objective: Werewolfが複数のとき "Werewolves" になること
+        """
+        agents = [make_test_actor("A", "Werewolf"), make_test_actor("B", "Werewolf")]
+        result = build_roster_summary(agents)
+        assert "2 Werewolves" in result
+
+    def test_madman_plural_is_madmen(self, make_test_actor):
+        """
+        SUT: build_roster_summary
+        Mock: なし
+        Level: unit
+        Objective: Madmanが複数のとき "Madmen" になること
+        """
+        agents = [make_test_actor("A", "Madman"), make_test_actor("B", "Madman")]
+        result = build_roster_summary(agents)
+        assert "2 Madmen" in result
+
+    def test_mixed_roles_format(self, make_test_actor):
+        """
+        SUT: build_roster_summary
+        Mock: なし
+        Level: unit
+        Objective: 複数役職が " · " 区切りで結合されること
+        """
+        agents = [
+            make_test_actor("A", "Villager"),
+            make_test_actor("B", "Villager"),
+            make_test_actor("C", "Villager"),
+            make_test_actor("D", "Seer"),
+            make_test_actor("E", "Werewolf"),
+        ]
+        result = build_roster_summary(agents)
+        assert result.startswith("This village has ")
+        assert " · " in result
+        assert "3 Villagers" in result
+        assert "1 Seer" in result
+        assert "1 Werewolf" in result
+
+
+class TestBuildRosterFull:
+    def test_returns_name_role_style_tuples(self, make_test_actor):
+        """
+        SUT: build_roster_full
+        Mock: なし
+        Level: unit
+        Objective: (name, role_name, style) のタプルリストが返ること
+        """
+        agents = [make_test_actor("Sora", "Seer"), make_test_actor("Vael", "Werewolf")]
+        result = build_roster_full(agents)
+        assert len(result) == 2
+        names = [r[0] for r in result]
+        roles = [r[1] for r in result]
+        assert "Sora" in names
+        assert "Vael" in names
+        assert "Seer" in roles
+        assert "Werewolf" in roles


### PR DESCRIPTION
## Summary
- Public モード開始時に役職カウントサマリーを表示 (例: `This village has 3 Villagers · 1 Seer · 1 Werewolf`)
- Replay モードも同等モードの表示に統一（`--replay` → サマリー、`--replay --spectator` → フルリスト）
- `src/ui/roster.py` に純粋関数 `build_roster_summary()` / `build_roster_full()` を切り出し（GUI化時も再利用可能）
- `Role` 基底クラスに `plural` プロパティを追加、`Werewolf` → `Werewolves`、`Madman` → `Madmen` をオーバーライド

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `test_mixed_roles_format` — サマリー形式・区切り文字を検証
- [ ] `test_werewolf_plural_is_werewolves` — 不規則複数形を検証
- [ ] `test_madman_plural_is_madmen` — 不規則複数形を検証

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)