### PR TITLE
feat: add replay viewer for archived games

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -391,7 +391,9 @@ frontend/
 │   │   ├── GameListScreen.jsx    # ゲーム一覧
 │   │   └── AgentScreen.jsx       # エージェント詳細
 │   ├── lib/
-│   │   └── parseGameData.js      # JSONL → GameData 型パーサー（#313）
+│   │   ├── archiveLoader.js      # state_archive/index.json → GameList 用データ
+│   │   ├── replayLoader.js       # replay session のログ・agent JSON fetch
+│   │   └── parseGameData.js      # JSONL → GameData 型パーサー（#318）
 │   └── tokens.css          # デザイントークン（design/proposal/prototypes/styles.css の :root を移植）
 ├── index.html
 ├── vite.config.js
@@ -412,6 +414,32 @@ frontend/
 
 Python 側の `LogEvent`（`src/domain/event.py`）と 1:1 対応する。
 フィールドの追加・変更は両側を同時に更新すること。
+
+### Replay loader（#318）
+
+`SpectatorScreen` は `sessionId` を受け取ると、画面 shell を先に表示してから `replayLoader.js` 経由で archived replay を読み込む。
+
+```text
+GameListScreen
+  ↓ GameCard click
+App.jsx state: { screen: "spectator", selectedGame: { id, cast } }
+  ↓ props
+SpectatorScreen(sessionId, cast)
+  ↓ async fetch
+replayLoader.js
+  ├─ spectator_log.jsonl
+  └─ agents/*.json
+      ↓
+parseGameData(jsonlText, agentJsonByName)
+      ↓
+{ events, agents }
+```
+
+`parseGameData()` は I/O を持たない同期・純粋関数。
+現在は `spectator_log.jsonl` 全体を一括 fetch して行単位に JSON parse する。
+ログ量が増えた場合の変更ポイントは `replayLoader.js` に閉じ、day chunk、cursor pagination、ReadableStream JSONL parser、または FastAPI endpoint に置き換える。
+
+`spectator_log.jsonl` の非公開 `[THINK]` speech 行は、同じ `day` / `agent` / `speech_id` を持つ公開 speech の `thought` に結合する。
 
 ### viewerMode — spectator / public
 

