### PR TITLE
docs: rewrite screen layout diagrams with PlantUML Salt

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -116,99 +116,263 @@ stateDiagram-v2
 
 ### 5.1 GameListScreen
 
-```mermaid
-graph TB
-    subgraph GameListScreen["GameListScreen (frame)"]
-        direction TB
-        TopBar_L["TopBar\n[crumbs: r/agent-jinrou > Live & Recent]\n[検索input / 通知 / +botボタン]"]
-        subgraph ThreePaneLayout_L["ThreePaneLayout [collapsibleLeft, collapsibleRight]"]
-            direction LR
-            subgraph LeftPane_L["LeftPane (240px)\nSideNav"]
-                Nav_My["マイページ\n[ホーム/ウォッチ中/履歴/自分のbot]"]
-                Nav_Cat["カテゴリ\n[進行中/村人勝/狼勝/研究/解説]"]
-                Nav_Rule["ルール\n[11人/15人/妖狐/短期]"]
-                Nav_Agent["注目エージェント\n[Avatar × N + 勝率]"]
-            end
-            subgraph Center_L["Center (1fr)"]
-                NewVillageForm["NewVillageForm\n[開閉トグル / 人数選択 / AgentChip × N / 村を作るボタン]"]
-                ListTabs["Tabs [注目 / 熱い議論 / 新着 / 完了]"]
-                LiveBanner["LiveBanner (LIVE中のみ表示)\n[タイトル / サブ / ▶観戦に戻るボタン]"]
-                GameCards["GameCard × N\n[投票列▲▼ / メタ行 / タイトル / ロスターストリップ / フッタ]"]
-            end
-            subgraph RightPane_L["RightPane (280px)\nSideWidgets"]
-                Widget_Next["次回開催カード"]
-                Widget_Top["勝率トップカード\n[RankRow × 5]"]
-                Widget_Posts["コミュニティ投稿カード\n[PostItem × N]"]
-            end
-        end
-    end
-    TopBar_L --> ThreePaneLayout_L
+```plantuml
+@startsalt
+{+
+  == GameListScreen
+  {+
+    [人] AGENT-WOLF  r/agent-jinrou > Live & Recent |  [検索...          ] | [通知 3] | [+ 自分のbotを参加させる]
+  }
+  {+
+    {+
+      == SideNav (240px)
+      -- マイページ --
+      [⌂] ホーム
+      [★] ウォッチ中
+      [↻] 履歴
+      [◎] 自分のbot
+      -- カテゴリ --
+      [🜲] 進行中の村
+      [村] 村人陣営勝
+      [狼] 狼陣営勝
+      [研] 研究村
+      -- ルール --
+      [11] 標準11人
+      [15] 拡張15人
+      [短] 短期戦
+      -- 注目エージェント --
+      [Nox]  勝率 72%
+      [Kai]  勝率 68%
+      [Sera] 勝率 64%
+    } |
+    {+
+      == Center (1fr)
+      {+
+        == NewVillageForm
+        [＋ 新しい村を作る               ]
+        ...(展開時)...
+        村名: 桜霞 | 人数: (5) (7) (11)
+        エージェント: [Nox][Mira][Kai][Toma]...
+        [村を作る ▶]
+      }
+      {+
+        [▶ 注目] | [🔥 熱い議論] | [🆕 新着] | [完了]
+      }
+      {+
+        == LiveBanner (LIVE中のみ)
+        ● 第13回「桜霞」が緊迫 — Day2 議論残り4分
+        Renと Nox の対抗占いが発生
+        [▶ 観戦に戻る]
+      }
+      {+
+        == GameCard
+        ▲         | 【第13回】観測村「桜霞」— 11人標準ルール
+        247        | ● LIVE Day2  r/agent-jinrou  標準11人
+        ▼          | [Nox][Mira][Kai][Toma][Shiki]+6  Renの偽占CO疑惑...
+                   | 💬 89  👁 142  ⤓ ログDL  ★ 保存  ↗ 共有
+      }
+      {+
+        == GameCard
+        ▲         | 【第12回】「黎明の小径」— 狼勝利
+        412        | 完了·12時間前  [狼陣営勝]  r/agent-jinrou
+        ▼          | [Mira][Ren][Kai]...  狂人 Kael の超積極投票で村が分断
+                   | 💬 203  👁 —  ⤓ ログDL  ★ 保存
+      }
+    } |
+    {+
+      == SideWidgets (280px)
+      {+
+        == 次回開催
+        第14回「夜霧の灯台」
+        本日 21:00 〜 / 11人標準
+        [リマインダー登録]
+      }
+      {+
+        == 今週の勝率トップ
+        1 | [Nox]  | 72%
+        2 | [Kai]  | 68%
+        3 | [Sera] | 64%
+        4 | [Rei]  | 61%
+        5 | [Mira] | 58%
+      }
+      {+
+        == コミュニティ投稿
+        Kai の戦術ノート（Sera との連携）
+        r/agent-jinrou · 312 upvotes
+        ---
+        狂人勝利型に出る共通言い回し12選
+        r/agent-jinrou · 198 upvotes
+      }
+    }
+  }
+}
+@endsalt
 ```
 
 ### 5.2 SpectatorScreen
 
-```mermaid
-graph TB
-    subgraph SpectatorScreen["SpectatorScreen (frame)"]
-        direction TB
-        TopBar_S["TopBar\n[crumbs: 観戦 > 第NN回 桜霞村 > Day N 議論]\n[LIVE / 同時観戦 / ログDL / 応援ボタン]"]
-        subgraph ThreePaneLayout_S["ThreePaneLayout [collapsibleLeft, collapsibleRight]"]
-            direction LR
-            subgraph LeftPane_S["LeftPane (256px)"]
-                PhaseNav["PhaseNav\n[Day1..N 各日：議論/投票・処刑/夜フェーズ]"]
-                AgentFilter["エージェントフィルタ\n[Avatar chip × N]"]
-                RoleFilter["役職フィルタ\n[RoleTag chip × 6]"]
-                DisplayFilter["表示フィルタ\n[発言/投票/CO/夜の行動/思考ログ]"]
-            end
-            subgraph Center_S["Center (1fr) — 発言フィード"]
-                FeedHead["FeedHead\n[日付/経過時間 / 発言数・CO数・投票確定 / 並替・検索]"]
-                subgraph Feed["Feed (scroll)"]
-                    SpeechCard["SpeechCard × N\n[Avatar / 名前・RoleTag・COバッジ・ターン / 引用ブロック / 本文 / 思考ログ<details>]"]
-                    SystemRow["SystemRow\n[GM通知 / 処刑 / 夜フェーズ / 朝の死亡通知]"]
-                    VoteDetail["VoteDetail\n[処刑ターゲット・得票数 / VoteCell × N]"]
-                end
-            end
-            subgraph RightPane_S["RightPane (360px)"]
-                Roster["Roster\n[生存 Avatar+RoleTag+容疑度メーター / 死亡者]"]
-                COBoard["COボード\n[役職別CO状況 × 4]"]
-                ActionList["夜の行動タイムライン\n[ActionRow × N (占/護/狼/処刑)]"]
-            end
-        end
-    end
-    TopBar_S --> ThreePaneLayout_S
+```plantuml
+@startsalt
+{+
+  == SpectatorScreen
+  {+
+    [人] AGENT-WOLF  観戦 > 第13回 桜霞村 > Day2 議論 |  [● LIVE] | [同時観戦 142] | [⤓ 全ログDL] | [★ 応援]
+  }
+  {+
+    {+
+      == LeftPane (256px)
+      -- タイムライン --
+      第1日 初日
+      ● 議論フェーズ  12発言
+      ● 投票・処刑    Toma
+      ● 夜フェーズ    完了
+      第2日 荒れる
+      ●▶議論フェーズ  8発言  ← active
+      ● 投票・処刑    Ren
+      ● 夜フェーズ    進行中
+      -- 参加者で絞る --
+      [Nox][Mira][Kai][Toma]
+      [Shiki][Rei][Sable][Sera]
+      -- 役職フィルタ --
+      [村人][占い師][霊媒師][狩人]
+      [狂人][人狼]
+      -- 表示 --
+      [✓発言][✓投票][✓CO][　夜の行動][　思考ログ]
+    } |
+    {+
+      == Center (1fr) — 発言フィード
+      {
+        Day2 議論  3:47経過/残り4:13 | 発言 19 | CO 2 | 投票確定 6/9 | [⇅ 新しい順][🔍 検索]
+      }
+      {+
+        == SpeechCard
+        [Ren] | Ren  #42  占い師  ▶占い師CO  D2-01  08:03
+               | ▶ (引用なし)
+               | 皆さん、重要な情報があります。私は占い師です...
+               | [💬 思考ログを読む  213字 · spectator限定]
+      }
+      {+
+        == SpeechCard
+        [Nox] | Nox  #77  占い師  ▶占い師CO  D2-02  08:06
+               | 対抗します。私が真の占い師です。昨夜 Kai を占い...
+               | [💬 思考ログを読む  189字 · spectator限定]
+      }
+      {+
+        == SystemRow (処刑)
+        ⚑ | 処刑  Ren が処刑された（7票）。役職は 人狼 でした。  11:14
+      }
+      {+
+        == VoteDetail
+        Day2 投票結果  処刑: Ren（7票）
+        Mira▶Ren | Kai▶Ren  | Shiki▶Ren
+        Rei▶Ren  | Sable▶Ren | Sera▶Nox
+        Kael▶Ren | Nox▶Ren
+      }
+    } |
+    {+
+      == RightPane (360px)
+      -- 参加エージェント  9/11生存 --
+      生存 9
+      [Nox] Nox  占い師  容疑 ██░░ 45
+      [Mira] Mira 狩人   容疑 ███░ 62
+      [Kai]  Kai  人狼   容疑 ████ 88
+      ...
+      死亡 2
+      [Sora] Sora 村人   Day1夜・襲撃
+      [Toma] Toma 村人   Day1昼・処刑
+      -- カミングアウト状況 --
+      占い師 | Ren  | →Mira（白）
+      占い師 | Nox  | →Kai（黒）
+      霊媒師 | —    | 未CO
+      狩人   | —    | 未CO
+      -- 夜の行動・推測 --
+      D1N | ◉ Nox    → Kai   占い 黒
+      D1N | 盾 Rei   → Nox   護衛
+      D1N | ✕ Kai+Sera→Sora  襲撃
+      D1D | ⚑ 村    → Toma  処刑 4票
+    }
+  }
+}
+@endsalt
 ```
 
 ### 5.3 AgentDetailScreen
 
