### PR TITLE
fix: restore DISCUSSION_ROUNDS to 3

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 # Game settings
-DISCUSSION_ROUNDS = 2
+DISCUSSION_ROUNDS = 3
 WOLF_CHAT_ROUNDS = 3
 
 # Environment


### PR DESCRIPTION
## Summary
- `DISCUSSION_ROUNDS` を 2 → 3 に戻す
- OPENING 削除時に誤って 2 に変更されていた

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)