--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -85,6 +85,24 @@ const SCREENS = { list: GameListScreen, spectator: SpectatorScreen, agent: Agent
 const [screen, setScreen] = useState('list');
 ```
 
+### 4.2.1 Replay viewer（#318）
+
+ゲーム一覧の `GameCard` を選択すると、`App.jsx` が `{ sessionId, cast }` を `SpectatorScreen` に渡す。
+`SpectatorScreen` は画面枠を先に描画し、`useEffect` で `state_archive/{session}/spectator_log.jsonl` と `agents/*.json` を非同期に読み込む。
+
+データ取得と変換の責務は `frontend/src/lib/` に分離する:
+
+| ファイル | 責務 |
+|---|---|
+| `archiveLoader.js` | `state_archive/index.json` → ゲーム一覧カード |
+| `replayLoader.js` | 選択 session の spectator log / agent JSON を fetch |
+| `parseGameData.js` | JSONL + agent JSON → `{ events, agents }` |
+
+`parseGameData.js` は同期の純粋関数として保つ。
+将来ログが大きくなった場合は、`replayLoader.js` 内を day chunk / cursor API / streaming parser に差し替え、画面側は `events` と `agents` を受け取る構造を維持する。
+
+#312 で「❌ スタブ固定」とされた村名・ルール名・投票内訳・夜行動サマリ・ソーシャル系メトリクスは、#318 では fallback 表示のまま残す。
+
 ### 4.3 ルーティング方針（Milestone 2）
 
 react-router を導入し、URL ベースの遷移に移行する。

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -24,7 +24,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#318 | enhancement | 🟡 | 3 | Replay viewer | state_archive/ から過去ゲームを表示（Milestone 2 前半） |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#314 | enhancement | 🟡 | 2 | spectator / public mode toggle | viewerMode prop による表示切替 |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,30 @@ const SCREENS = {
 
 export default function App() {
   const [screen, setScreen] = useState('list');
+  const [selectedGame, setSelectedGame] = useState(null);
   const Screen = SCREENS[screen];
+
+  if (screen === 'list') {
+    return (
+      <GameListScreen
+        onOpenGame={(game) => {
+          setSelectedGame(game);
+          setScreen('spectator');
+        }}
+      />
+    );
+  }
+
+  if (screen === 'spectator') {
+    return (
+      <SpectatorScreen
+        sessionId={selectedGame?.id}
+        cast={selectedGame?.cast ?? []}
+        title={selectedGame?.title}
+        onBack={() => setScreen('list')}
+      />
+    );
+  }
+
   return <Screen />;
 }

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -1,0 +1,122 @@
+import { normalizeAgentJson } from '../legacy/normalizeAgentJson.js';
+
+const THINK_PREFIX = '[THINK]';
+
+/**
+ * Parse one JSONL line into a LogEvent-compatible object.
+ *
+ * Kept separate so replay loading can later move from whole-file parsing to
+ * chunked JSONL parsing without changing screen components.
+ *
+ * @param {string} line
+ * @returns {object | null}
+ */
+export function parseEventLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  return JSON.parse(trimmed);
+}
+
+function stripThinkPrefix(content) {
+  if (!content?.startsWith(THINK_PREFIX)) return content ?? '';
+  return content.slice(THINK_PREFIX.length).trimStart();
+}
+
+function eventKey(event) {
+  return `${event.day ?? ''}:${event.agent ?? ''}:${event.speech_id ?? ''}`;
+}
+
+function isPrivateThinkEvent(event) {
+  return (
+    event.event_type === 'speech' &&
+    event.is_public === false &&
+    typeof event.content === 'string' &&
+    event.content.startsWith(THINK_PREFIX)
+  );
+}
+
+/**
+ * Convert raw LogEvent rows into UI events.
+ *
+ * The current archive stores thoughts as private "[THINK]" speech rows that
+ * share day/agent/speech_id with the public speech. The spectator feed wants
+ * the thought on the visible public speech card, so we merge those rows here.
+ *
+ * @param {object[]} rawEvents
+ * @returns {object[]}
+ */
+export function normalizeEvents(rawEvents) {
+  const publicEvents = [];
+  const speechByKey = new Map();
+  const pendingThoughts = new Map();
+
+  rawEvents.forEach(event => {
+    if (isPrivateThinkEvent(event)) {
+      const key = eventKey(event);
+      const thought = stripThinkPrefix(event.content);
+      const speech = speechByKey.get(key);
+      if (speech) {
+        speech.thought = thought;
+      } else {
+        pendingThoughts.set(key, thought);
+      }
+      return;
+    }
+
+    const normalized = { ...event };
+    if (normalized.event_type === 'speech' && normalized.is_public !== false) {
+      const key = eventKey(normalized);
+      if (pendingThoughts.has(key)) {
+        normalized.thought = pendingThoughts.get(key);
+      }
+      speechByKey.set(key, normalized);
+    }
+    publicEvents.push(normalized);
+  });
+
+  return publicEvents;
+}
+
+function parseAgent(agentJson) {
+  const normalized = normalizeAgentJson(agentJson);
+  const name = normalized.profile?.name ?? agentJson.name;
+
+  return {
+    name,
+    role: normalized.role ?? null,
+    is_alive: normalized.state?.is_alive ?? true,
+    claimed_role: normalized.state?.claimed_role ?? null,
+    persona: normalized.profile?.persona ?? {},
+    profile: normalized.profile ?? {},
+    state: normalized.state ?? {},
+  };
+}
+
+/**
+ * Parse archive JSONL and agent JSON into the GameData shape consumed by React.
+ *
+ * This function is intentionally synchronous and pure. I/O stays in
+ * replayLoader.js, which is the seam to replace with cursor/chunk/streaming
+ * APIs if archived games become too large for whole-file fetch.
+ *
+ * @param {string} jsonlText
+ * @param {Record<string, object>} agentJsonByName
+ * @returns {{ events: object[], agents: Record<string, object> }}
+ */
+export function parseGameData(jsonlText, agentJsonByName = {}) {
+  const rawEvents = jsonlText
+    .split(/\r?\n/)
+    .map(parseEventLine)
+    .filter(Boolean);
+
+  const agents = {};
+  Object.values(agentJsonByName).forEach(agentJson => {
+    const agent = parseAgent(agentJson);
+    if (agent.name) agents[agent.name] = agent;
+  });
+
+  return {
+    events: normalizeEvents(rawEvents),
+    agents,
+  };
+}

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseEventLine, parseGameData, normalizeEvents } from './parseGameData.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const sourceLogDir = path.join(repoRoot, 'design/proposal/source_logs');
+
+function readFixture(relativePath) {
+  return fs.readFileSync(path.join(sourceLogDir, relativePath), 'utf8');
+}
+
+function readAgent(name) {
+  return JSON.parse(readFixture(`agents/${name.toLowerCase()}.json`));
+}
+
+describe('parseEventLine', () => {
+  it('parses one JSONL event line', () => {
+    /**
+     * SUT: parseEventLine
+     * Mock: なし
+     * Level: unit
+     * Objective: JSONL の1行を LogEvent オブジェクトに変換できることを検証する。
+     */
+    const event = parseEventLine('{"event_type":"speech","agent":"Mira"}');
+    expect(event).toEqual({ event_type: 'speech', agent: 'Mira' });
+  });
+
+  it('returns null for blank lines', () => {
+    /**
+     * SUT: parseEventLine
+     * Mock: なし
+     * Level: unit
+     * Objective: JSONL 末尾の空行を無視できることを検証する。
+     */
+    expect(parseEventLine('   ')).toBeNull();
+  });
+});
+
+describe('normalizeEvents', () => {
+  it('merges private THINK rows into their public speech event', () => {
+    /**
+     * SUT: normalizeEvents
+     * Mock: なし
+     * Level: unit
+     * Objective: spectator_log.jsonl の非公開 THINK 行が公開 speech の thought に結合されることを検証する。
+     */
+    const events = normalizeEvents([
+      { day: 1, event_type: 'speech', agent: 'Mira', speech_id: 1, is_public: true, content: 'おはよう' },
+      { day: 1, event_type: 'speech', agent: 'Mira', speech_id: 1, is_public: false, content: '[THINK] 内心' },
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].content).toBe('おはよう');
+    expect(events[0].thought).toBe('内心');
+  });
+});
+
+describe('parseGameData', () => {
+  it('parses real spectator_log.jsonl into events and agents', () => {
+    /**
+     * SUT: parseGameData
+     * Mock: なし（design/proposal/source_logs/ の実ログを fixture に使用）
+     * Level: unit
+     * Objective: 実ログから GameData の events と agents を生成できることを検証する。
+     */
+    const gameData = parseGameData(readFixture('spectator_log.jsonl'), {
+      Mira: readAgent('Mira'),
+      Ren: readAgent('Ren'),
+      Nox: readAgent('Nox'),
+    });
+
+    expect(gameData.events.length).toBeGreaterThan(0);
+    expect(gameData.agents.Mira.name).toBe('Mira');
+    expect(gameData.agents.Ren.name).toBe('Ren');
+    expect(gameData.agents.Nox.name).toBe('Nox');
+  });
+
+  it('attaches thought text from real spectator_log.jsonl', () => {
+    /**
+     * SUT: parseGameData
+     * Mock: なし（design/proposal/source_logs/ の実ログを fixture に使用）
+     * Level: unit
+     * Objective: 実 spectator log の THINK 行が speech.thought として利用できることを検証する。
+     */
+    const gameData = parseGameData(readFixture('spectator_log.jsonl'));
+    const miraSpeech = gameData.events.find(
+      event => event.event_type === 'speech' && event.agent === 'Mira' && event.speech_id === 1
+    );
+
+    expect(miraSpeech.thought).toContain('Day 1');
+    expect(miraSpeech.thought).not.toContain('[THINK]');
+  });
+});