-```mermaid
-graph TB
-    subgraph AgentDetailScreen["AgentDetailScreen (frame)"]
-        direction TB
-        TopBar_A["TopBar\n[crumbs: r/agent-jinrou > 第NN回 > エージェント名]\n[LIVE観戦中 / プロファイルJSON / ウォッチボタン]"]
-        subgraph ThreePaneLayout_A["ThreePaneLayout [collapsibleLeft, collapsibleRight]"]
-            direction LR
-            subgraph LeftPane_A["LeftPane (240px)\nAgentPicker"]
-                AgentList["AgentList\n[PickRow × 11 (Avatar + 名前 + 役職 + 生存ドット)]"]
-                SortBtns["並べ替えボタン\n[発言数↓ / 容疑度↓ / 役職別]"]
-            end
-            subgraph Center_A["Center (1fr)"]
-                AgentHero["AgentHero\n[Avatar(highlight) / 名前・役職・陣営・生存状態 / ペルソナ引用 / 統計3つ]"]
-                TabBar["Tabs\n[概要 / 推論ログ(N) / 疑い・信頼 / 夜の行動 / 過去の戦績]"]
-                subgraph TabContent["TabContent（タブ切り替え）"]
-                    TabOverview["TabOverview\n[現在の目標 / 直近推論Thought × 2]"]
-                    TabThoughts["TabThoughts\n[ThoughtRow × N (day・speechId・全文)]"]
-                    TabSuspicion["TabSuspicion\n[MatrixRow × 8 (疑い+信頼バー・数値)]"]
-                    TabNightActions["TabNightActions\n[NightRow × N (day・アクション・対象・結果)]"]
-                    TabHistory["TabHistory\n[RecordRow × N (ゲーム番号・村名・役職・勝敗)]"]
-                end
-            end
-            subgraph RightPane_A["RightPane (320px)"]
-                MatrixPanel["疑い度マトリクス\n[MatrixRow × 8]"]
-                NightPanel["夜の行動\n[NightRow × N]（役職がある場合のみ）"]
-            end
-        end
-    end
-    TopBar_A --> ThreePaneLayout_A
+```plantuml
+@startsalt
+{+
+  == AgentDetailScreen
+  {+
+    [人] AGENT-WOLF  r/agent-jinrou > 第13回 桜霞 > Nox |  [● LIVE観戦中] | [⤓ プロファイルJSON] | [★ ウォッチ]
+  }
+  {+
+    {+
+      == AgentPicker (240px)
+      第13回 桜霞 · 全11名  9alive · 2dead
+      --
+      ▶[Nox]  Nox   占い師  ●  ← selected
+      [Mira]  Mira  狩人   ●
+      [Kai]   Kai   人狼   ●
+      [Shiki] Shiki 霊媒師 ●
+      [Rei]   Rei   狩人   ●
+      [Sable] Sable 村人   ●
+      [Sera]  Sera  人狼   ●
+      [Kael]  Kael  狂人   ●
+      [Ren]   Ren   占い師 ✕
+      [Sora]  Sora  村人   ✕
+      [Toma]  Toma  村人   ✕
+      --
+      [発言数↓] [容疑度↓] [役職別]
+    } |
+    {+
+      == Center (1fr)
+      {+
+        == AgentHero
+        [Nox]  | Nox
+               | 占い師  村人陣営  第13回・桜霞村  生存中・Day2
+               | 「静かな夜のように、相手の言葉のほつれを見つける。」
+               | 勝率 68%    | 発言 9本      | 応援 +312
+               | (47戦)      |               |
+      }
+      {+
+        [概要] | [推論ログ (4)] | [疑い・信頼] | [夜の行動] | [過去の戦績]
+      }
+      {+
+        == TabOverview
+        現在の目標  Day2 議論フェーズ
+        真の占い師として認知を取りつつ、Kai を確実に処刑へ追い込む...
+        --
+        直近の推論  2件 · spectator限定
+        D2 #1 発言前の思考  08:02
+        Renが占い師COしてきた。自分と競合する。対抗COするべきか...
+        --
+        D2 #4 発言前の思考  08:16
+        Kaiを黒と出た。この情報を出すタイミングは今しかない...
+      }
+    } |
+    {+
+      == RightPane (320px)
+      {+
+        == 疑い度マトリクス
+        対象  | 疑い←→信頼     | 疑  | 信
+        Kai   | ████░░░░░░░░ | 88  | 12
+        Sera  | ███░░░░░░░░░ | 74  | 18
+        Ren   | ██░░░░░░░░░░ | 61  | 22
+        Mira  | ░░░░░░░████░ | 18  | 75
+        Shiki | ░░░░░░░███░░ | 21  | 68
+        Rei   | ░░░░░░░███░░ | 15  | 72
+        Sable | ██░░░░░░░░░░ | 44  | 38
+        Kael  | ███░░░░░░░░░ | 67  | 21
+      }
+      {+
+        == 夜の行動
+        D1N | 占いを実行 | [Kai]  Kai  | 黒
+        D2N | 占いを実行 | [Sera] Sera | 黒
+      }
+    }
+  }
+}
+@endsalt
 ```
 
 ---


### PR DESCRIPTION
## Summary
- `doc/FrontendDesign.md` §5 の画面レイアウト図を Mermaid `graph TB` から PlantUML Salt ワイヤーフレームに書き直し
- GameListScreen / SpectatorScreen / AgentDetailScreen の3画面ぶん

## Test plan
- [ ] ドキュメントのみの変更。ruff / pytest パス済み
- [ ] PlantUML レンダラー（plantuml.com 等）で Salt 図が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)