### PR TITLE
fix: constrain spectator feed layout

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,7 +19,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#348 | bug | 🔴 | 1 | SpectatorScreen feed overflows viewport | 中央フィードが画面外にはみ出しスクロール不能。colCenter が flex コンテナ外に膨張している |
 | yukkie/AgentVillage#349 | tech-debt | 🔴 | 2 | Remove public_log.jsonl — use spectator_log.jsonl with is_public filter | spectator_log.jsonl に一本化し public_log.jsonl の出力を廃止。CUI は is_public フラグでフィルタ |
 | yukkie/AgentVillage#346 | bug | 🔴 | 2 | SpectatorScreen left pane shows hardcoded execution target and phase labels | 左ペインの処刑対象・夜フェーズラベルが実ログ未接続。elimination / vote / night_attack から導出可能 |
 | yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |

--- a/frontend/src/components/ThreePaneLayout.layout.test.js
+++ b/frontend/src/components/ThreePaneLayout.layout.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const componentsDir = __dirname;
+const screensDir = path.resolve(__dirname, '../screens');
+
+function readCss(relativePath) {
+  const baseDir = relativePath.startsWith('screens/') ? screensDir : componentsDir;
+  const cssPath = relativePath.replace(/^screens\//, '');
+  return fs.readFileSync(path.join(baseDir, cssPath), 'utf8');
+}
+
+function ruleBlock(css, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`${escaped}\\s*\\{(?<body>[^}]*)\\}`));
+  return match?.groups?.body ?? '';
+}
+
+function expectDeclaration(block, property, value) {
+  expect(block.replace(/\s+/g, ' ')).toContain(`${property}: ${value}`);
+}
+
+describe('ThreePaneLayout height contract', () => {
+  it('keeps viewport height ownership in SpectatorScreen frame', () => {
+    /**
+     * SUT: SpectatorScreen.module.css / ThreePaneLayout.module.css
+     * Mock: なし
+     * Level: unit
+     * Objective: ブラウザ由来の viewport height を SpectatorScreen frame だけが所有することを検証する。
+     */
+    const spectatorCss = readCss('screens/SpectatorScreen.module.css');
+    const layoutCss = readCss('ThreePaneLayout.module.css');
+
+    expectDeclaration(ruleBlock(spectatorCss, '.frame'), 'height', '100vh');
+    expect(layoutCss).not.toContain('100vh');
+  });
+
+  it('allows panes to shrink inside their parent instead of expanding to fit feed content', () => {
+    /**
+     * SUT: ThreePaneLayout.module.css
+     * Mock: なし
+     * Level: unit
+     * Objective: 3ペインがコンテンツ高さではなく親から与えられた高さに閉じる制約を持つことを検証する。
+     */
+    const css = readCss('ThreePaneLayout.module.css');
+
+    expectDeclaration(ruleBlock(css, '.shell'), 'min-height', '0');
+    expectDeclaration(ruleBlock(css, '.shell'), 'overflow', 'hidden');
+    expectDeclaration(ruleBlock(css, '.colLeft'), 'min-height', '0');
+    expectDeclaration(ruleBlock(css, '.colCenter'), 'min-height', '0');
+    expectDeclaration(ruleBlock(css, '.colCenter'), 'min-width', '0');
+    expectDeclaration(ruleBlock(css, '.colCenter'), 'overflow', 'hidden');
+    expectDeclaration(ruleBlock(css, '.colRight'), 'min-height', '0');
+  });
+
+  it('keeps the speech feed as the scrolling area within the center pane', () => {
+    /**
+     * SUT: SpectatorScreen.module.css
+     * Mock: なし
+     * Level: unit
+     * Objective: 中央フィードが残り高さの中でスクロールする領域として定義されることを検証する。
+     */
+    const css = readCss('screens/SpectatorScreen.module.css');
+    const feed = ruleBlock(css, '.feed');
+
+    expectDeclaration(feed, 'flex', '1');
+    expectDeclaration(feed, 'min-height', '0');
+    expectDeclaration(feed, 'overflow-y', 'auto');
+  });
+});

--- a/frontend/src/components/ThreePaneLayout.module.css
+++ b/frontend/src/components/ThreePaneLayout.module.css
@@ -7,6 +7,7 @@
   transition: grid-template-columns 220ms ease;
   min-height: 0;
   position: relative;
+  overflow: hidden;
 }
 
 .colLeft {
@@ -15,7 +16,8 @@
   background: var(--bg-1);
   display: flex;
   flex-direction: column;
-  overflow: visible;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .colCenter {
@@ -23,6 +25,8 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .colRight {
@@ -31,7 +35,8 @@
   background: var(--bg-1);
   display: flex;
   flex-direction: column;
-  overflow: visible;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* コンテンツ領域（collapse時に隠す） */

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -116,7 +116,7 @@
 }
 .feedHead .stat strong { color: var(--tx); font-weight: 600; font-family: var(--mono); }
 
-.feed { flex: 1; overflow-y: auto; padding: 4px 0 40px; }
+.feed { flex: 1; min-height: 0; overflow-y: auto; padding: 4px 0 40px; }
 
 /* Speech card */
 .speech {


### PR DESCRIPTION
## Summary
- constrain ThreePaneLayout panes so they stay inside the SpectatorScreen viewport frame
- keep the speech feed as the center pane's internal scroll area
- add a CSS contract test for the layout height ownership and scroll behavior
- remove completed issue #348 from Ideas.md

## Test plan
- [x] `npm.cmd test`
- [x] `npm.cmd run build`
- [x] `uv run ruff check .`
- [x] `uv run pytest`
- [x] Playwright verification at 1440x893 and 1920x893

Closes #348

🤖 Generated with [Codex](https://Codex.com/Codex)