### PR TITLE
fix: clear state/agents/ on game start

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -27,13 +27,13 @@ AgentVillage/
 │   ├── stats/                  # ゲーム統計の記録（state/stats/ への書き込み）・集計・表示
 │   └── ui/                     # UIレイヤー（CLI / 将来Web）
 ├── state/
-│   ├── world.json              # ゲーム全体の状態
-│   ├── public_log.jsonl        # 公開ログ
-│   ├── agents/                 # エージェントごとの状態ファイル
+│   ├── public_log.jsonl        # 公開ログ（ゲーム開始時にクリア、アーカイブ後も残留）
+│   ├── spectator_log.jsonl     # 観戦者ログ（ゲーム開始時にクリア、アーカイブ後も残留）
+│   ├── agents/                 # エージェントごとの状態ファイル（ゲーム開始時に削除、アーカイブ後も残留）
 │   │   ├── setsu.json
 │   │   └── ...
 │   └── stats/
-│       └── game_stats.json     # ゲームごとの統計（累積）
+│       └── game_stats.json     # ゲームごとの統計（累積・削除しない）
 ├── tests/
 │   ├── conftest.py
 │   ├── unit/
@@ -193,6 +193,9 @@ Contract test: `tests/contract/test_day_phase_contract.py`, `tests/contract/test
 
 - 公開ログ（`public_log.jsonl`）と観戦者ログ（真実込み）を分けて保存
 - リプレイ機能の基盤
+- `LogWriter.__init__` がゲーム開始時にログファイルのクリアと同時に `state/agents/*.json` も削除する。ログと agents の初期化責務を同一箇所に集約するため
+- `state/stats/game_stats.json` は削除しない（累積統計を維持）
+- `main.py` の呼び出し順: `LogWriter()` → `initialize_agents()` の順を守ること（先にクリアしてから新しい JSON を書く）
 
 ### 3.7 Stats（`src/stats/`）
 

--- a/main.py
+++ b/main.py
@@ -82,13 +82,13 @@ def main() -> None:
     else:
         lang: str = args.lang
 
+        log_writer = LogWriter()
+
         agents = initialize_agents(args.players)
 
         cli = CLI(agents=agents, spectator_mode=spectator_mode)
         cli.show_intro()
         cli.show_agent_roles()
-
-        log_writer = LogWriter()
 
         engine = GameEngine(
             agents=agents,

--- a/src/agent/store.py
+++ b/src/agent/store.py
@@ -1,23 +1,23 @@
 import json
 from pathlib import Path
 
-from src.config import STATE_DIR
+from src.config import AGENTS_DIR
 from src.domain.actor import Actor, actor_from_dict, actor_to_dict
 
 
 def _ensure_dir() -> None:
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    AGENTS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def save(actor: Actor) -> None:
     _ensure_dir()
-    path = STATE_DIR / f"{actor.name.lower()}.json"
+    path = AGENTS_DIR / f"{actor.name.lower()}.json"
     data = actor_to_dict(actor)
     path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
 def load(name: str) -> Actor:
-    path = STATE_DIR / f"{name.lower()}.json"
+    path = AGENTS_DIR / f"{name.lower()}.json"
     if not path.exists():
         raise FileNotFoundError(f"Agent state file not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -34,4 +34,4 @@ def load_all_from_dir(path: Path) -> list[Actor]:
 
 def load_all() -> list[Actor]:
     _ensure_dir()
-    return load_all_from_dir(STATE_DIR)
+    return load_all_from_dir(AGENTS_DIR)

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,7 @@ WOLF_CHAT_ROUNDS = 3
 
 # Environment
 PROJECT_ROOT = Path(__file__).parent.parent
-STATE_DIR = PROJECT_ROOT / "state/agents"
+AGENTS_DIR = PROJECT_ROOT / "state/agents"
 LOG_DIR = PROJECT_ROOT / "state"
 PUBLIC_LOG = LOG_DIR / "public_log.jsonl"
 SPECTATOR_LOG = LOG_DIR / "spectator_log.jsonl"

--- a/src/engine/setup.py
+++ b/src/engine/setup.py
@@ -4,14 +4,14 @@ import random
 import sys
 from pathlib import Path
 
-from src.config import STATE_DIR
+from src.config import AGENTS_DIR
 from src.domain.actor import Actor, ActorProfile, ActorState, Belief, Persona, make_actor
 from src.agent import store
 
 
 def initialize_agents(num_players: int) -> list[Actor]:
     """Create and persist initial agent states with randomized roles."""
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    AGENTS_DIR.mkdir(parents=True, exist_ok=True)
 
     try:
         agent_configs = json.loads(Path("config/agents.json").read_text(encoding="utf-8"))

--- a/src/logger/writer.py
+++ b/src/logger/writer.py
@@ -3,7 +3,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-from src.config import ARCHIVE_DIR, LOG_DIR, PUBLIC_LOG, SPECTATOR_LOG
+from src.config import ARCHIVE_DIR, LOG_DIR, PUBLIC_LOG, SPECTATOR_LOG, AGENTS_DIR
 from src.domain.event import LogEvent
 
 
@@ -24,9 +24,11 @@ def archive_state() -> Path | None:
 class LogWriter:
     def __init__(self) -> None:
         LOG_DIR.mkdir(parents=True, exist_ok=True)
-        # Clear logs at start of new game
+        AGENTS_DIR.mkdir(parents=True, exist_ok=True)
         PUBLIC_LOG.write_text("", encoding="utf-8")
         SPECTATOR_LOG.write_text("", encoding="utf-8")
+        for f in AGENTS_DIR.glob("*.json"):
+            f.unlink()
 
     def write(self, event: LogEvent) -> None:
         line = event.model_dump_json() + "\n"

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -41,17 +41,17 @@ def test_load_all_from_dir_empty(tmp_path: Path) -> None:
 def test_load_missing_file_raises(tmp_path: Path, monkeypatch) -> None:
     """
     SUT: load()
-    Mock: monkeypatch で STATE_DIR を tmp_path に差し替え
+    Mock: monkeypatch で AGENTS_DIR を tmp_path に差し替え
     Level: unit
     Objective: 存在しないエージェントファイルを load() したとき FileNotFoundError が送出されること。
     """
-    monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(store, "AGENTS_DIR", tmp_path)
     with pytest.raises(FileNotFoundError, match="Agent state file not found"):
         store.load("ghost")
 
 
 def test_load_all_delegates_to_load_all_from_dir(agents_dir: Path, monkeypatch) -> None:
-    """load_all() が load_all_from_dir(STATE_DIR) に委譲していること。"""
+    """load_all() が load_all_from_dir(AGENTS_DIR) に委譲していること。"""
     called_with: list[Path] = []
 
     original = store.load_all_from_dir
@@ -61,14 +61,14 @@ def test_load_all_delegates_to_load_all_from_dir(agents_dir: Path, monkeypatch) 
         return original(path)
 
     monkeypatch.setattr(store, "load_all_from_dir", spy)
-    monkeypatch.setattr(store, "STATE_DIR", agents_dir)
+    monkeypatch.setattr(store, "AGENTS_DIR", agents_dir)
 
     store.load_all()
     assert called_with == [agents_dir]
 
 
 def test_save_writes_split_json(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(store, "AGENTS_DIR", tmp_path)
     actor = Actor(
         profile=ActorProfile(name="Alice", persona=Persona(style="calm")),
         state=ActorState(beliefs={}, memory_summary=[], is_alive=True),
@@ -115,12 +115,12 @@ def test_actor_state_loads_without_threat_scores_field(tmp_path: Path, monkeypat
 def test_save_preserves_non_ascii_text(tmp_path: Path, monkeypatch) -> None:
     """
     SUT: store.save()
-    Mock: monkeypatch で STATE_DIR を tmp_path に差し替え
+    Mock: monkeypatch で AGENTS_DIR を tmp_path に差し替え
     Level: unit
     Objective: memory_summary に日本語を含む ActorState を save したとき、
                書き込まれたファイルに \\uXXXX 形式のエスケープが含まれないこと。
     """
-    monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(store, "AGENTS_DIR", tmp_path)
     japanese_memory = "初日：setsu を怪しいと感じた"
     actor = Actor(
         profile=ActorProfile(name="Alice", persona=Persona(style="calm")),

--- a/tests/unit/test_writer.py
+++ b/tests/unit/test_writer.py
@@ -1,0 +1,101 @@
+"""src/logger/writer.py の LogWriter / archive_state() のテスト。"""
+from pathlib import Path
+from unittest.mock import patch
+
+from src.logger.writer import LogWriter
+
+
+def _make_state(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """テスト用の state/ 構造を作成して返す。"""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    public_log = tmp_path / "public_log.jsonl"
+    spectator_log = tmp_path / "spectator_log.jsonl"
+    return agents_dir, public_log, spectator_log
+
+
+def test_log_writer_clears_agent_json(tmp_path: Path) -> None:
+    """
+    SUT: LogWriter.__init__
+    Mock: src.logger.writer の LOG_DIR / PUBLIC_LOG / SPECTATOR_LOG / AGENTS_DIR を tmp_path 配下に差し替え
+    Level: unit
+    Objective: LogWriter 生成時に state/agents/*.json が削除されること
+    """
+    agents_dir, public_log, spectator_log = _make_state(tmp_path)
+    stale = agents_dir / "wolf1.json"
+    stale.write_text("{}", encoding="utf-8")
+
+    with (
+        patch("src.logger.writer.LOG_DIR", tmp_path),
+        patch("src.logger.writer.PUBLIC_LOG", public_log),
+        patch("src.logger.writer.SPECTATOR_LOG", spectator_log),
+        patch("src.logger.writer.AGENTS_DIR", agents_dir),
+    ):
+        LogWriter()
+
+    assert not stale.exists()
+
+
+def test_log_writer_preserves_stats(tmp_path: Path) -> None:
+    """
+    SUT: LogWriter.__init__
+    Mock: src.logger.writer のパス定数を tmp_path 配下に差し替え
+    Level: unit
+    Objective: LogWriter 生成時に state/stats/ 配下のファイルが削除されないこと
+    """
+    agents_dir, public_log, spectator_log = _make_state(tmp_path)
+    stats_file = tmp_path / "stats" / "game_stats.json"
+    stats_file.write_text("[]", encoding="utf-8")
+
+    with (
+        patch("src.logger.writer.LOG_DIR", tmp_path),
+        patch("src.logger.writer.PUBLIC_LOG", public_log),
+        patch("src.logger.writer.SPECTATOR_LOG", spectator_log),
+        patch("src.logger.writer.AGENTS_DIR", agents_dir),
+    ):
+        LogWriter()
+
+    assert stats_file.exists()
+
+
+def test_log_writer_clears_multiple_agent_json(tmp_path: Path) -> None:
+    """
+    SUT: LogWriter.__init__
+    Mock: src.logger.writer のパス定数を tmp_path 配下に差し替え
+    Level: unit
+    Objective: state/agents/ 内の複数 JSON がすべて削除されること
+    """
+    agents_dir, public_log, spectator_log = _make_state(tmp_path)
+    files = [agents_dir / f"{name}.json" for name in ("alice", "wolf1", "wolf2")]
+    for f in files:
+        f.write_text("{}", encoding="utf-8")
+
+    with (
+        patch("src.logger.writer.LOG_DIR", tmp_path),
+        patch("src.logger.writer.PUBLIC_LOG", public_log),
+        patch("src.logger.writer.SPECTATOR_LOG", spectator_log),
+        patch("src.logger.writer.AGENTS_DIR", agents_dir),
+    ):
+        LogWriter()
+
+    assert not any(f.exists() for f in files)
+
+
+def test_log_writer_no_error_when_agents_dir_empty(tmp_path: Path) -> None:
+    """
+    SUT: LogWriter.__init__
+    Mock: src.logger.writer のパス定数を tmp_path 配下に差し替え
+    Level: unit
+    Objective: state/agents/ が空のときでもエラーなく初期化できること
+    """
+    agents_dir, public_log, spectator_log = _make_state(tmp_path)
+
+    with (
+        patch("src.logger.writer.LOG_DIR", tmp_path),
+        patch("src.logger.writer.PUBLIC_LOG", public_log),
+        patch("src.logger.writer.SPECTATOR_LOG", spectator_log),
+        patch("src.logger.writer.AGENTS_DIR", agents_dir),
+    ):
+        LogWriter()  # エラーが出なければ OK


### PR DESCRIPTION
## Summary
- `AGENTS_DIR`（旧 `STATE_DIR`）に定数名をリネーム（`state/agents/` を指す定数として明確化）
- `LogWriter.__init__` でゲーム開始時に `state/agents/*.json` を削除するよう追加
- `main.py` の呼び出し順を `LogWriter()` → `initialize_agents()` に変更し、クリア後に新 JSON を書く順序を保証
- `doc/Architecture.md` のディレクトリ構成と Logger セクションにファイルのライフサイクルを明記

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（356 passed）
- [x] `LogWriter` 生成時に stale な JSON が削除されること
- [x] `state/stats/game_stats.json` が削除されないこと

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)