### PR TITLE
docs: add real-data frontend follow-up issues

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -25,6 +25,8 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#318 | enhancement | 🟡 | 3 | Replay viewer | state_archive/ から過去ゲームを表示（Milestone 2 前半） |
+| yukkie/AgentVillage#338 | enhancement | 🟡 | 2 | Game list real archives | stub/gameList.js の GAMES を state_archive/ 由来の実アーカイブ一覧に置き換え |
+| yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#314 | enhancement | 🟡 | 2 | spectator / public mode toggle | viewerMode prop による表示切替 |
 | yukkie/AgentVillage#321 | enhancement | 🟡 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止。Architecture.md に配置指針を追記 |


### PR DESCRIPTION
## Summary

- Add Milestone 2 follow-up rows for game list real-data connection
- Add Milestone 2 follow-up rows for top-agent stats real-data connection

## Tests

- Not run; documentation-only change