### PR TITLE
feat: add game creation form to GameListScreen

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -18,7 +18,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#329 | enhancement | 🔴 | 2 | Add new game creation form to GameListScreen | リスト上部にアコーディオン展開フォーム（人数選択・アバターピッカー・村名プリセット） |
 | yukkie/AgentVillage#328 | enhancement | 🔴 | 2 | Add collapsible side panes to all 3-pane screens | ThreePaneLayout に collapse 機能を追加し、全3画面で左右ペインを折りたたみ可能にする |
 | yukkie/AgentVillage#331 | tech-debt | 🔴 | 2 | Write frontend design document | Milestone 2 着手前に doc/FrontendDesign.md を新設（コンポーネント・CSS方針・画面遷移仕様） |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 1/2 横串） |

--- a/frontend/src/screens/GameListScreen.jsx
+++ b/frontend/src/screens/GameListScreen.jsx
@@ -2,10 +2,111 @@ import { useState } from 'react';
 import Avatar from '../components/Avatar.jsx';
 import TopBar, { TopBarBtn } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
-import { GAMES, TOP_AGENTS, COMMUNITY_POSTS } from '../../stub/gameList.js';
+import { GAMES, TOP_AGENTS, COMMUNITY_POSTS, VILLAGE_NAME_PRESETS } from '../../stub/gameList.js';
+import { AGENT_PALETTE } from '../lib/constants.js';
 import styles from './GameListScreen.module.css';
 
 const TABS = ['▶ 注目', '🔥 熱い議論', '🆕 新着', '完了'];
