### PR TITLE
fix: validate suspicion/threat score dicts from LLM to prevent AttributeError

### DIFF
--- a/src/llm/discussion_tools.py
+++ b/src/llm/discussion_tools.py
@@ -17,6 +17,13 @@ from src.legacy.role_normalizer import normalize_role_field
 _XML_TAG_RE = re.compile(r"<(\w[\w:-]*)[^>]*>.*?</\1>", re.DOTALL)
 
 
+def _parse_score_dict(value: object) -> dict[str, float] | None:
+    """Return value as dict[str, float] if valid, otherwise None."""
+    if not isinstance(value, dict):
+        return None
+    return {k: float(v) for k, v in value.items() if isinstance(k, str) and isinstance(v, (int, float))}
+
+
 def build_discussion_tools(co_eligible: bool) -> list[dict]:
     """Build the tool definitions list for a DISCUSSION call."""
     role_names_hint = "e.g. Seer, Villager, Knight, Werewolf"
@@ -145,8 +152,8 @@ def parse_discussion_tool_result(message: anthropic.types.Message, agent_name: s
                 thought=thought,
                 speech=speech,
                 memory_update=inp.get("memory_update", []),  # type: ignore[arg-type]
-                suspicion_scores=inp.get("suspicion_scores"),  # type: ignore[arg-type]
-                threat_scores=inp.get("threat_scores"),  # type: ignore[arg-type]
+                suspicion_scores=_parse_score_dict(inp.get("suspicion_scores")),
+                threat_scores=_parse_score_dict(inp.get("threat_scores")),
             )
         if name == "challenge":
             return ChallengeResult(
@@ -154,8 +161,8 @@ def parse_discussion_tool_result(message: anthropic.types.Message, agent_name: s
                 speech=speech,
                 reply_to=int(inp.get("reply_to", 0)),  # type: ignore[arg-type]
                 memory_update=inp.get("memory_update", []),  # type: ignore[arg-type]
-                suspicion_scores=inp.get("suspicion_scores"),  # type: ignore[arg-type]
-                threat_scores=inp.get("threat_scores"),  # type: ignore[arg-type]
+                suspicion_scores=_parse_score_dict(inp.get("suspicion_scores")),
+                threat_scores=_parse_score_dict(inp.get("threat_scores")),
             )
         if name == "co":
             raw_role = inp.get("claim_role")
@@ -166,16 +173,16 @@ def parse_discussion_tool_result(message: anthropic.types.Message, agent_name: s
                     thought=thought,
                     speech=speech,
                     memory_update=inp.get("memory_update", []),  # type: ignore[arg-type]
-                    suspicion_scores=inp.get("suspicion_scores"),  # type: ignore[arg-type]
-                    threat_scores=inp.get("threat_scores"),  # type: ignore[arg-type]
+                    suspicion_scores=_parse_score_dict(inp.get("suspicion_scores")),
+                    threat_scores=_parse_score_dict(inp.get("threat_scores")),
                 )
             return CoResult(
                 thought=thought,
                 speech=speech,
                 claim_role=claim_role,
                 memory_update=inp.get("memory_update", []),  # type: ignore[arg-type]
-                suspicion_scores=inp.get("suspicion_scores"),  # type: ignore[arg-type]
-                threat_scores=inp.get("threat_scores"),  # type: ignore[arg-type]
+                suspicion_scores=_parse_score_dict(inp.get("suspicion_scores")),
+                threat_scores=_parse_score_dict(inp.get("threat_scores")),
             )
 
     # No tool_use block found — fall back to silent

--- a/tests/unit/test_discussion_tools.py
+++ b/tests/unit/test_discussion_tools.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock
 
 from src.domain.schema import ChallengeResult, CoResult, SilentResult, SpeakResult
-from src.llm.discussion_tools import parse_discussion_tool_result
+from src.llm.discussion_tools import _parse_score_dict, parse_discussion_tool_result
 
 
 def _make_message(tool_name: str, tool_input: dict):
@@ -270,3 +270,103 @@ class TestParseXmlTagWarning:
         parse_discussion_tool_result(msg, "TestAgent")
         captured = capsys.readouterr()
         assert "XML tag" not in captured.err
+
+
+class TestParseScoreDict:
+    def test_valid_dict_returns_float_values(self):
+        """
+        SUT: _parse_score_dict
+        Mock: なし
+        Level: unit
+        Objective: 正常な dict[str, float] がそのまま返ること。
+        """
+        assert _parse_score_dict({"Alice": 0.8, "Bob": 0.3}) == {"Alice": 0.8, "Bob": 0.3}
+
+    def test_string_value_returns_none(self):
+        """
+        SUT: _parse_score_dict
+        Mock: なし
+        Level: unit
+        Objective: LLM が str を返した場合に None になること（AttributeError クラッシュを防ぐ）。
+        """
+        assert _parse_score_dict("Alice: 0.8") is None
+
+    def test_none_returns_none(self):
+        """
+        SUT: _parse_score_dict
+        Mock: なし
+        Level: unit
+        Objective: None 入力が None を返すこと。
+        """
+        assert _parse_score_dict(None) is None
+
+    def test_list_returns_none(self):
+        """
+        SUT: _parse_score_dict
+        Mock: なし
+        Level: unit
+        Objective: list 入力が None を返すこと。
+        """
+        assert _parse_score_dict(["Alice", 0.8]) is None
+
+    def test_non_string_keys_are_filtered(self):
+        """
+        SUT: _parse_score_dict
+        Mock: なし
+        Level: unit
+        Objective: キーが str でないエントリは除外されること。
+        """
+        assert _parse_score_dict({1: 0.5, "Bob": 0.3}) == {"Bob": 0.3}
+
+
+class TestSuspicionScoresDictValidation:
+    def test_speak_with_string_suspicion_scores_returns_speak_result_without_scores(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with speak tool; suspicion_scores is a string
+        Level: unit
+        Objective: LLM が suspicion_scores を str で返したとき AttributeError を起こさず
+                   suspicion_scores=None の SpeakResult を返すこと。
+        """
+        msg = _make_message("speak", {
+            "speech": "I suspect Alice.",
+            "thought": "...",
+            "suspicion_scores": "Alice: 0.8",
+        })
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SpeakResult)
+        assert result.suspicion_scores is None
+
+    def test_challenge_with_string_suspicion_scores_returns_challenge_result_without_scores(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with challenge tool; suspicion_scores is a string
+        Level: unit
+        Objective: challenge ツールで suspicion_scores が str のとき suspicion_scores=None の
+                   ChallengeResult を返すこと。
+        """
+        msg = _make_message("challenge", {
+            "speech": "That doesn't add up.",
+            "thought": "...",
+            "reply_to": 2,
+            "suspicion_scores": "high",
+        })
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, ChallengeResult)
+        assert result.suspicion_scores is None
+
+    def test_speak_with_valid_dict_suspicion_scores_preserved(self):
+        """
+        SUT: parse_discussion_tool_result
+        Mock: anthropic.types.Message (MagicMock) with speak tool; suspicion_scores is a valid dict
+        Level: unit
+        Objective: suspicion_scores が正常な dict のときそのまま SpeakResult に保持されること。
+        """
+        msg = _make_message("speak", {
+            "speech": "I suspect Alice.",
+            "thought": "...",
+            "suspicion_scores": {"Alice": 0.8, "Bob": 0.2},
+        })
+        result = parse_discussion_tool_result(msg, "TestAgent")
+        assert isinstance(result, SpeakResult)
+        assert result.suspicion_scores == {"Alice": 0.8, "Bob": 0.2}


### PR DESCRIPTION
## Summary
- `discussion_tools.py` に `_parse_score_dict()` ヘルパーを追加
- LLM が `suspicion_scores` / `threat_scores` を dict 以外（str など）で返した場合に `None` に落とす
- `update_beliefs()` に非 dict が渡って `AttributeError: 'str' object has no attribute 'items'` が発生するクラッシュを修正

## Root Cause
tool use の入力を `inp.get("suspicion_scores")` で取り出す際に型チェックがなく、
LLM が稀に文字列を返すとそのまま `memory.update_beliefs()` に渡されてクラッシュしていた。

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（352 tests）
- [ ] `TestParseScoreDict` — str/None/list/invalid key を網羅
- [ ] `TestSuspicionScoresDictValidation` — speak/challenge で str が来ても SpeakResult/ChallengeResult が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)