### PR TITLE
docs: add Web UI architecture, milestones, and issue breakdown

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -11,11 +11,25 @@
 AgentVillage/
 ├── .github/workflows/
 │   └── ci.yml                  # Push/PR 時: ruff + pytest
+├── config/
+│   ├── agents.json             # エージェント定義（name / persona / occupation）
+│   └── icons/                  # エージェントアイコン PNG（frontend で使用）
+├── design/
+│   └── proposal/               # UI デザインプロポーザル（hifi プロトタイプ JSX/CSS）
 ├── doc/
 │   ├── Architecture.md         # 本ドキュメント
 │   ├── Spec.md                 # 仕様書
 │   ├── Ideas.md                # アイデア・未決事項
 │   └── Task.md                 # タスク管理
+├── frontend/                   # Web UI（Vite + React + CSS Modules）
+│   ├── src/
+│   │   ├── components/         # 共通コンポーネント（Avatar, RoleTag など）
+│   │   ├── screens/            # 画面コンポーネント（観戦・一覧・エージェント詳細）
+│   │   ├── lib/                # ユーティリティ（JSONL パーサーなど）
+│   │   └── tokens.css          # デザイントークン（CSS Variables）
+│   ├── index.html
+│   ├── vite.config.js
+│   └── package.json
 ├── src/
 │   ├── domain/                 # Pydanticドメインモデル定義（ゲーム仕様依存の型）+ Role クラス群
 │   ├── engine/                 # ゲームエンジン（決定論的）