+const COUNTS = [5, 8, 11];
+const ALL_AGENTS = Object.keys(AGENT_PALETTE);
+
+function NewVillageForm() {
+  const [open, setOpen] = useState(false);
+  const [count, setCount] = useState(COUNTS[0]);
+  const [selected, setSelected] = useState(new Set());
+  const [villageName] = useState(
+    () => VILLAGE_NAME_PRESETS[Math.floor(Math.random() * VILLAGE_NAME_PRESETS.length)]
+  );
+
+  function toggleAgent(name) {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else if (next.size < count) {
+        next.add(name);
+      }
+      return next;
+    });
+  }
+
+  function handleCountChange(n) {
+    setCount(n);
+    setSelected(new Set());
+  }
+
+  const canCreate = selected.size === count;
+
+  return (
+    <div className={styles.newVillage}>
+      <button
+        className={`${styles.newVillageBtn} ${open ? styles.newVillageBtnOpen : ''}`}
+        onClick={() => setOpen(o => !o)}
+      >
+        <span className={styles.newVillagePlus}>{open ? '✕' : '＋'}</span>
+        新しい村を作る
+      </button>
+
+      {open && (
+        <div className={styles.newVillageForm}>
+          <div className={styles.formRow}>
+            <span className={styles.formLabel}>村名</span>
+            <span className={styles.villageName}>{villageName}</span>
+          </div>
+
+          <div className={styles.formRow}>
+            <span className={styles.formLabel}>人数</span>
+            <div className={styles.countBtns}>
+              {COUNTS.map(n => (
+                <button
+                  key={n}
+                  className={`${styles.countBtn} ${count === n ? styles.countBtnOn : ''}`}
+                  onClick={() => handleCountChange(n)}
+                >
+                  {n}人
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.formRow}>
+            <span className={styles.formLabel}>エージェント</span>
+            <span className={styles.selectHint}>{selected.size}/{count}人選択中</span>
+          </div>
+
+          <div className={styles.agentGrid}>
+            {ALL_AGENTS.map(name => {
+              const isSelected = selected.has(name);
+              const color = AGENT_PALETTE[name];
+              return (
+                <button
+                  key={name}
+                  className={`${styles.agentChip} ${isSelected ? styles.agentChipOn : ''}`}
+                  style={{ '--chip-c': color }}
+                  onClick={() => toggleAgent(name)}
+                  title={name}
+                >
+                  <Avatar name={name} size="sm" />
+                  <span className={styles.chipName}>{name}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className={styles.formFooter}>
+            <button
+              className={styles.createBtn}
+              disabled={!canCreate}
+              onClick={() => setOpen(false)}
+            >
+              村を作る
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 function filterGames(games, tab) {
   if (tab === '完了') return games.filter(g => !g.live);
@@ -186,6 +287,8 @@ export default function GameListScreen() {
 
       <ThreePaneLayout left={<LeftPane />} right={<RightPane />}>
         <div className={styles.listMain}>
+          <NewVillageForm />
+
           <div className={styles.listTabs}>
             {TABS.map(t => (
               <button

--- a/frontend/src/screens/GameListScreen.module.css
+++ b/frontend/src/screens/GameListScreen.module.css
@@ -363,3 +363,168 @@
   cursor: pointer;
 }
 .reminderBtn:hover { border-color: var(--tx-3); color: var(--tx); }
+
+/* === 新しい村を作るフォーム === */
+.newVillage {
+  margin-bottom: 14px;
+}
+
+.newVillageBtn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 16px;
+  background: transparent;
+  border: 1px dashed var(--bd);
+  border-radius: var(--r2);
+  color: var(--tx-3);
+  font-size: 13px;
+  font-family: var(--sans);
+  cursor: pointer;
+  width: 100%;
+  transition: border-color 120ms, color 120ms, background 120ms;
+}
+.newVillageBtn:hover {
+  border-color: var(--acc);
+  color: var(--tx);
+  background: color-mix(in oklab, var(--acc) 6%, transparent);
+}
+.newVillageBtnOpen {
+  border-color: var(--acc);
+  border-style: solid;
+  color: var(--tx);
+  background: color-mix(in oklab, var(--acc) 6%, transparent);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: none;
+}
+
+.newVillagePlus {
+  font-size: 15px;
+  line-height: 1;
+  color: var(--acc);
+}
+
+.newVillageForm {
+  border: 1px solid var(--acc);
+  border-top: none;
+  border-bottom-left-radius: var(--r2);
+  border-bottom-right-radius: var(--r2);
+  background: var(--bg-1);
+  padding: 16px;
+}
+
+.formRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.formLabel {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--tx-3);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  width: 72px;
+  flex: 0 0 72px;
+}
+
+.villageName {
+  font-family: var(--serif);
+  font-size: 14px;
+  color: var(--tx);
+  font-weight: 600;
+}
+
+.countBtns {
+  display: flex;
+  gap: 6px;
+}
+
+.countBtn {
+  height: 28px;
+  padding: 0 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd);
+  border-radius: var(--r1);
+  color: var(--tx-3);
+  font-size: 12px;
+  font-family: var(--sans);
+  cursor: pointer;
+  transition: border-color 100ms, color 100ms, background 100ms;
+}
+.countBtn:hover { border-color: var(--tx-3); color: var(--tx); }
+.countBtnOn {
+  border-color: var(--acc);
+  color: var(--acc);
+  background: color-mix(in oklab, var(--acc) 12%, var(--bg-2));
+  font-weight: 600;
+}
+
+.selectHint {
+  font-size: 11px;
+  color: var(--tx-3);
+  font-family: var(--mono);
+}
+
+.agentGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(52px, 1fr));
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.agentChip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 4px 5px;
+  border: 1px solid var(--bd);
+  border-radius: var(--r1);
+  background: var(--bg-2);
+  cursor: pointer;
+  opacity: 0.35;
+  transition: opacity 120ms, border-color 120ms, box-shadow 120ms;
+}
+.agentChip:hover { opacity: 0.65; }
+.agentChipOn {
+  opacity: 1;
+  border-color: var(--chip-c);
+  box-shadow: 0 0 0 1px var(--chip-c);
+}
+
+.chipName {
+  font-size: 10px;
+  color: var(--tx-2);
+  font-family: var(--sans);
+  text-align: center;
+  line-height: 1;
+}
+
+.formFooter {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.createBtn {
+  height: 34px;
+  padding: 0 20px;
+  background: var(--acc);
+  border: none;
+  border-radius: var(--r1);
+  color: #fff;
+  font-size: 13px;
+  font-family: var(--sans);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 120ms;
+}
+.createBtn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.createBtn:not(:disabled):hover { opacity: 0.85; }

--- a/frontend/stub/gameList.js
+++ b/frontend/stub/gameList.js
@@ -90,6 +90,12 @@ export const TOP_AGENTS = [
   { name: 'Mira', winRate: 58 },
 ];
 
+export const VILLAGE_NAME_PRESETS = [
+  '桜霞', '黎明の小径', '霜降る塔', '黒鏡の湖', '灰色の朝',
+  '暁の森', '夜霧の灯台', '蒼穹の丘', '残雪の庭', '星詠みの里',
+  '朱鷺色の夕', '月影の渚', '雪解けの道', '風薫る谷', '銀霧の廊',
+];
+
 export const COMMUNITY_POSTS = [
   { title: 'Kai の戦術ノート（Sera との連携）', votes: 312 },
   { title: '狂人勝利型に出る共通言い回し12選', votes: 198 },


### PR DESCRIPTION
## Summary
- GameListScreen 上部に「＋ 新しい村を作る」ボタンを追加、クリックでアコーディオン展開
- 村名プリセット（`VILLAGE_NAME_PRESETS`）からランダム表示、人数選択（5/8/11人）、アバターカードピッカーを実装
- アバターピッカーは既存の `Avatar` コンポーネント（`sm` サイズ）を再利用し、キャラアイコン画像 + 名前テキストの縦型カード表示
- 選択数が人数ちょうどになると「村を作る」ボタンが活性化（Milestone 1 モック: クリックで閉じるのみ）
- `src/` への変更なし

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` 356 passed パス
- [x] 「＋ 新しい村を作る」ボタンが一覧上部に表示される（Playwright 確認）
- [x] ボタンクリックでフォーム展開・再クリックで閉じる（Playwright 確認）
- [x] 人数変更で「N/M人選択中」が連動する（Playwright 確認）
- [x] アバターカードが暗め表示→クリックで明るく選択状態に切り替わる（Playwright 確認）
- [x] 選択数 = 人数で「村を作る」が活性化する（Playwright 確認）

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)