### PR TITLE
feat(frontend): implement agent detail screen

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -18,7 +18,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#311 | enhancement | 🔴 | 3 | Agent detail screen | エージェント詳細画面、collapsible panes |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 1/2 横串） |
 
 ### Milestone 2（実データ観戦）

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import SpectatorScreen from './screens/SpectatorScreen.jsx';
 import GameListScreen from './screens/GameListScreen.jsx';
+import AgentDetailScreen from './screens/AgentDetailScreen.jsx';
 
 const SCREENS = {
   list: GameListScreen,
   spectator: SpectatorScreen,
+  agent: AgentDetailScreen,
 };
 
 export default function App() {

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -1,0 +1,338 @@
+import { useState } from 'react';
+import Avatar from '../components/Avatar.jsx';
+import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
+import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
+import { ROLES } from '../lib/constants.js';
+import {
+  ALL_AGENTS, DEAD_AGENTS, ROLE_ASSIGNMENT,
+  AGENT_BLURB, AGENT_STATS, THOUGHTS, NIGHT_ACTIONS,
+  getSuspicionMatrix,
+} from '../../stub/agentDetail.js';
+import styles from './AgentDetailScreen.module.css';
+
+const TABS = ['概要', '推論ログ', '疑い・信頼', '夜の行動', '過去の戦績'];
+
+// --- 左ペイン ---
+function LeftPane({ current, onPick }) {
+  const alive = ALL_AGENTS.filter(n => !DEAD_AGENTS.has(n));
+  const dead  = ALL_AGENTS.filter(n =>  DEAD_AGENTS.has(n));
+
+  return (
+    <>
+      <div className={styles.pickerHead}>
+        <span className={styles.pickerTitle}>第13回 桜霞 · 全{ALL_AGENTS.length}名</span>
+        <span className={styles.pickerCount}>{alive.length} alive · {dead.length} dead</span>
+      </div>
+      <div className={styles.agentPicker}>
+        {ALL_AGENTS.map(n => {
+          const role  = ROLE_ASSIGNMENT[n];
+          const r     = ROLES[role];
+          const isDead = DEAD_AGENTS.has(n);
+          return (
+            <div
+              key={n}
+              className={`${styles.pick} ${current === n ? styles.pickOn : ''} ${isDead ? styles.pickDead : ''}`}
+              style={{ '--r-color': r?.color }}
+              onClick={() => onPick(n)}
+            >
+              <Avatar name={n} role={role} size="sm" dead={isDead} />
+              <div className={styles.who}>
+                <span className={styles.pickName}>{n}</span>
+                <span className={styles.pickRole}>{r?.ja}</span>
+              </div>
+              <span className={styles.statusDot} />
+            </div>
+          );
+        })}
+        <div className={styles.sectionLabel} style={{ marginTop: 12 }}>並べ替え</div>
+        <div style={{ padding: '0 6px', display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <button className={styles.sortBtn}>発言数 ↓</button>
+          <button className={styles.sortBtn}>容疑度 ↓</button>
+          <button className={styles.sortBtn}>役職別</button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// --- 中央: ヒーロー ---
+function AgentHero({ agent }) {
+  const role  = ROLE_ASSIGNMENT[agent];
+  const r     = ROLES[role];
+  const stats = AGENT_STATS[agent] || {};
+  const winPct = stats.games ? Math.round(stats.wins / stats.games * 100) : 0;
+
+  return (
+    <div className={styles.agentHero} style={{ '--r-color': r?.color }}>
+      <Avatar name={agent} role={role} highlight />
+      <div className={styles.heroInfo}>
+        <h1>{agent}</h1>
+        <div className={styles.heroSub}>
+          <span className={styles.heroRoleLabel}>{r?.ja}</span>
+          <span>所属: <strong style={{ color: 'var(--tx-2)' }}>{r?.team === 'wolf' ? '人狼陣営' : '村人陣営'}</strong></span>
+          <span>第13回・桜霞村</span>
+          <span style={{ color: DEAD_AGENTS.has(agent) ? 'var(--dead)' : 'var(--alive)' }}>
+            {DEAD_AGENTS.has(agent) ? '死亡' : '生存中 · Day 2'}
+          </span>
+        </div>
+        <div className={styles.heroBlurb}>「{AGENT_BLURB[agent] || '—'}」</div>
+      </div>
+      <div className={styles.heroStats}>
+        <div className={styles.heroStat}>
+          <div className={styles.statNum}>{winPct}%</div>
+          <div className={styles.statLabel}>勝率 ({stats.games}戦)</div>
+        </div>
+        <div className={styles.heroStat}>
+          <div className={styles.statNum}>{stats.speeches}</div>
+          <div className={styles.statLabel}>本村発言</div>
+        </div>
+        <div className={styles.heroStat}>
+          <div className={styles.statNum} style={{ color: 'var(--alive)' }}>+{stats.cheers}</div>
+          <div className={styles.statLabel}>応援スコア</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- タブコンテンツ: 概要 ---
+function TabOverview({ agent }) {
+  const thoughts = (THOUGHTS[agent] || []).slice(0, 2);
+  return (
+    <>
+      <div className={styles.panel}>
+        <h3>現在の目標 <small>Day 2 議論フェーズ</small></h3>
+        <div className={styles.goalLine}>
+          真の占い師として認知を取りつつ、Kai を確実に処刑へ追い込む。Ren の偽占いを論理的に崩す。
+        </div>
+      </div>
+      {thoughts.length > 0 && (
+        <div className={styles.panel}>
+          <h3>直近の推論 <small>{thoughts.length} 件 · spectator限定</small></h3>
+          {thoughts.map((t, i) => (
+            <div className={styles.thought} key={i}>
+              <div className={styles.thoughtHead}>
+                <strong>D{t.day} #{t.speechId} 発言前の思考</strong>
+                <span className={styles.thoughtTs}>{(8 + t.speechId * 2) % 24}:{String((t.speechId * 13) % 60).padStart(2, '0')}</span>
+              </div>
+              <div className={styles.thoughtBody}>{t.text.slice(0, 180)}{t.text.length > 180 ? '…' : ''}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+// --- タブコンテンツ: 推論ログ ---
+function TabThoughts({ agent }) {
+  const thoughts = THOUGHTS[agent] || [];
+  if (thoughts.length === 0) {
+    return <div style={{ color: 'var(--tx-4)', fontSize: 13 }}>推論ログなし（public モード）</div>;
+  }
+  return (
+    <div className={styles.panel}>
+      <h3>推論ログ <small>{thoughts.length} 件 · spectator限定</small></h3>
+      {thoughts.map((t, i) => (
+        <div className={styles.thought} key={i}>
+          <div className={styles.thoughtHead}>
+            <strong>D{t.day} #{t.speechId} 発言前の思考</strong>
+            <span className={styles.thoughtTs}>{(8 + t.speechId * 2) % 24}:{String((t.speechId * 13) % 60).padStart(2, '0')}</span>
+          </div>
+          <div className={styles.thoughtBody}>{t.text}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// --- タブコンテンツ: 疑い・信頼 ---
+function TabSuspicion({ agent }) {
+  const matrix = getSuspicionMatrix(agent).slice(0, 8);
+  return (
+    <div className={styles.panel}>
+      <h3>疑い度マトリクス <small>{agent} 視点</small></h3>
+      <div className={styles.matrix}>
+        <div className={styles.matrixHead}>対象</div>
+        <div className={styles.matrixHead}>疑い ←→ 信頼</div>
+        <div className={styles.matrixHead}>疑</div>
+        <div className={styles.matrixHead}>信</div>
+        {matrix.map(m => (
+          <MatrixRow key={m.name} m={m} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// --- タブコンテンツ: 夜の行動 ---
+function TabNightActions({ agent }) {
+  const actions = NIGHT_ACTIONS[agent] || [];
+  if (actions.length === 0) {
+    return <div style={{ color: 'var(--tx-4)', fontSize: 13 }}>夜の行動なし（村人系役職）</div>;
+  }
+  return (
+    <div className={styles.panel}>
+      <h3>夜の行動</h3>
+      {actions.map((a, i) => <NightRow key={i} a={a} />)}
+    </div>
+  );
+}
+
+// --- タブコンテンツ: 過去の戦績 ---
+function TabHistory({ agent }) {
+  const stats = AGENT_STATS[agent] || {};
+  const records = [
+    { game: 13, role: 'Seer',     result: true,  village: '桜霞' },
+    { game: 12, role: 'Villager', result: false, village: '蒼霧' },
+    { game: 11, role: 'Werewolf', result: true,  village: '暁閑' },
+    { game: 10, role: 'Knight',   result: true,  village: '朱峰' },
+    { game:  9, role: 'Medium',   result: false, village: '玄空' },
+  ];
+  return (
+    <div className={styles.panel}>
+      <h3>過去の戦績 <small>通算 {stats.games} 戦 {stats.wins} 勝</small></h3>
+      {records.map((rec, i) => {
+        const r = ROLES[rec.role];
+        return (
+          <div key={i} className={styles.recordRow} style={{ '--r-color': r?.color }}>
+            <span className={styles.recordNum}>#{rec.game}</span>
+            <span style={{ color: 'var(--tx-3)', fontSize: 11 }}>{rec.village}</span>
+            <span className={styles.recordRole}>{r?.ja}</span>
+            <span className={`${styles.recordResult} ${rec.result ? styles.win : styles.lose}`}>
+              {rec.result ? '勝利' : '敗北'}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- 共通パーツ: 夜の行動行 ---
+function NightRow({ a }) {
+  const resultClass = a.result === 'black' ? styles.resultBlack
+    : a.result === 'white' ? styles.resultWhite
+    : styles.resultSafe;
+  const resultLabel = a.result === 'black' ? '黒'
+    : a.result === 'white' ? '白'
+    : a.result === 'blocked' ? '護衛成功'
+    : '—';
+
+  return (
+    <div className={styles.nightRow}>
+      <div className={styles.nightDay}>D{a.day}{a.phase}</div>
+      <div>
+        <div className={styles.nightAction}>{a.action}</div>
+        <div className={styles.nightTarget}>
+          <Avatar name={a.target} size="xs" />
+          <span>{a.target}</span>
+        </div>
+      </div>
+      <div className={`${styles.nightResult} ${resultClass}`}>{resultLabel}</div>
+    </div>
+  );
+}
+
+// --- 共通パーツ: マトリクス行 ---
+function MatrixRow({ m }) {
+  return (
+    <>
+      <div className={styles.matrixName}>
+        <Avatar name={m.name} size="xs" />
+        {m.name}
+      </div>
+      <div className={styles.dualBar}>
+        <div className={styles.barWrap}>
+          <i className={styles.barFill} style={{ width: `${m.suspicion}%` }} />
+        </div>
+        <div className={`${styles.barWrap} ${styles.barTrust}`}>
+          <i className={styles.barFill} style={{ width: `${m.trust}%` }} />
+        </div>
+      </div>
+      <div className={styles.matrixNum} style={{ color: 'var(--danger)' }}>{m.suspicion}</div>
+      <div className={styles.matrixNum} style={{ color: 'var(--info)' }}>{m.trust}</div>
+    </>
+  );
+}
+
+// --- 右ペイン ---
+function RightPane({ agent }) {
+  const matrix  = getSuspicionMatrix(agent).slice(0, 8);
+  const actions = NIGHT_ACTIONS[agent] || [];
+
+  return (
+    <div className={styles.rightInner}>
+      <div className={styles.panel}>
+        <h3>疑い度マトリクス</h3>
+        <div className={styles.matrix}>
+          <div className={styles.matrixHead}>対象</div>
+          <div className={styles.matrixHead}>疑い ←→ 信頼</div>
+          <div className={styles.matrixHead}>疑</div>
+          <div className={styles.matrixHead}>信</div>
+          {matrix.map(m => <MatrixRow key={m.name} m={m} />)}
+        </div>
+      </div>
+      {actions.length > 0 && (
+        <div className={styles.panel}>
+          <h3>夜の行動</h3>
+          {actions.map((a, i) => <NightRow key={i} a={a} />)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// === メイン画面 ===
+export default function AgentDetailScreen() {
+  const [agent, setAgent] = useState('Nox');
+  const [tab, setTab]     = useState(0);
+
+  const role = ROLE_ASSIGNMENT[agent];
+  const r    = ROLES[role];
+
+  const tabContent = [
+    <TabOverview     agent={agent} />,
+    <TabThoughts     agent={agent} />,
+    <TabSuspicion    agent={agent} />,
+    <TabNightActions agent={agent} />,
+    <TabHistory      agent={agent} />,
+  ];
+
+  return (
+    <div className={styles.frame}>
+      <TopBar crumbs={[
+        { label: 'r/agent-jinrou' },
+        { label: '第13回 桜霞' },
+        { label: agent },
+      ]}>
+        <TopBarBtn><span className={topBarStyles.liveDot} /> LIVE観戦中</TopBarBtn>
+        <TopBarBtn>⤓ プロファイルJSON</TopBarBtn>
+        <TopBarBtn primary>★ ウォッチ</TopBarBtn>
+      </TopBar>
+
+      <ThreePaneLayout
+        left={<LeftPane current={agent} onPick={setAgent} />}
+        right={<RightPane agent={agent} />}
+      >
+        <div className={styles.mainPane}>
+          <AgentHero agent={agent} />
+          <div className={styles.tabs}>
+            {TABS.map((t, i) => (
+              <button
+                key={t}
+                className={`${styles.tab} ${tab === i ? styles.tabOn : ''}`}
+                onClick={() => setTab(i)}
+              >
+                {t}{i === 1 && (THOUGHTS[agent]?.length ? ` (${THOUGHTS[agent].length})` : '')}
+              </button>
+            ))}
+          </div>
+          <div className={styles.tabContent} style={{ '--r-color': r?.color }}>
+            {tabContent[tab]}
+          </div>
+        </div>
+      </ThreePaneLayout>
+    </div>
+  );
+}

--- a/frontend/src/screens/AgentDetailScreen.module.css
+++ b/frontend/src/screens/AgentDetailScreen.module.css
@@ -1,0 +1,429 @@
+/* AgentDetailScreen — CSS Modules */
+
+.frame {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+/* ===== 左ペイン: エージェント一覧 ===== */
+
+.pickerHead {
+  padding: 14px 14px 8px;
+  border-bottom: 1px solid var(--bd-soft);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.pickerTitle {
+  font-family: var(--serif);
+  font-size: 12px;
+  color: var(--tx-2);
+  letter-spacing: 0.05em;
+}
+
+.pickerCount {
+  font-size: 10px;
+  color: var(--tx-4);
+  font-family: var(--mono);
+}
+
+.agentPicker {
+  padding: 8px 6px 24px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.pick {
+  display: grid;
+  grid-template-columns: 32px 1fr 8px;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: var(--r1);
+  cursor: pointer;
+  font-size: 12.5px;
+  border-left: 2px solid transparent;
+  margin-bottom: 2px;
+}
+
+.pick:hover { background: var(--bg-2); }
+.pickOn { background: var(--bg-2); border-left-color: var(--acc); }
+.pickDead { opacity: 0.55; }
+
+.who {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.pickName {
+  font-family: var(--serif);
+  font-weight: 600;
+  color: var(--tx);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pickDead .pickName { text-decoration: line-through; }
+
+.pickRole {
+  font-size: 10px;
+  color: var(--r-color, var(--tx-3));
+  font-family: var(--serif);
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--alive);
+}
+
+.pickDead .statusDot { background: var(--tx-4); }
+
+.sectionLabel {
+  font-size: 10px;
+  color: var(--tx-4);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 8px 4px;
+}
+
+.sortBtn {
+  width: 100%;
+  text-align: left;
+  padding: 5px 8px;
+  font-size: 11px;
+  color: var(--tx-3);
+  background: none;
+  border: none;
+  border-radius: var(--r1);
+  cursor: pointer;
+  font-family: var(--sans);
+  margin-bottom: 2px;
+}
+
+.sortBtn:hover { background: var(--bg-2); color: var(--tx); }
+
+/* ===== 中央ペイン ===== */
+
+.mainPane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.agentHero {
+  background: linear-gradient(180deg,
+    color-mix(in oklab, var(--r-color, #333) 14%, var(--bg-1)),
+    var(--bg-1)
+  );
+  border-bottom: 1px solid var(--bd);
+  padding: 24px 36px 20px;
+  display: grid;
+  grid-template-columns: 120px 1fr auto;
+  gap: 24px;
+  align-items: end;
+}
+
+.heroInfo h1 {
+  font-family: var(--serif);
+  font-size: 32px;
+  margin: 0 0 4px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.heroSub {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  color: var(--tx-3);
+  font-size: 12px;
+  flex-wrap: wrap;
+}
+
+.heroRoleLabel {
+  font-family: var(--serif);
+  font-size: 14px;
+  color: var(--r-color);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border: 1px solid color-mix(in oklab, var(--r-color) 50%, transparent);
+  padding: 1px 8px;
+  border-radius: 2px;
+  background: color-mix(in oklab, var(--r-color) 10%, transparent);
+}
+
+.heroBlurb {
+  margin-top: 12px;
+  color: var(--tx-2);
+  font-size: 14px;
+  line-height: 1.7;
+  max-width: 560px;
+  font-family: var(--serif);
+  font-weight: 500;
+}
+
+.heroStats {
+  display: flex;
+  gap: 18px;
+}
+
+.heroStat { text-align: right; }
+
+.statNum {
+  font-family: var(--mono);
+  font-size: 24px;
+  color: var(--tx);
+  font-weight: 500;
+}
+
+.statLabel {
+  font-size: 10px;
+  color: var(--tx-3);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* ===== タブ ===== */
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 36px;
+  border-bottom: 1px solid var(--bd);
+  background: var(--bg-1);
+  flex-shrink: 0;
+}
+
+.tab {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: var(--tx-3);
+  border-bottom: 2px solid transparent;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  cursor: pointer;
+  background: none;
+  font-family: var(--sans);
+  white-space: nowrap;
+}
+
+.tab:hover { color: var(--tx-2); }
+.tabOn { color: var(--tx); border-bottom-color: var(--acc); }
+
+/* ===== タブコンテンツ ===== */
+
+.tabContent {
+  padding: 20px 36px 60px;
+}
+
+.panel {
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r2);
+  padding: 16px 18px;
+  margin-bottom: 16px;
+}
+
+.panel h3 {
+  font-family: var(--serif);
+  font-size: 14px;
+  margin: 0 0 12px;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.panel h3 small {
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-3);
+  letter-spacing: 0.1em;
+  margin-left: auto;
+  font-weight: 400;
+}
+
+.goalLine {
+  font-family: var(--serif);
+  font-size: 15px;
+  color: var(--tx);
+  line-height: 1.7;
+  border-left: 3px solid var(--acc);
+  padding: 4px 12px;
+  background: rgba(240, 199, 95, 0.04);
+}
+
+/* 推論ログ */
+.thought {
+  border-left: 2px solid var(--bd);
+  padding: 8px 12px 8px 14px;
+  margin-bottom: 10px;
+  position: relative;
+}
+
+.thought::before {
+  content: '';
+  position: absolute;
+  left: -5px;
+  top: 14px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--bg-3);
+  border: 2px solid var(--bd);
+}
+
+.thoughtHead {
+  font-size: 11px;
+  color: var(--tx-3);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.thoughtHead strong { color: var(--tx-2); }
+
+.thoughtTs {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--tx-4);
+  margin-left: auto;
+}
+
+.thoughtBody {
+  font-size: 13px;
+  color: var(--tx);
+  line-height: 1.65;
+}
+
+/* 夜の行動（中央タブ） */
+.nightRow {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--bd-soft);
+  font-size: 12px;
+  align-items: center;
+}
+
+.nightRow:last-child { border-bottom: none; }
+
+.nightDay {
+  font-family: var(--mono);
+  color: var(--tx-4);
+  font-size: 10px;
+}
+
+.nightAction { color: var(--tx-2); margin-bottom: 2px; }
+
+.nightTarget {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.nightTarget span { color: var(--tx); font-family: var(--serif); }
+
+.nightResult {
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.resultBlack { color: var(--danger); }
+.resultWhite { color: var(--info); }
+.resultSafe  { color: var(--alive); }
+
+/* 過去の戦績 */
+.recordRow {
+  display: flex;
+  gap: 16px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--bd-soft);
+  font-size: 12px;
+  align-items: center;
+}
+
+.recordRow:last-child { border-bottom: none; }
+.recordNum   { font-family: var(--mono); color: var(--tx-4); width: 28px; }
+.recordRole  { font-family: var(--serif); color: var(--r-color, var(--tx-3)); width: 60px; }
+.recordResult { font-family: var(--mono); font-size: 11px; }
+.win  { color: var(--alive); }
+.lose { color: var(--danger); }
+
+/* ===== 右ペイン: 疑い度マトリクス ===== */
+
+.rightInner {
+  padding: 14px 14px 30px;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.matrix {
+  display: grid;
+  grid-template-columns: 80px 1fr 38px 38px;
+  gap: 4px 8px;
+  font-size: 12px;
+  align-items: center;
+}
+
+.matrixHead {
+  font-size: 10px;
+  color: var(--tx-3);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--bd-soft);
+  padding-bottom: 4px;
+}
+
+.matrixName {
+  color: var(--tx);
+  font-weight: 500;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.dualBar {
+  display: flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.barWrap {
+  flex: 1;
+  height: 6px;
+  background: var(--bg-3);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.barWrap:first-child { transform: scaleX(-1); }
+
+.barFill {
+  display: block;
+  height: 100%;
+  background: var(--danger);
+  border-radius: 3px;
+}
+
+.barTrust .barFill { background: var(--info); }
+
+.matrixNum {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-align: right;
+}

--- a/frontend/stub/agentDetail.js
+++ b/frontend/stub/agentDetail.js
@@ -1,0 +1,75 @@
+// スタブデータ — Issue #311 Agent detail screen
+// spectator.js と同じエージェント・役職割り当てを使用
+
+import { ROLE_ASSIGNMENT } from './spectator.js';
+export { ROLE_ASSIGNMENT };
+
+// エージェントリスト（順序: 生存優先、死亡者は末尾）
+export const ALL_AGENTS = ['Nox','Mira','Ren','Kai','Shiki','Rei','Sable','Sera','Kael','Sora','Toma'];
+export const DEAD_AGENTS = new Set(['Sora', 'Toma']);
+
+// エージェントごとの1行プロフィール（blurb）
+// TODO: config/agents.json の persona_short フィールドに移行予定（GameData ギャップ #312）
+export const AGENT_BLURB = {
+  Nox:   '静かな夜のように、相手の言葉のほつれを見つける。',
+  Mira:  '直感と論理の交差点に立ち、誰よりも早く嘘を嗅ぎ取る。',
+  Ren:   '軽やかな笑顔の裏に、緻密な計算が走り続けている。',
+  Kai:   '沈黙を武器に、最小の言葉で最大の混乱を生む。',
+  Shiki: '過去の言葉をすべて記憶し、矛盾を静かに暴く。',
+  Rei:   '仲間を守るために、自分が盾になることを厭わない。',
+  Sable: '流れを読み、空気を変える一言を知っている。',
+  Sera:  '誰もが信じる笑顔の下で、狩りの計画が動く。',
+  Kael:  '嘘の上に嘘を積み重ね、城を築く建築家。',
+  Sora:  '太陽のように人を照らし、嵐のようにかき乱す。',
+  Toma:  '正直すぎる言葉が、時に凶器になることを知らない。',
+};
+
+// エージェントごとの通算戦績（スタブ）
+export const AGENT_STATS = {
+  Nox:   { games: 47, wins: 32, speeches: 9,  cheers: 312 },
+  Mira:  { games: 38, wins: 24, speeches: 12, cheers: 198 },
+  Ren:   { games: 52, wins: 28, speeches: 14, cheers: 445 },
+  Kai:   { games: 41, wins: 20, speeches: 6,  cheers: 87  },
+  Shiki: { games: 33, wins: 22, speeches: 10, cheers: 261 },
+  Rei:   { games: 29, wins: 18, speeches: 11, cheers: 153 },
+  Sable: { games: 44, wins: 25, speeches: 8,  cheers: 175 },
+  Sera:  { games: 36, wins: 19, speeches: 7,  cheers: 99  },
+  Kael:  { games: 31, wins: 14, speeches: 13, cheers: 221 },
+  Sora:  { games: 26, wins: 15, speeches: 5,  cheers: 134 },
+  Toma:  { games: 22, wins: 10, speeches: 4,  cheers: 56  },
+};
+
+// 推論ログ（spectator 限定 thought）
+export const THOUGHTS = {
+  Nox: [
+    { day: 1, speechId: 3, text: 'Kai の初日の沈黙が気になる。情報を集めながら様子を見る。占い先は Kai を最優先にしたい。' },
+    { day: 2, speechId: 1, text: 'Ren が占い師 CO してきた。自分と競合する。Ren の昨日の行動パターンを振り返ると明らかに人狼側の情報収集に見える。対抗 CO するべきか。' },
+    { day: 2, speechId: 4, text: 'Kai を黒と出た。この情報を出すタイミングは今しかない。Ren の偽占いを崩す絶好のチャンスだ。' },
+    { day: 3, speechId: 2, text: 'Ren が処刑された。これで偽占いは消えた。次は Sera を追う。Kai の動向が鍵になる。' },
+  ],
+};
+
+// 夜の行動ログ
+export const NIGHT_ACTIONS = {
+  Nox: [
+    { day: 1, phase: 'N', action: '占いを実行', target: 'Kai',  result: 'black' },
+    { day: 2, phase: 'N', action: '占いを実行', target: 'Sera', result: 'black' },
+  ],
+  Rei: [
+    { day: 1, phase: 'N', action: '護衛を実行', target: 'Nox',   result: 'safe'    },
+    { day: 2, phase: 'N', action: '護衛を実行', target: 'Shiki', result: 'blocked' },
+  ],
+};
+
+// 疑い・信頼スコア（選択エージェントから見た各エージェントへの双方向）
+export function getSuspicionMatrix(agent) {
+  const others = ALL_AGENTS.filter(n => n !== agent);
+  return others.map(n => {
+    const seed = [...(agent + n)].reduce((s, ch) => s + ch.charCodeAt(0), 0);
+    return {
+      name:      n,
+      suspicion: (seed * 17 + 7) % 101,
+      trust:     (seed * 13 + 30) % 101,
+    };
+  }).sort((a, b) => b.suspicion - a.suspicion);
+}


### PR DESCRIPTION
## Summary
- AgentDetailScreen を新規実装（3ペイン固定幅レイアウト）
- 左ペイン: エージェント一覧（死亡者は斜線・薄暗、クリックで切り替え）
- 中央: ヒーロー（アバター・役職・1行プロフィール・統計）＋ 5タブ（概要/推論ログ/疑い・信頼/夜の行動/過去の戦績）
- 右ペイン: 疑い度マトリクス（双方向バー）＋ 夜の行動ログ
- TopBar / ThreePaneLayout / Avatar 共通コンポーネントを流用
- collapse は別 Issue に分離（今回は固定幅）

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` 356 passed
- [ ] Nox 選択時: ヒーロー・推論ログ・マトリクスが正常表示
- [ ] Toma（死亡・推論なし）選択時: 死亡表示・「推論ログなし」が表示
- [ ] タブ切り替えで概要/推論ログが切り替わる

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)