--- a/frontend/src/lib/replayLoader.js
+++ b/frontend/src/lib/replayLoader.js
@@ -1,0 +1,74 @@
+import { parseGameData } from './parseGameData.js';
+
+function agentFileName(name) {
+  return `${String(name).toLowerCase()}.json`;
+}
+
+function archiveUrl(sessionId, path) {
+  return `/state_archive/${encodeURIComponent(sessionId)}/${path}`;
+}
+
+async function fetchText(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  return res.text();
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Fetch archived agent JSON files for one session.
+ *
+ * Missing agent files are skipped so older/incomplete archives can still show
+ * the speech feed. A future API endpoint can replace this fan-out with one
+ * request without changing SpectatorScreen.
+ *
+ * @param {{ sessionId: string, cast: string[] }} params
+ * @returns {Promise<Record<string, object>>}
+ */
+export async function fetchReplayAgents({ sessionId, cast = [] }) {
+  const entries = await Promise.all(
+    cast.map(async name => {
+      try {
+        const data = await fetchJson(archiveUrl(sessionId, `agents/${agentFileName(name)}`));
+        return [name, data];
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  return Object.fromEntries(entries.filter(Boolean));
+}
+
+/**
+ * Fetch the spectator log for one archived session.
+ *
+ * This is currently a whole-file fetch. If logs become large, this function is
+ * the intended replacement point for day chunks, cursor pagination, or a
+ * ReadableStream JSONL parser.
+ *
+ * @param {{ sessionId: string }} params
+ * @returns {Promise<string>}
+ */
+export function fetchReplayLog({ sessionId }) {
+  return fetchText(archiveUrl(sessionId, 'spectator_log.jsonl'));
+}
+
+/**
+ * Convenience loader for callers that do not need staged updates.
+ *
+ * @param {{ sessionId: string, cast: string[] }} params
+ * @returns {Promise<{ events: object[], agents: Record<string, object> }>}
+ */
+export async function fetchReplayGame({ sessionId, cast = [] }) {
+  const [jsonlText, agentJsonByName] = await Promise.all([
+    fetchReplayLog({ sessionId }),
+    fetchReplayAgents({ sessionId, cast }),
+  ]);
+  return parseGameData(jsonlText, agentJsonByName);
+}

--- a/frontend/src/screens/GameListScreen.jsx
+++ b/frontend/src/screens/GameListScreen.jsx
@@ -122,7 +122,7 @@ function winnerClass(winner) {
   return '';
 }
 
-function GameCard({ g }) {
+function GameCard({ g, onOpen }) {
   return (
     <div className={`${styles.gcard} ${g.hot ? styles.featured : ''}`}>
       <div className={styles.vote}>
@@ -130,7 +130,18 @@ function GameCard({ g }) {
         <span className={styles.voteNum}>{g.votes}</span>
         <button>▼</button>
       </div>
-      <div className={styles.cardBody}>
+      <div
+        className={styles.cardBody}
+        role="button"
+        tabIndex={0}
+        onClick={() => onOpen(g)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onOpen(g);
+          }
+        }}
+      >
         <div className={styles.gmeta}>
           {g.live
             ? (
@@ -261,7 +272,7 @@ function RightPane() {
 }
 
 // === メインゲーム一覧画面 ===
-export default function GameListScreen() {
+export default function GameListScreen({ onOpenGame = () => {} }) {
   const [activeTab, setActiveTab] = useState('完了');
   const [games, setGames] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -332,7 +343,7 @@ export default function GameListScreen() {
             </div>
           )}
 
-          {visibleGames.map(g => <GameCard key={g.id} g={g} />)}
+          {visibleGames.map(g => <GameCard key={g.id} g={g} onOpen={onOpenGame} />)}
         </div>
       </ThreePaneLayout>
     </div>

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Avatar from '../components/Avatar.jsx';
 import RoleTag from '../components/RoleTag.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
@@ -8,6 +8,8 @@ import {
   ROLE_ASSIGNMENT, NIGHT_RESULTS, EXEC_RESULTS,
   VOTE_TABLE_D1, ACTIONS_TIMELINE, EVENTS,
 } from '../../stub/spectator.js';
+import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
+import { parseGameData } from '../lib/parseGameData.js';
 import styles from './SpectatorScreen.module.css';
 
 // --- ユーティリティ ---
@@ -27,8 +29,8 @@ function Mentioned({ text }) {
 }
 
 // --- 発言カード ---
-function SpeechCard({ ev, prevById }) {
-  const role = ROLE_ASSIGNMENT[ev.agent];
+function SpeechCard({ ev, prevById, roleAssignment }) {
+  const role = roleAssignment[ev.agent];
   const r = ROLES[role];
   const replied = ev.reply_to ? prevById[`${ev.day}-${ev.reply_to}`] : null;
   const isWolf = role === 'Werewolf';
@@ -127,13 +129,13 @@ function VoteDetail({ day }) {
 }
 
 // --- フィードアイテム ---
-function FeedItem({ ev, prevById }) {
-  if (ev.event_type === 'speech') return <SpeechCard ev={ev} prevById={prevById} />;
+function FeedItem({ ev, prevById, roleAssignment, title }) {
+  if (ev.event_type === 'speech') return <SpeechCard ev={ev} prevById={prevById} roleAssignment={roleAssignment} />;
   if (ev.event_type === 'phase_start') {
     if (ev.content.includes('GAME START')) {
       return (
         <SystemRow kind="gm" label="ゲームマスター" ts="10:00">
-          <strong>第13回 観測村「桜霞」</strong> が開始されました。村人陣営 7 / 人狼陣営 2 / 占・霊・狩・狂 各1。
+          <strong>{title || 'Archived Game'}</strong> が開始されました。
         </SystemRow>
       );
     }
@@ -144,12 +146,12 @@ function FeedItem({ ev, prevById }) {
 }
 
 // === 左ペイン ===
-function LeftPane({ activeDay, setDay }) {
+function LeftPane({ activeDay, setDay, days, agentNames }) {
   return (
     <>
       <div className={styles.phaseNav}>
         <div className={styles.sectionLabel}>タイムライン</div>
-        {[1, 2, 3].map(d => (
+        {days.map(d => (
           <div key={d}>
             <div className={styles.phaseDay}>
               <h3>第 {d} 日 <small>{d === 1 ? '初日' : d === 2 ? '荒れる' : '進行中'}</small></h3>
@@ -175,7 +177,7 @@ function LeftPane({ activeDay, setDay }) {
       <div className={styles.filt}>
         <div className={styles.sectionLabel}>参加者で絞る</div>
         <div className={styles.filtRow}>
-          {Object.keys(AGENT_PALETTE).slice(0, 8).map(n => (
+          {agentNames.slice(0, 8).map(n => (
             <button key={n} className={styles.chip}>
               <Avatar name={n} size="xs" /> {n}
             </button>
@@ -203,10 +205,14 @@ function LeftPane({ activeDay, setDay }) {
 }
 
 // === 右ペイン ===
-function RightPane() {
-  const order = ['Nox','Mira','Ren','Kai','Toma','Shiki','Rei','Sable','Sera','Kael','Sora'];
-  const dead = ['Sora', 'Toma'];
-  const alive = order.filter(n => !dead.includes(n));
+function RightPane({ agents, roleAssignment }) {
+  const order = Object.keys(agents).length
+    ? Object.keys(agents)
+    : ['Nox','Mira','Ren','Kai','Toma','Shiki','Rei','Sable','Sera','Kael','Sora'];
+  const dead = order.filter(n => agents[n]?.is_alive === false);
+  const fallbackDead = Object.keys(agents).length ? [] : ['Sora', 'Toma'];
+  const deadNames = dead.length ? dead : fallbackDead;
+  const alive = order.filter(n => !deadNames.includes(n));
 
   return (
     <div className={styles.roster}>
@@ -218,7 +224,7 @@ function RightPane() {
       <div className={styles.rosterSection}>
         <h4>生存 <span className={styles.count}>{alive.length}</span></h4>
         {alive.map(n => {
-          const role = ROLE_ASSIGNMENT[n];
+          const role = roleAssignment[n];
           const r = ROLES[role];
           const sus = (n.charCodeAt(0) * 13) % 100;
           return (
@@ -241,9 +247,9 @@ function RightPane() {
       </div>
 
       <div className={styles.rosterSection}>
-        <h4>死亡者 <span className={styles.count}>{dead.length}</span></h4>
-        {dead.map(n => {
-          const role = ROLE_ASSIGNMENT[n];
+        <h4>死亡者 <span className={styles.count}>{deadNames.length}</span></h4>
+        {deadNames.map(n => {
+          const role = roleAssignment[n];
           const r = ROLES[role];
           return (
             <div key={n} className={`${styles.rosterRow} ${styles.dead}`} style={{ '--r-color': r?.color }}>
@@ -300,21 +306,91 @@ function RightPane() {
 }
 
 // === メイン観戦画面 ===
-export default function SpectatorScreen() {
+export default function SpectatorScreen({ sessionId, cast = [], title, onBack }) {
   const [activeDay, setActiveDay] = useState(2);
+  const [replayEvents, setReplayEvents] = useState(null);
+  const [replayAgents, setReplayAgents] = useState({});
+  const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
+  const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
+  const [loadError, setLoadError] = useState(null);
+
+  useEffect(() => {
+    if (!sessionId) return undefined;
+
+    let cancelled = false;
+    setReplayEvents(null);
+    setReplayAgents({});
+    setLoadingEvents(true);
+    setLoadingAgents(true);
+    setLoadError(null);
+
+    fetchReplayAgents({ sessionId, cast })
+      .then(agentJsonByName => {
+        if (cancelled) return;
+        setReplayAgents(parseGameData('', agentJsonByName).agents);
+      })
+      .catch(error => {
+        if (!cancelled) setLoadError(error);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingAgents(false);
+      });
+
+    fetchReplayLog({ sessionId })
+      .then(jsonlText => {
+        if (cancelled) return;
+        const parsed = parseGameData(jsonlText);
+        setReplayEvents(parsed.events);
+        const firstDay = parsed.events.find(event => event.day)?.day;
+        if (firstDay) setActiveDay(firstDay);
+      })
+      .catch(error => {
+        if (!cancelled) setLoadError(error);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingEvents(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, cast]);
+
+  const events = replayEvents ?? EVENTS;
+  const agents = replayAgents;
+  const roleAssignment = useMemo(() => {
+    if (!Object.keys(agents).length) return ROLE_ASSIGNMENT;
+    return Object.fromEntries(
+      Object.entries(agents).map(([name, agent]) => [name, agent.role])
+    );
+  }, [agents]);
+  const agentNames = Object.keys(agents).length ? Object.keys(agents) : Object.keys(AGENT_PALETTE);
+  const days = [...new Set(events.map(event => event.day).filter(Boolean))].sort((a, b) => a - b);
+  const visibleDays = days.length ? days : [1, 2, 3];
 
   const prevById = {};
-  EVENTS.forEach(e => {
+  events.forEach(e => {
     if (e.speech_id != null) prevById[`${e.day}-${e.speech_id}`] = e;
   });
 
-  const d1 = EVENTS.filter(e =>
+  const d1 = events.filter(e =>
     e.day === 1 && (
       e.event_type === 'speech' ||
       (e.event_type === 'phase_start' && e.content.includes('GAME START'))
     )
   );
-  const d2 = EVENTS.filter(e => e.day === 2 && e.event_type === 'speech');
+  const d2 = events.filter(e => e.day === 2 && e.event_type === 'speech');
+  const activeEvents = events.filter(e =>
+    e.day === activeDay && (
+      e.event_type === 'speech' ||
+      e.event_type === 'phase_start'
+    )
+  );
+  const feedEvents = sessionId
+    ? activeEvents
+    : [...d1, ...d2];
+  const speechCount = events.filter(e => e.event_type === 'speech').length;
+  const coCount = events.filter(e => e.claimed_role).length;
 
   const annotate = (e) => {
     if (e.day === 2 && e.agent === 'Ren' && e.speech_id === 1) return { ...e, claimed_role: 'Seer' };
@@ -324,8 +400,9 @@ export default function SpectatorScreen() {
 
   return (
     <div className={styles.frame}>
-      <TopBar crumbs={[{ label: '観戦' }, { label: '第13回 桜霞村' }, { label: `Day ${activeDay} 議論` }]}>
-        <TopBarBtn><span className={topBarStyles.liveDot} /> LIVE</TopBarBtn>
+      <TopBar crumbs={[{ label: '観戦' }, { label: title || sessionId || '第13回 桜霞村' }, { label: `Day ${activeDay} 議論` }]}>
+        {onBack && <TopBarBtn onClick={onBack}>← 一覧</TopBarBtn>}
+        <TopBarBtn><span className={topBarStyles.liveDot} /> REPLAY</TopBarBtn>
         <TopBarBtn>同時観戦 142</TopBarBtn>
         <TopBarBtn>⤓ 全ログDL</TopBarBtn>
         <TopBarBtn primary>★ 応援</TopBarBtn>
@@ -334,30 +411,52 @@ export default function SpectatorScreen() {
       <ThreePaneLayout
         collapsibleLeft
         collapsibleRight
-        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} />}
-        right={<RightPane />}
+        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} days={visibleDays} agentNames={agentNames} />}
+        right={<RightPane agents={agents} roleAssignment={roleAssignment} />}
       >
         <div className={styles.feedHead}>
-          <h2>Day {activeDay} 議論 <small>3:47 経過 / 残り 4:13</small></h2>
-          <span className={styles.stat}>発言 <strong>{d1.length + d2.length}</strong></span>
-          <span className={styles.stat}>CO <strong>2</strong></span>
+          <h2>Day {activeDay} 議論 <small>{sessionId ? sessionId : '3:47 経過 / 残り 4:13'}</small></h2>
+          <span className={styles.stat}>発言 <strong>{speechCount}</strong></span>
+          <span className={styles.stat}>CO <strong>{coCount}</strong></span>
           <span className={styles.stat}>投票確定 <strong>6/9</strong></span>
           <span className={styles.spacer} />
           <TopBarBtn>⇅ 新しい順</TopBarBtn>
           <TopBarBtn>🔍 検索</TopBarBtn>
         </div>
         <div className={styles.feed}>
-          {d1.map((e, i) => <FeedItem key={i} ev={annotate(e)} prevById={prevById} />)}
-          <SystemRow kind="exec" label="処刑" ts="11:14">
-            <strong>Toma</strong> が処刑された（4票）。役職は <strong style={{ color: 'var(--r-villager)' }}>村人</strong> でした。
-          </SystemRow>
-          <VoteDetail day={1} />
-          <SystemRow kind="phase" label="夜フェーズ" ts="11:20">夜が訪れた。占い師・人狼・狩人が行動を選択中…</SystemRow>
-          <SystemRow kind="death" label="襲撃" ts="08:00">
-            朝、<strong>Sora</strong> が無残な姿で発見された。村は大きく動揺している。
-          </SystemRow>
-          <SystemRow kind="phase" label="Day 2 議論開始" ts="08:05">2日目の議論が始まりました。</SystemRow>
-          {d2.map((e, i) => <FeedItem key={`d2-${i}`} ev={annotate(e)} prevById={prevById} />)}
+          {loadError && (
+            <SystemRow kind="death" label="読み込みエラー" ts="—">
+              {loadError.message}
+            </SystemRow>
+          )}
+          {(loadingEvents || loadingAgents) && (
+            <SystemRow kind="phase" label="読み込み中" ts="—">
+              {loadingAgents ? '参加者情報を読み込み中。' : ''}
+              {loadingEvents ? '発言ログを読み込み中。' : ''}
+            </SystemRow>
+          )}
+          {feedEvents.map((e, i) => (
+            <FeedItem
+              key={e.id || `${e.day}-${e.event_type}-${e.agent}-${e.speech_id}-${i}`}
+              ev={annotate(e)}
+              prevById={prevById}
+              roleAssignment={roleAssignment}
+              title={title || sessionId}
+            />
+          ))}
+          {!sessionId && (
+            <>
+              <SystemRow kind="exec" label="処刑" ts="11:14">
+                <strong>Toma</strong> が処刑された（4票）。役職は <strong style={{ color: 'var(--r-villager)' }}>村人</strong> でした。
+              </SystemRow>
+              <VoteDetail day={1} />
+              <SystemRow kind="phase" label="夜フェーズ" ts="11:20">夜が訪れた。占い師・人狼・狩人が行動を選択中…</SystemRow>
+              <SystemRow kind="death" label="襲撃" ts="08:00">
+                朝、<strong>Sora</strong> が無残な姿で発見された。村は大きく動揺している。
+              </SystemRow>
+              <SystemRow kind="phase" label="Day 2 議論開始" ts="08:05">2日目の議論が始まりました。</SystemRow>
+            </>
+          )}
         </div>
       </ThreePaneLayout>
     </div>


### PR DESCRIPTION
## Summary
- Add replay parsing/loading for archived `state_archive/{session}` games.
- Connect game cards to the spectator screen with async replay loading.
- Add Vitest coverage for JSONL parsing and THINK-row merging.
- Document the replay loader boundary and future chunk/streaming replacement points.
- Remove completed Issue #318 from `doc/Ideas.md`.

## Test plan
- [x] `npm test`
- [x] `npm run build`
- [x] `uv run ruff check .`
- [x] `uv run pytest`
- [x] Local Vite smoke check for `/state_archive/index.json` and replay JSONL serving

## Notes
- Follow-up polish is likely needed around real replay UI fidelity: vote breakdowns, night summaries, social counters, and deeper navigation remain fallback/stubbed per #312.

Closes #318

🤖 Generated with [Codex](https://Codex.com/Codex)
