### PR TITLE
fix: increase call_speech/call_discussion max_tokens to 4096 for large games

### DIFF
--- a/config/tokens.json
+++ b/config/tokens.json
@@ -1,6 +1,6 @@
 {
-  "call_speech": 2048,
-  "call_discussion": 2048,
+  "call_speech": 4096,
+  "call_discussion": 4096,
   "call_vote": 512,
   "call_wolf_chat": 2048,
   "call_night_action": 256


### PR DESCRIPTION
## Summary
- `call_speech` / `call_discussion` の `max_tokens` を 2048 → 4096 に引き上げ

## Background
15人制ゲームでは議論ログ・エージェント情報が増えて入力トークンが膨らみ、
`stop_reason: max_tokens` で出力が途中打ち切りになる問題が発生した。
`speak` ツールの引数が空になり silent にフォールバックしていた。

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `uv run main.py --players 15` で speak ツールが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)