### PR TITLE
feat: add collapsible side panes to all 3-pane screens (#328)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -18,7 +18,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#328 | enhancement | 🔴 | 2 | Add collapsible side panes to all 3-pane screens | ThreePaneLayout に collapse 機能を追加し、全3画面で左右ペインを折りたたみ可能にする |
 | yukkie/AgentVillage#331 | tech-debt | 🔴 | 2 | Write frontend design document | Milestone 2 着手前に doc/FrontendDesign.md を新設（コンポーネント・CSS方針・画面遷移仕様） |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 1/2 横串） |
 

--- a/frontend/src/components/ThreePaneLayout.jsx
+++ b/frontend/src/components/ThreePaneLayout.jsx
@@ -1,14 +1,54 @@
+import { useState } from 'react';
 import styles from './ThreePaneLayout.module.css';
 
-/**
- * 共通3カラムレイアウト（左256px・中央flex・右360px）
- */
-export default function ThreePaneLayout({ left, right, children }) {
+export default function ThreePaneLayout({
+  left, right, children,
+  collapsibleLeft = false,
+  collapsibleRight = false,
+  leftLabel = '',
+  rightLabel = '',
+}) {
+  const [leftOpen, setLeftOpen] = useState(true);
+  const [rightOpen, setRightOpen] = useState(true);
+
+  const lcol = leftOpen ? '256px' : '32px';
+  const rcol = rightOpen ? '360px' : '32px';
+
   return (
-    <div className={styles.shell}>
-      <div className={styles.colLeft}>{left}</div>
+    <div className={styles.shell} style={{ '--lcol': lcol, '--rcol': rcol }}>
+      <div className={`${styles.colLeft} ${!leftOpen ? styles.collapsed : ''}`}>
+        <div className={styles.colContent}>{left}</div>
+        {collapsibleLeft && (
+          <button
+            className={`${styles.chevron} ${styles.chevronLeft}`}
+            onClick={() => setLeftOpen(o => !o)}
+            aria-label={leftOpen ? '左ペインを閉じる' : '左ペインを開く'}
+          >
+            {leftOpen ? '‹' : '›'}
+          </button>
+        )}
+        {collapsibleLeft && !leftOpen && leftLabel && (
+          <span className={styles.rail}>{leftLabel}</span>
+        )}
+      </div>
+
       <div className={styles.colCenter}>{children}</div>
-      <div className={styles.colRight}>{right}</div>
+
+      <div className={`${styles.colRight} ${!rightOpen ? styles.collapsed : ''}`}>
+        {collapsibleRight && (
+          <button
+            className={`${styles.chevron} ${styles.chevronRight}`}
+            onClick={() => setRightOpen(o => !o)}
+            aria-label={rightOpen ? '右ペインを閉じる' : '右ペインを開く'}
+          >
+            {rightOpen ? '›' : '‹'}
+          </button>
+        )}
+        {collapsibleRight && !rightOpen && rightLabel && (
+          <span className={styles.rail}>{rightLabel}</span>
+        )}
+        <div className={styles.colContent}>{right}</div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ThreePaneLayout.jsx
+++ b/frontend/src/components/ThreePaneLayout.jsx
@@ -18,15 +18,6 @@ export default function ThreePaneLayout({
     <div className={styles.shell} style={{ '--lcol': lcol, '--rcol': rcol }}>
       <div className={`${styles.colLeft} ${!leftOpen ? styles.collapsed : ''}`}>
         <div className={styles.colContent}>{left}</div>
-        {collapsibleLeft && (
-          <button
-            className={`${styles.chevron} ${styles.chevronLeft}`}
-            onClick={() => setLeftOpen(o => !o)}
-            aria-label={leftOpen ? '左ペインを閉じる' : '左ペインを開く'}
-          >
-            {leftOpen ? '‹' : '›'}
-          </button>
-        )}
         {collapsibleLeft && !leftOpen && leftLabel && (
           <span className={styles.rail}>{leftLabel}</span>
         )}
@@ -35,20 +26,33 @@ export default function ThreePaneLayout({
       <div className={styles.colCenter}>{children}</div>
 
       <div className={`${styles.colRight} ${!rightOpen ? styles.collapsed : ''}`}>
-        {collapsibleRight && (
-          <button
-            className={`${styles.chevron} ${styles.chevronRight}`}
-            onClick={() => setRightOpen(o => !o)}
-            aria-label={rightOpen ? '右ペインを閉じる' : '右ペインを開く'}
-          >
-            {rightOpen ? '›' : '‹'}
-          </button>
-        )}
         {collapsibleRight && !rightOpen && rightLabel && (
           <span className={styles.rail}>{rightLabel}</span>
         )}
         <div className={styles.colContent}>{right}</div>
       </div>
+
+      {collapsibleLeft && (
+        <button
+          className={`${styles.chevron} ${styles.chevronLeft}`}
+          style={{ left: 'calc(var(--lcol, 256px) - 8px)' }}
+          onClick={() => setLeftOpen(o => !o)}
+          aria-label={leftOpen ? '左ペインを閉じる' : '左ペインを開く'}
+        >
+          {leftOpen ? '‹' : '›'}
+        </button>
+      )}
+
+      {collapsibleRight && (
+        <button
+          className={`${styles.chevron} ${styles.chevronRight}`}
+          style={{ right: 'calc(var(--rcol, 360px) - 8px)' }}
+          onClick={() => setRightOpen(o => !o)}
+          aria-label={rightOpen ? '右ペインを閉じる' : '右ペインを開く'}
+        >
+          {rightOpen ? '›' : '‹'}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ThreePaneLayout.module.css
+++ b/frontend/src/components/ThreePaneLayout.module.css
@@ -3,11 +3,13 @@
 .shell {
   flex: 1;
   display: grid;
-  grid-template-columns: 256px 1fr 360px;
+  grid-template-columns: var(--lcol, 256px) 1fr var(--rcol, 360px);
+  transition: grid-template-columns 220ms ease;
   min-height: 0;
 }
 
 .colLeft {
+  position: relative;
   border-right: 1px solid var(--bd);
   background: var(--bg-1);
   display: flex;
@@ -23,9 +25,73 @@
 }
 
 .colRight {
+  position: relative;
   border-left: 1px solid var(--bd);
   background: var(--bg-1);
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+/* コンテンツ領域（collapse時に隠す） */
+.colContent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.collapsed .colContent {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+/* チェブロンボタン */
+.chevron {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 40px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd);
+  border-radius: var(--r1);
+  color: var(--tx-3);
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  transition: color 120ms, background 120ms;
+  padding: 0;
+  line-height: 1;
+}
+.chevron:hover {
+  color: var(--tx);
+  background: var(--bg-3);
+}
+
+.chevronLeft {
+  right: -10px;
+}
+
+.chevronRight {
+  left: -10px;
+}
+
+/* 縦書きラベル（collapse時） */
+.rail {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(90deg);
+  font-size: 10px;
+  color: var(--tx-4);
+  letter-spacing: 0.12em;
+  white-space: nowrap;
+  writing-mode: horizontal-tb;
+  pointer-events: none;
+  margin-top: 24px;
 }

--- a/frontend/src/components/ThreePaneLayout.module.css
+++ b/frontend/src/components/ThreePaneLayout.module.css
@@ -6,6 +6,7 @@
   grid-template-columns: var(--lcol, 256px) 1fr var(--rcol, 360px);
   transition: grid-template-columns 220ms ease;
   min-height: 0;
+  position: relative;
 }
 
 .colLeft {
@@ -14,7 +15,7 @@
   background: var(--bg-1);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .colCenter {
@@ -30,7 +31,7 @@
   background: var(--bg-1);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
 }
 
 /* コンテンツ領域（collapse時に隠す） */
@@ -40,6 +41,7 @@
   flex-direction: column;
   overflow: hidden;
   min-height: 0;
+  min-width: 0;
 }
 
 .collapsed .colContent {
@@ -52,33 +54,35 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  width: 20px;
-  height: 40px;
-  background: var(--bg-2);
-  border: 1px solid var(--bd);
+  width: 16px;
+  height: 48px;
+  background: var(--bg-3);
+  border: 1px solid var(--tx-4);
   border-radius: var(--r1);
-  color: var(--tx-3);
-  font-size: 14px;
+  color: var(--tx-2);
+  font-size: 16px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10;
-  transition: color 120ms, background 120ms;
+  transition: color 120ms, background 120ms, border-color 120ms;
   padding: 0;
   line-height: 1;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
 }
 .chevron:hover {
-  color: var(--tx);
-  background: var(--bg-3);
+  color: var(--acc);
+  background: var(--bg-4, color-mix(in oklab, var(--bg-3) 70%, white 30%));
+  border-color: var(--acc);
 }
 
 .chevronLeft {
-  right: -10px;
+  /* inline style で left を設定 */
 }
 
 .chevronRight {
-  left: -10px;
+  /* inline style で right を設定 */
 }
 
 /* 縦書きラベル（collapse時） */

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -312,6 +312,8 @@ export default function AgentDetailScreen() {
       </TopBar>
 
       <ThreePaneLayout
+        collapsibleLeft
+        collapsibleRight
         left={<LeftPane current={agent} onPick={setAgent} />}
         right={<RightPane agent={agent} />}
       >

--- a/frontend/src/screens/GameListScreen.jsx
+++ b/frontend/src/screens/GameListScreen.jsx
@@ -285,7 +285,7 @@ export default function GameListScreen() {
         <TopBarBtn primary>＋ 自分のbotを参加させる</TopBarBtn>
       </TopBar>
 
-      <ThreePaneLayout left={<LeftPane />} right={<RightPane />}>
+      <ThreePaneLayout collapsibleLeft collapsibleRight left={<LeftPane />} right={<RightPane />}>
         <div className={styles.listMain}>
           <NewVillageForm />
 

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -332,6 +332,8 @@ export default function SpectatorScreen() {
       </TopBar>
 
       <ThreePaneLayout
+        collapsibleLeft
+        collapsibleRight
         left={<LeftPane activeDay={activeDay} setDay={setActiveDay} />}
         right={<RightPane />}
       >


### PR DESCRIPTION
## Summary
- `ThreePaneLayout` に `collapsibleLeft` / `collapsibleRight` props を追加
- チェブロンボタン（`‹` / `›`）で左右ペインを独立して折りたたみ可能に
- CSS 変数 `--lcol` / `--rcol` で幅を制御し、220ms ease でアニメーション
- SpectatorScreen・GameListScreen・AgentDetailScreen の3画面すべてに適用

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（356 passed）
- [x] GameListScreen で左・右・両ペイン折りたたみ／展開を Playwright で確認
- [x] SpectatorScreen で左・右・両ペイン折りたたみ／展開を Playwright で確認
- [x] AgentDetailScreen で左・右・両ペイン折りたたみ／展開を Playwright で確認

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)