@@ -64,6 +78,31 @@ AgentVillage/
 CLI   →  src/ui/cli.py   ┐
 Web   →  src/ui/api.py   ├─  src/engine/ / src/agent/ には依存しない
 ```
+
+### 2.3（追記）フロントエンドと Python の連携方式
+
+`frontend/`（JS）と `src/`（Python）は **ファイルシステム経由の JSON のみで連携する**。
+直接の関数呼び出し・プロセス間通信は行わない。
+
+```
+Python (src/)              ファイルシステム              JS (frontend/)
+─────────────              ───────────────              ──────────────
+GameEngine がゲームを進行
+  ↓
+spectator.py がログを書き出す  →  state_archive/{session}/
+                                   public_log.jsonl     →  JS がファイルを読む
+                                   spectator_log.jsonl      （lib/parseGameData.js）
+                                   agents/*.json
+```
+
+**この方針を採用する理由**:
+- Python 側は既存の CLI 動作を一切変えずに済む（CLI を壊さない）
+- JS 側はファイルを読むだけなので Python への依存ゼロ
+- 将来 FastAPI（#315）に移行する際も、JS 側の fetch 先を変えるだけで済む
+
+**将来の FastAPI 化**（#315 実装時）:
+`src/ui/api.py` を追加して WebSocket でイベントをリアルタイム配信する。
+`src/ui/cli.py` / `src/ui/renderer.py` には触れない。
 
 ### 2.3 LLM出力は構造化して受け取る
 

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -362,6 +362,69 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 | `renderer.py` | `Renderer` クラス（`on_event()`）でイベントを Rich `Text` に変換。将来的に EventPresenter（中立の `DisplayEvent`）→ `ConsoleRenderer` / `WebRenderer` へ分割する前提のシーム |
 | `replay.py` | アーカイブ選択UI + ページャー。LLMを一切呼ばずにJSONLログを再生する |
 
+---
+
+## frontend/ — Web UI（Vite + React + CSS Modules）
+
+Python 側（`src/`）には一切依存しない。`state_archive/` の JSONL ファイルを JS 側で読み込んで描画する。
+
+### 技術スタック
+
+| 項目 | 採用技術 | 理由 |
+|---|---|---|
+| ビルドツール | Vite | 高速 HMR、設定が軽量 |
+| UI ライブラリ | React | プロトタイプが JSX で書かれており移植コストが低い |
+| スタイリング | CSS Modules | `design/proposal/prototypes/styles.css` の CSS Variables をそのまま流用できる |
+| 将来移行先 | Next.js | React 資産を保持したまま SSR / API Routes を追加できる |
+
+### ディレクトリ構成
+
+```text
+frontend/
+├── src/
+│   ├── components/         # 共通コンポーネント
+│   │   ├── Avatar.jsx      # config/icons/ の PNG を表示。モノグラムフォールバックあり
+│   │   ├── RoleTag.jsx     # 役職名 + 役職カラー（--r-* トークン）
+│   │   └── Icon.jsx        # 吹き出し / 鍵 / チェブロン SVG
+│   ├── screens/            # 画面コンポーネント
+│   │   ├── SpectatorScreen.jsx   # 観戦メイン画面（3ペイン）
+│   │   ├── GameListScreen.jsx    # ゲーム一覧
+│   │   └── AgentScreen.jsx       # エージェント詳細
+│   ├── lib/
+│   │   └── parseGameData.js      # JSONL → GameData 型パーサー（#313）
+│   └── tokens.css          # デザイントークン（design/proposal/prototypes/styles.css の :root を移植）
+├── index.html
+├── vite.config.js
+└── package.json
+```
+
+### GameData 型（JS 側のデータ契約）
+
+`design/proposal/README.md §Source Data` で定義されたシェイプに準拠する。
+
+```js
+// GameData = { events: PublicEvent[], agents: Record<AgentName, AgentProfile> }
+// PublicEvent の主要フィールド:
+//   id, day, phase, event_type, agent, target, content,
+//   is_public, speech_id, reply_to, claimed_role, inspection_role,
+//   reasoning, decision, thought (spectator のみ)
+```
+
+Python 側の `LogEvent`（`src/domain/event.py`）と 1:1 対応する。
+フィールドの追加・変更は両側を同時に更新すること。
+
+### viewerMode — spectator / public
+
+`viewerMode: 'spectator' | 'public'` prop を各コンポーネントに伝播する。
+
+| 要素 | spectator | public |
+|---|---|---|
+| 役職タグ | 真の役職を常時表示 | 未CO は「役職不明」 |
+| 偽CO バッジ | 赤＋「偽」マーク | 中立色 |
+| 思考ログピル | 展開可 | ロックバッジ（存在のみ示す） |
+
+`spectator_log.jsonl`（`thought` フィールドあり）と `public_log.jsonl`（`thought` なし）を切り替えることで対応する。
+
 ### replay.py — クラス構成
 
 #### `run_replay(spectator_mode: bool, archive_path: Path | None = None)`

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -25,7 +25,15 @@
 | yukkie/AgentVillage#25 | enhancement | 🟢 | 8 | Skill memory (cross-game learning) | ゲームをまたいで引き継がれる戦略記憶 |
 | yukkie/AgentVillage#28 | enhancement | 🟢 | 8 | Human player participation mode | 人間がエージェントとして参加 |
 | yukkie/AgentVillage#29 | enhancement | 🟢 | 8 | Persona community sharing | キャラテンプレートの共有 |
-| yukkie/AgentVillage#27 | enhancement | 🟢 | 13 | Web / mobile app | FastAPI + WebSocket + React |
+| yukkie/AgentVillage#308 | enhancement | 🔴 | 2 | Frontend scaffolding | Vite + React + CSS Modules、デザイントークン、Avatar/RoleTag |
+| yukkie/AgentVillage#309 | enhancement | 🔴 | 5 | Spectator feed screen | 観戦メイン画面（3ペイン + 発言カード）スタブデータ |
+| yukkie/AgentVillage#310 | enhancement | 🔴 | 3 | Game list screen | ゲーム一覧画面、スタブデータ |
+| yukkie/AgentVillage#311 | enhancement | 🔴 | 3 | Agent detail screen | エージェント詳細画面、collapsible panes |
+| yukkie/AgentVillage#312 | enhancement | 🟡 | 3 | GameData gap analysis | 足りないデータの洗い出し・spectator_log 拡張 |
+| yukkie/AgentVillage#313 | enhancement | 🟡 | 3 | JSONL to GameData parser | 実ログ接続・ポーリング更新 |
+| yukkie/AgentVillage#314 | enhancement | 🟡 | 2 | spectator / public mode toggle | viewerMode prop による表示切替 |
+| yukkie/AgentVillage#315 | enhancement | 🟢 | 8 | FastAPI + WebSocket backend | リアルタイムストリーミング（Milestone 2 完了後） |
+| yukkie/AgentVillage#316 | enhancement | 🟢 | 13 | Mobile app (React Native) | iOS/Android 対応（#315 完了後） |
 | yukkie/AgentVillage#30 | enhancement | 🟢 | 13 | State management DB migration | JSON → DB 移行 |
 
 ---

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -29,8 +29,9 @@
 | yukkie/AgentVillage#309 | enhancement | 🔴 | 5 | Spectator feed screen | 観戦メイン画面（3ペイン + 発言カード）スタブデータ |
 | yukkie/AgentVillage#310 | enhancement | 🔴 | 3 | Game list screen | ゲーム一覧画面、スタブデータ |
 | yukkie/AgentVillage#311 | enhancement | 🔴 | 3 | Agent detail screen | エージェント詳細画面、collapsible panes |
-| yukkie/AgentVillage#312 | enhancement | 🟡 | 3 | GameData gap analysis | 足りないデータの洗い出し・spectator_log 拡張 |
-| yukkie/AgentVillage#313 | enhancement | 🟡 | 3 | JSONL to GameData parser | 実ログ接続・ポーリング更新 |
+| yukkie/AgentVillage#312 | enhancement | 🟡 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 1/2 横串） |
+| yukkie/AgentVillage#318 | enhancement | 🟡 | 3 | Replay viewer | state_archive/ から過去ゲームを表示（Milestone 2 前半） |
+| yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#314 | enhancement | 🟡 | 2 | spectator / public mode toggle | viewerMode prop による表示切替 |
 | yukkie/AgentVillage#315 | enhancement | 🟢 | 8 | FastAPI + WebSocket backend | リアルタイムストリーミング（Milestone 2 完了後） |
 | yukkie/AgentVillage#316 | enhancement | 🟢 | 13 | Mobile app (React Native) | iOS/Android 対応（#315 完了後） |

--- a/doc/project-discipline.md
+++ b/doc/project-discipline.md
@@ -12,7 +12,16 @@
 | #311 | エージェント詳細画面（collapsible panes） |
 
 ### Milestone 2（次 Sprint）
-`python main.py` のログを実際にブラウザで観戦できる状態。構成 Issue: #312 / #313 / #314
+`python main.py` のログを実際にブラウザで観戦できる状態。
+
+| Issue | 内容 |
+|---|---|
+| #312 | GameData レジストリ（Milestone 1 から継続、本マイルストーン着手前にレジストリ全体の対応方針確定） |
+| #318 | Replay viewer（state_archive/ から過去ゲームを表示） |
+| #319 | LIVE spectator（state/ を tail して進行中ゲームをリアルタイム表示） |
+| #314 | spectator / public モード切替 |
+
+#318 を先に完成させて「過去ゲーム観戦」を達成し、#319 で LIVE 化する段階アプローチ。
 
 ### 将来フェーズ
 - #315: FastAPI + WebSocket バックエンド

--- a/doc/project-discipline.md
+++ b/doc/project-discipline.md
@@ -1,7 +1,22 @@
 # Project Discipline
 
 ## Sprint Goal
-ゴール: AIのみ15人制での人狼ゲームの実現（実装漏れ機能の優先実装）
+ゴール: Web UI Milestone 1 達成（ブラウザで `localhost:5173` を開くと `design/proposal` と同じ画面がスタブデータで動く状態）
+
+### Milestone 1 の構成 Issue
+| Issue | 内容 |
+|---|---|
+| #308 | Frontend scaffolding（Vite + React + CSS Modules + デザイントークン + 共通プリミティブ） |
+| #309 | 観戦メイン画面（3ペイン + 発言カード + 投票内訳 + ロスター） |
+| #310 | ゲーム一覧画面 |
+| #311 | エージェント詳細画面（collapsible panes） |
+
+### Milestone 2（次 Sprint）
+`python main.py` のログを実際にブラウザで観戦できる状態。構成 Issue: #312 / #313 / #314
+
+### 将来フェーズ
+- #315: FastAPI + WebSocket バックエンド
+- #316: モバイルアプリ（React Native）
 
 ## 優先度の価値観
 

--- a/tests/TestStrategy.md
+++ b/tests/TestStrategy.md
@@ -291,3 +291,122 @@ Missing 行を発見
 | 実LLM API呼び出し（Live Integration） | APIコスト・Flakyリスクを避けるため。`MagicMock` で代替 |
 | LLM出力の品質・整合性検証 | Issue #45（promptfoo導入）で別途対応予定 |
 | UIのターミナル描画（Visual Regression） | 保守コストが高いため目視確認に留める |
+
+---
+
+## 9. Frontend Testing（`frontend/`）
+
+`frontend/` 配下の JS/JSX コードについても §1〜§8 の原則を適用する。
+言語・ツールが異なるだけで、**SUT-first・Mockポリシー・カバレッジ判断フロー**は同じ。
+本章では JS 固有の事情（採用ツール・段階導入方針・ファイル配置）を補足する。
+
+### 9.1 段階導入方針
+
+Web UI は段階的に複雑化するため、テスト基盤も段階的に導入する。
+**先回りでテスト基盤を整えると、スタブから実データへの差し替えで陳腐化する**ため避ける。
+
+| Sprint | 範囲 | 導入するテスト |
+|---|---|---|
+| Milestone 1（#308〜#311） | スタブデータの描画 | **なし**（AC をスクショで確認） |
+| Milestone 2（#312/#318/#319/#314） | 実データ接続・ロジック追加 | **Vitest によるユニットテスト**（純粋関数のみ） |
+| #315 以降（FastAPI 化） | WebSocket・状態管理・認証 | **コンポーネントテスト + E2E**（React Testing Library + Playwright） |
+
+#### 各段階で何をテストするか
+
+**Milestone 1**: テスト不要。
+- 大半が見た目・スタブ描画。コンポーネントテストを書いても「`<img>` の `src` 属性が正しい」程度しか検証できず、AC のスクショ確認の方が情報量が多い。
+- スタブから実データに差し替えるとロジックが大きく変わり、Milestone 1 で書いたテストはすぐ陳腐化する。
+- 例外: `Avatar` の「PNG が無いキャラはモノグラムにフォールバック」のような分岐ロジックがあれば、それだけは書いてよい。
+
+**Milestone 2**: `parseGameData.js` のような **純粋関数のみ** ユニットテストを書く。
+- 入出力が明確で陳腐化しにくい。
+- 実ログ（`design/proposal/source_logs/` や `state_archive/{session}/`）をフィクスチャとして使う。
+
+**#315 以降**: コンポーネント・E2E を本格導入する。
+- WebSocket イベントの順序・再接続、認証フロー、マルチタブ動作などはテストなしでは品質保証できない。
+
+### 9.2 採用ツール
+
+| 種別 | ツール | 用途 |
+|---|---|---|
+| Unit / 純粋関数 | **Vitest** | Vite と統合された高速テストランナー。Jest 互換 API |
+| コンポーネント | **React Testing Library**（#315 以降） | DOM 操作ベースでユーザー視点の動作を検証 |
+| E2E | **Playwright**（#315 以降） | 実ブラウザでの操作シナリオ検証 |
+| WebSocket Mock | **mock-socket** 等（#315 以降） | WS 接続のテスト |
+
+### 9.3 ファイル配置
+
+JS のテストは Python と同じ `tests/` 配下ではなく、**`frontend/` 内にコロケーション**する。
+
+```text
+frontend/
+├── src/
+│   ├── lib/
+│   │   ├── parseGameData.js
+│   │   └── parseGameData.test.js     # コロケーション
+│   ├── components/
+│   │   ├── Avatar.jsx
+│   │   └── Avatar.test.jsx           # コロケーション（#315 以降）
+│   └── ...
+└── tests/                            # E2E（Playwright）はここ（#315 以降）
+    └── e2e/
+```
+
+**理由**:
+- Vitest は `*.test.js` をデフォルトで拾うため設定が単純
+- ソースとテストが隣り合うことで参照しやすく、削除忘れも防げる
+- E2E だけは `frontend/tests/e2e/` に分離（複数コンポーネントを跨ぐため）
+
+### 9.4 docstring 規約（JS 版）
+
+§3 の規約を JS の慣習（JSDoc）に合わせて適用する。
+
+```js
+/**
+ * SUT: parseGameData()
+ * Mock: なし（design/proposal/source_logs/ の実ログを fixture に使用）
+ * Level: unit
+ * Objective: JSONL 形式のログを { events, agents } の GameData 型に変換できること。
+ */
+test('parses public_log.jsonl into events array', () => {
+  const result = parseGameData(fixtures.publicLog);
+  expect(result.events).toHaveLength(42);
+});
+```
+
+### 9.5 Mock 使用ポリシー（JS 版）
+
+§4 の3分類（Required / Forbidden / Conditional）はそのまま JS にも適用する。
+
+#### Required（モック必須）
+- `fetch()` / WebSocket の外部呼び出し（実通信は Flaky）
+- `Date.now()` / `Math.random()`（非決定要素）
+
+#### Forbidden（モック禁止 = 実物を使う）
+
+JS 側でも、**Python と JS の境界で受け渡される契約データ**は実物を使う。
+
+| 型 | ファイル | 契約の相手 |
+|---|---|---|
+| `GameData` | `frontend/src/lib/parseGameData.js`（型定義） | Python LogWriter（producer）↔ React 画面（consumer） |
+| `PublicEvent` | 同上 | 同上 |
+
+これらは Python 側の `LogEvent`（`src/domain/event.py`、Mock-Policy: Forbidden）と 1:1 対応する境界型。
+テストでは `design/proposal/source_logs/` や実ログを fixture として使い、合成しない。
+
+#### Conditional
+上記以外のオブジェクトはデフォルトで Conditional 扱い。
+
+### 9.6 カバレッジ判断フロー（JS 版）
+
+§7 の3分類チェック（A: 内部不変条件 / B: 外部境界フォールバック / C: テスト不可）はそのまま適用する。
+カバレッジ計測は Vitest の `--coverage` オプションを使う（v8 / istanbul）。
+
+### 9.7 CI 統合
+
+**Milestone 2 以降**:
+- `frontend/package.json` に `"test": "vitest run"` スクリプトを追加
+- `.github/workflows/ci.yml` に JS テスト job を追加（Node のセットアップ + `npm ci` + `npm test`）
+- Python の pytest job と並列実行する
+
+CI 統合は #318 の AC に含める（`npm test` がコマンド一発で実行できること）。


### PR DESCRIPTION
## Summary

- `Architecture.md`: `frontend/` ディレクトリ構成と JS/Python ファイルベース連携方針（§1, §2.3）を追加
- `DetailDesign.md`: `frontend/` セクション追加（技術スタック・ディレクトリ・GameData 契約・viewerMode）
- `project-discipline.md`: Sprint Goal を Web UI Milestone 1 に更新。Milestone 1/2 の Issue 一覧と将来フェーズを追記
- `Ideas.md`: #27 を #308〜#316 に置き換え

## Test plan

- [ ] ドキュメントのリンク・表が正しく表示される
- [ ] `pytest` / `ruff` パス（コード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)