### PR TITLE
refactor: remove public_log.jsonl

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -264,7 +264,7 @@ Contract test: `tests/contract/test_day_phase_contract.py`, `tests/contract/test
 |---|---|---|
 | 長期記憶 | 性格・他エージェントの基本印象 | `persona` / `beliefs` フィールド |
 | 中期記憶 | 今回のゲームの出来事 | `memory_summary` フィールド |
-| 短期記憶 | 今日の議論・投票候補 | 当日の `public_log` をそのまま渡す |
+| 短期記憶 | 今日の議論・投票候補 | 当日の公開イベントと投票候補を渡す |
 
 ---
 

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -43,8 +43,7 @@ AgentVillage/
 │   ├── stats/                  # ゲーム統計の記録（state/stats/ への書き込み）・集計・表示
 │   └── ui/                     # UIレイヤー（CLI / 将来Web）
 ├── state/
-│   ├── public_log.jsonl        # 公開ログ（ゲーム開始時にクリア、アーカイブ後も残留）
-│   ├── spectator_log.jsonl     # 観戦者ログ（公開＋非公開の全イベントを is_public フラグ付きで記録。Web UI はこちらのみ読む）
+│   ├── spectator_log.jsonl     # 公開＋非公開の全イベントを is_public フラグ付きで記録
 │   ├── agents/                 # エージェントごとの状態ファイル（ゲーム開始時に削除、アーカイブ後も残留）
 │   │   ├── setsu.json
 │   │   └── ...
@@ -96,11 +95,10 @@ spectator.py がログを書き出す  →  state_archive/{session}/
                                    agents/*.json            （lib/parseGameData.js）
                                                             is_public=false のイベントは
                                                             public モードで非表示にする
-                                   public_log.jsonl     ※ Web UI は使用しない（CLI 専用）
 ```
 
 **この方針を採用する理由**:
-- Python 側は既存の CLI 動作を一切変えずに済む（CLI を壊さない）
+- Python 側はログ出力を1本に集約し、CLI/Web ともに `is_public` フィルタで公開範囲を切り替えられる
 - JS 側はファイルを読むだけなので Python への依存ゼロ
 - 将来 FastAPI（#315）に移行する際も、JS 側の fetch 先を変えるだけで済む
 
@@ -234,7 +232,8 @@ Contract test: `tests/contract/test_day_phase_contract.py`, `tests/contract/test
 
 ### 3.6 Logger（`src/logger/`）
 
-- 公開ログ（`public_log.jsonl`）と観戦者ログ（真実込み）を分けて保存
+- `spectator_log.jsonl` に公開・非公開の全イベントを `is_public` フラグ付きで保存する
+- CUI replay の public モードは `is_public=true` のイベントのみを表示し、spectator モードは全イベントを表示する
 - リプレイ機能の基盤
 - `LogWriter.__init__` がゲーム開始時にログファイルのクリアと同時に `state/agents/*.json` も削除する。ログと agents の初期化責務を同一箇所に集約するため
 - `state/stats/game_stats.json` は削除しない（累積統計を維持）

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -310,7 +310,7 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 | モジュール | 責務 |
 |---|---|
 | `logger.py` | 削除済み。定数は `src/config.py` に移管 |
-| `writer.py` | `public_log.jsonl`（全員公開）と `spectator_log.jsonl`（真実込み）への書き込み。定数は `src/config` から import |
+| `writer.py` | `spectator_log.jsonl` への書き込み。公開・非公開の全イベントを `is_public` フラグ付きで保存する。定数は `src/config` から import |
 | `reader.py` | `load_events(path: Path) -> list[LogEvent]` — JSONL ログの読み込みユーティリティ。GUI・リプレイ・将来の外部ツールが共通利用する |
 | `replay.py` | ログを読んで再生する（将来のリプレイUI用） |
 
@@ -451,7 +451,7 @@ parseGameData(jsonlText, agentJsonByName)
 | 偽CO バッジ | 赤＋「偽」マーク | 中立色 |
 | 思考ログピル | 展開可 | ロックバッジ（存在のみ示す） |
 
-`spectator_log.jsonl`（`thought` フィールドあり）と `public_log.jsonl`（`thought` なし）を切り替えることで対応する。
+`spectator_log.jsonl` を読み込み、public モードでは `is_public=true` のイベントのみを表示し、spectator モードでは全イベントを表示することで対応する。
 
 ### replay.py — クラス構成
 
@@ -481,7 +481,7 @@ class ReplayPager:
 
 **初期化:**
 1. `archive_path/agents/*.json` を `actor_from_dict()` 経由で `Actor` としてロード
-2. `spectator_mode` に応じて `spectator_log.jsonl` または `public_log.jsonl` を読み込み
+2. `spectator_log.jsonl` を読み込み、public モードでは `is_public=true` のイベントだけに絞る
 3. 各 `LogEvent` を `Renderer.on_event()` で描画し、`list[str]`（ANSI 文字列）としてバッファに積む
 
 **`_build_lines()` の claimed_role 動的追跡:**

--- a/doc/GameData.md
+++ b/doc/GameData.md
@@ -18,7 +18,7 @@ Issue #312 の責務：Milestone 1/2 実装中に発覚した「実ログにな�
 | `hot` | 注目フラグ（「注目」タブのフィルター条件） | ❌ ログに存在しない | ❌ スタブ固定（`false` で代替） |
 | `live` | 進行中フラグ（LIVE表示・「注目」タブのフィルター条件） | ❌ ログに存在しない（完了済みアーカイブのみ） | ❌ スタブ固定（`false` で代替） |
 
-上記フィールドは `public_log.jsonl` / `agents/*.json` のいずれにも存在しない。
+上記フィールドは `spectator_log.jsonl` / `agents/*.json` のいずれにも存在しない。
 Milestone 3（FastAPI / DB 導入後）に改めて対応方針を検討する。
 
 ### #338 で確認したスタブUI（データギャップとは別）
@@ -78,9 +78,9 @@ Milestone 3（FastAPI / DB 導入後）に改めて対応方針を検討する�
 | フィールド | 用途 | 現状 | 対応方針 |
 |---|---|---|---|
 | `thought` | 発言前の思考ログ（spectator限定表示） | ✅ `spectator_log.jsonl` に `is_public=false` + `content: "[THINK] ..."` の speech 行として存在。`parseGameData.js` が同じ `day/agent/speech_id` の公開 speech に結合して `thought` プロパティを生成 | ✅ 実装済み（スタブ不要） |
-| `claimed_role` | CO（カミングアウト）フラグ | ✅ `public_log.jsonl` / `spectator_log.jsonl` の speech 行・co_announcement 行に存在 | ✅ 実装済み（スタブ不要） |
-| `reply_to` | 返信先 speech_id | ✅ `public_log.jsonl` / `spectator_log.jsonl` の speech 行に存在（返信なし時は `null`） | ✅ 実装済み（スタブ不要） |
-| `speech_id` | 発言の連番ID（日内） | ✅ `public_log.jsonl` / `spectator_log.jsonl` の speech 行に存在 | ✅ 実装済み（スタブ不要） |
+| `claimed_role` | CO（カミングアウト）フラグ | ✅ `spectator_log.jsonl` の speech 行・co_announcement 行に存在 | ✅ 実装済み（スタブ不要） |
+| `reply_to` | 返信先 speech_id | ✅ `spectator_log.jsonl` の speech 行に存在（返信なし時は `null`） | ✅ 実装済み（スタブ不要） |
+| `speech_id` | 発言の連番ID（日内） | ✅ `spectator_log.jsonl` の speech 行に存在 | ✅ 実装済み（スタブ不要） |
 
 #### スタブUI（データ・機能が未実装の UI 要素）
 
@@ -142,7 +142,7 @@ AgentDetailScreen は現在 `stub/agentDetail.js` のデータのみを参照し
 | `persona_short`（blurb） | エージェントの1行プロフィール | ❌ `config/agents.json` に存在しない | `stub/agentDetail.js` の `AGENT_BLURB` スタブ固定。`config/agents.json` への追加が必要 |
 | 通算戦績（wins / games / cheers） | ヒーローヘッダーの統計表示 | ❌ アーカイブから集計されていない | `stub/agentDetail.js` の `AGENT_STATS` スタブ固定。#337 実データ集計で対応予定 |
 | 疑い・信頼スコア | 疑いマトリクス表示 | ❌ 実ログに存在しない | `getSuspicionMatrix()` が `charCodeAt` ベースのハッシュで生成。エージェントの `thought` から推定する設計が必要 |
-| 夜の行動ログ | 夜の行動タブ | ❌ `public_log.jsonl` に存在しない | `stub/agentDetail.js` の `NIGHT_ACTIONS` スタブ固定。夜フェーズログの出力が必要 |
+| 夜の行動ログ | 夜の行動タブ | ✅ `spectator_log.jsonl` に観戦者向けイベントとして存在 | `stub/agentDetail.js` の `NIGHT_ACTIONS` スタブ固定。実ログ接続が必要 |
 
 #### スタブUI
 
@@ -198,5 +198,5 @@ AgentDetailScreen は現在 `stub/agentDetail.js` のデータのみを参照し
 ## 凡例
 
 - **発見Issue**: このギャップを発見した実装 Issue
-- **現状**: 実ログ（`public_log.jsonl` / `state_archive/`）における現在の状態
+- **現状**: 実ログ（`spectator_log.jsonl` / `state_archive/`）における現在の状態
 - **対応方針**: Milestone 2 以降の実データ接続時に取るべきアクション

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,7 +19,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#349 | tech-debt | 🔴 | 2 | Remove public_log.jsonl — use spectator_log.jsonl with is_public filter | spectator_log.jsonl に一本化し public_log.jsonl の出力を廃止。CUI は is_public フラグでフィルタ |
 | yukkie/AgentVillage#346 | bug | 🔴 | 2 | SpectatorScreen left pane shows hardcoded execution target and phase labels | 左ペインの処刑対象・夜フェーズラベルが実ログ未接続。elimination / vote / night_attack から導出可能 |
 | yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |

--- a/frontend/stub/spectator.js
+++ b/frontend/stub/spectator.js
@@ -1,5 +1,5 @@
 // スタブデータ — Issue #309 Spectator feed screen
-// 本実装（#318 Replay viewer）で fetch('../state_archive/.../public_log.jsonl') に差し替える
+// 本実装（#318 Replay viewer）で fetch('../state_archive/.../spectator_log.jsonl') に差し替える
 
 // 役職割り当て（観戦者視点の真実情報 — 実ログには存在しない）
 export const ROLE_ASSIGNMENT = {
@@ -55,7 +55,7 @@ export const ACTIONS_TIMELINE = [
 ];
 
 // イベント列（data.js から抜粋・最小化）
-// GameData.md ギャップ: thought フィールドは実ログの public_log.jsonl には含まれない（spectator専用）
+// GameData.md ギャップ: thought フィールドは spectator_log.jsonl の非公開イベントから結合する
 export const EVENTS = [
   { day: 1, event_type: 'phase_start', content: '=== GAME START ===', agent: null, speech_id: null, reply_to: null },
   { day: 1, event_type: 'phase_start', content: '=== DAY 1  TURN 1 ===', agent: null, speech_id: null, reply_to: null },

--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,6 @@ WOLF_CHAT_ROUNDS = 3
 PROJECT_ROOT = Path(__file__).parent.parent
 AGENTS_DIR = PROJECT_ROOT / "state/agents"
 LOG_DIR = PROJECT_ROOT / "state"
-PUBLIC_LOG = LOG_DIR / "public_log.jsonl"
 SPECTATOR_LOG = LOG_DIR / "spectator_log.jsonl"
 ARCHIVE_DIR = PROJECT_ROOT / "state_archive"
 

--- a/src/logger/writer.py
+++ b/src/logger/writer.py
@@ -3,7 +3,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-from src.config import ARCHIVE_DIR, LOG_DIR, PUBLIC_LOG, SPECTATOR_LOG, AGENTS_DIR
+from src.config import ARCHIVE_DIR, LOG_DIR, SPECTATOR_LOG, AGENTS_DIR
 from src.domain.event import LogEvent
 
 
@@ -12,7 +12,7 @@ def archive_state() -> Path | None:
 
     Returns the archive path, or None if there was nothing to archive.
     """
-    if not PUBLIC_LOG.exists() or PUBLIC_LOG.stat().st_size == 0:
+    if not SPECTATOR_LOG.exists() or SPECTATOR_LOG.stat().st_size == 0:
         return None
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     dest = ARCHIVE_DIR / timestamp
@@ -25,7 +25,6 @@ class LogWriter:
     def __init__(self) -> None:
         LOG_DIR.mkdir(parents=True, exist_ok=True)
         AGENTS_DIR.mkdir(parents=True, exist_ok=True)
-        PUBLIC_LOG.write_text("", encoding="utf-8")
         SPECTATOR_LOG.write_text("", encoding="utf-8")
         for f in AGENTS_DIR.glob("*.json"):
             f.unlink()
@@ -33,12 +32,7 @@ class LogWriter:
     def write(self, event: LogEvent) -> None:
         line = event.model_dump_json() + "\n"
         try:
-            # Spectator log contains everything
             with SPECTATOR_LOG.open("a", encoding="utf-8") as f:
                 f.write(line)
-            # Public log only contains public events
-            if event.is_public:
-                with PUBLIC_LOG.open("a", encoding="utf-8") as f:
-                    f.write(line)
         except IOError as e:
             print(f"[LogWriter] write failed: {e}", file=sys.stderr)

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -118,8 +118,10 @@ class ReplayPager:
         return actors
 
     def _load_events(self) -> list[LogEvent]:
-        log_file = "spectator_log.jsonl" if self._spectator else "public_log.jsonl"
-        return load_events(self._archive / log_file)
+        events = load_events(self._archive / "spectator_log.jsonl")
+        if self._spectator:
+            return events
+        return [event for event in events if event.is_public]
 
     def _build_lines(self) -> list[str]:
         width = shutil.get_terminal_size().columns

--- a/tests/TestStrategy.md
+++ b/tests/TestStrategy.md
@@ -368,8 +368,8 @@ frontend/
  * Level: unit
  * Objective: JSONL 形式のログを { events, agents } の GameData 型に変換できること。
  */
-test('parses public_log.jsonl into events array', () => {
-  const result = parseGameData(fixtures.publicLog);
+test('parses spectator_log.jsonl into events array', () => {
+  const result = parseGameData(fixtures.spectatorLog);
   expect(result.events).toHaveLength(42);
 });
 ```

--- a/tests/unit/test_logger_writer.py
+++ b/tests/unit/test_logger_writer.py
@@ -17,10 +17,14 @@ def _make_event(is_public: bool = True) -> LogEvent:
 
 
 def test_write_creates_log_files(tmp_path: Path) -> None:
-    """正常系: ログファイルにイベントが書き込まれること。"""
+    """
+    SUT: LogWriter.write
+    Mock: src.logger.writer の LOG_DIR / SPECTATOR_LOG を tmp_path 配下に差し替え
+    Level: unit
+    Objective: spectator_log.jsonl にイベントが書き込まれ、public_log.jsonl が生成されないこと。
+    """
     with (
         patch("src.logger.writer.LOG_DIR", tmp_path),
-        patch("src.logger.writer.PUBLIC_LOG", tmp_path / "public_log.jsonl"),
         patch("src.logger.writer.SPECTATOR_LOG", tmp_path / "spectator_log.jsonl"),
     ):
         from src.logger.writer import LogWriter
@@ -29,14 +33,18 @@ def test_write_creates_log_files(tmp_path: Path) -> None:
         writer.write(_make_event(is_public=True))
 
         assert (tmp_path / "spectator_log.jsonl").read_text(encoding="utf-8").strip()
-        assert (tmp_path / "public_log.jsonl").read_text(encoding="utf-8").strip()
+        assert not (tmp_path / "public_log.jsonl").exists()
 
 
 def test_write_ioerror_prints_to_stderr_and_does_not_raise(tmp_path: Path) -> None:
-    """IOError 発生時にゲームが止まらず stderr に出力されること。"""
+    """
+    SUT: LogWriter.write
+    Mock: pathlib.Path.open が IOError を投げるように差し替え
+    Level: unit
+    Objective: IOError 発生時にゲームが止まらず stderr に出力されること。
+    """
     with (
         patch("src.logger.writer.LOG_DIR", tmp_path),
-        patch("src.logger.writer.PUBLIC_LOG", tmp_path / "public_log.jsonl"),
         patch("src.logger.writer.SPECTATOR_LOG", tmp_path / "spectator_log.jsonl"),
     ):
         from src.logger.writer import LogWriter

--- a/tests/unit/test_writer.py
+++ b/tests/unit/test_writer.py
@@ -5,15 +5,14 @@ from unittest.mock import patch
 from src.logger.writer import LogWriter, archive_state
 
 
-def _make_state(tmp_path: Path) -> tuple[Path, Path, Path]:
+def _make_state(tmp_path: Path) -> tuple[Path, Path]:
     """テスト用の state/ 構造を作成して返す。"""
     agents_dir = tmp_path / "agents"
     agents_dir.mkdir()
     stats_dir = tmp_path / "stats"
     stats_dir.mkdir()
     spectator_log = tmp_path / "spectator_log.jsonl"
-    public_log = tmp_path / "public_log.jsonl"
-    return agents_dir, public_log, spectator_log
+    return agents_dir, spectator_log
 
 
 def test_log_writer_clears_agent_json(tmp_path: Path) -> None:
@@ -23,7 +22,7 @@ def test_log_writer_clears_agent_json(tmp_path: Path) -> None:
     Level: unit
     Objective: LogWriter 生成時に state/agents/*.json が削除されること
     """
-    agents_dir, _public_log, spectator_log = _make_state(tmp_path)
+    agents_dir, spectator_log = _make_state(tmp_path)
     stale = agents_dir / "wolf1.json"
     stale.write_text("{}", encoding="utf-8")
 
@@ -44,7 +43,7 @@ def test_log_writer_preserves_stats(tmp_path: Path) -> None:
     Level: unit
     Objective: LogWriter 生成時に state/stats/ 配下のファイルが削除されないこと
     """
-    agents_dir, _public_log, spectator_log = _make_state(tmp_path)
+    agents_dir, spectator_log = _make_state(tmp_path)
     stats_file = tmp_path / "stats" / "game_stats.json"
     stats_file.write_text("[]", encoding="utf-8")
 
@@ -65,7 +64,7 @@ def test_log_writer_clears_multiple_agent_json(tmp_path: Path) -> None:
     Level: unit
     Objective: state/agents/ 内の複数 JSON がすべて削除されること
     """
-    agents_dir, _public_log, spectator_log = _make_state(tmp_path)
+    agents_dir, spectator_log = _make_state(tmp_path)
     files = [agents_dir / f"{name}.json" for name in ("alice", "wolf1", "wolf2")]
     for f in files:
         f.write_text("{}", encoding="utf-8")
@@ -87,7 +86,8 @@ def test_log_writer_no_error_when_agents_dir_empty(tmp_path: Path) -> None:
     Level: unit
     Objective: state/agents/ が空のときでもエラーなく初期化できること
     """
-    agents_dir, public_log, spectator_log = _make_state(tmp_path)
+    agents_dir, spectator_log = _make_state(tmp_path)
+    public_log = tmp_path / "public_log.jsonl"
 
     with (
         patch("src.logger.writer.LOG_DIR", tmp_path),

--- a/tests/unit/test_writer.py
+++ b/tests/unit/test_writer.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from src.logger.writer import LogWriter
+from src.logger.writer import LogWriter, archive_state
 
 
 def _make_state(tmp_path: Path) -> tuple[Path, Path, Path]:
@@ -11,25 +11,24 @@ def _make_state(tmp_path: Path) -> tuple[Path, Path, Path]:
     agents_dir.mkdir()
     stats_dir = tmp_path / "stats"
     stats_dir.mkdir()
-    public_log = tmp_path / "public_log.jsonl"
     spectator_log = tmp_path / "spectator_log.jsonl"
+    public_log = tmp_path / "public_log.jsonl"
     return agents_dir, public_log, spectator_log
 
 
 def test_log_writer_clears_agent_json(tmp_path: Path) -> None:
     """
     SUT: LogWriter.__init__
-    Mock: src.logger.writer の LOG_DIR / PUBLIC_LOG / SPECTATOR_LOG / AGENTS_DIR を tmp_path 配下に差し替え
+    Mock: src.logger.writer の LOG_DIR / SPECTATOR_LOG / AGENTS_DIR を tmp_path 配下に差し替え
     Level: unit
     Objective: LogWriter 生成時に state/agents/*.json が削除されること
     """
-    agents_dir, public_log, spectator_log = _make_state(tmp_path)
+    agents_dir, _public_log, spectator_log = _make_state(tmp_path)
     stale = agents_dir / "wolf1.json"
     stale.write_text("{}", encoding="utf-8")
 
     with (
         patch("src.logger.writer.LOG_DIR", tmp_path),
-        patch("src.logger.writer.PUBLIC_LOG", public_log),
         patch("src.logger.writer.SPECTATOR_LOG", spectator_log),
         patch("src.logger.writer.AGENTS_DIR", agents_dir),
     ):
@@ -45,13 +44,12 @@ def test_log_writer_preserves_stats(tmp_path: Path) -> None:
     Level: unit
     Objective: LogWriter 生成時に state/stats/ 配下のファイルが削除されないこと
     """
-    agents_dir, public_log, spectator_log = _make_state(tmp_path)
+    agents_dir, _public_log, spectator_log = _make_state(tmp_path)
     stats_file = tmp_path / "stats" / "game_stats.json"
     stats_file.write_text("[]", encoding="utf-8")
 
     with (
         patch("src.logger.writer.LOG_DIR", tmp_path),
-        patch("src.logger.writer.PUBLIC_LOG", public_log),
         patch("src.logger.writer.SPECTATOR_LOG", spectator_log),
         patch("src.logger.writer.AGENTS_DIR", agents_dir),
     ):
@@ -67,14 +65,13 @@ def test_log_writer_clears_multiple_agent_json(tmp_path: Path) -> None:
     Level: unit
     Objective: state/agents/ 内の複数 JSON がすべて削除されること
     """
-    agents_dir, public_log, spectator_log = _make_state(tmp_path)
+    agents_dir, _public_log, spectator_log = _make_state(tmp_path)
     files = [agents_dir / f"{name}.json" for name in ("alice", "wolf1", "wolf2")]
     for f in files:
         f.write_text("{}", encoding="utf-8")
 
     with (
         patch("src.logger.writer.LOG_DIR", tmp_path),
-        patch("src.logger.writer.PUBLIC_LOG", public_log),
         patch("src.logger.writer.SPECTATOR_LOG", spectator_log),
         patch("src.logger.writer.AGENTS_DIR", agents_dir),
     ):
@@ -94,8 +91,49 @@ def test_log_writer_no_error_when_agents_dir_empty(tmp_path: Path) -> None:
 
     with (
         patch("src.logger.writer.LOG_DIR", tmp_path),
-        patch("src.logger.writer.PUBLIC_LOG", public_log),
         patch("src.logger.writer.SPECTATOR_LOG", spectator_log),
         patch("src.logger.writer.AGENTS_DIR", agents_dir),
     ):
         LogWriter()  # エラーが出なければ OK
+
+    assert not public_log.exists()
+
+
+def test_archive_state_uses_spectator_log_as_archive_source(tmp_path: Path) -> None:
+    """
+    SUT: archive_state
+    Mock: src.logger.writer の LOG_DIR / SPECTATOR_LOG / ARCHIVE_DIR を tmp_path 配下に差し替え
+    Level: unit
+    Objective: spectator_log.jsonl が空でないとき state/ がアーカイブされること。
+    """
+    log_dir = tmp_path / "state"
+    archive_dir = tmp_path / "state_archive"
+    log_dir.mkdir()
+    spectator_log = log_dir / "spectator_log.jsonl"
+    spectator_log.write_text('{"event_type":"game_over"}\n', encoding="utf-8")
+
+    with (
+        patch("src.logger.writer.LOG_DIR", log_dir),
+        patch("src.logger.writer.SPECTATOR_LOG", spectator_log),
+        patch("src.logger.writer.ARCHIVE_DIR", archive_dir),
+    ):
+        archived = archive_state()
+
+    assert archived is not None
+    assert (archived / "spectator_log.jsonl").exists()
+
+
+def test_archive_state_returns_none_when_spectator_log_empty(tmp_path: Path) -> None:
+    """
+    SUT: archive_state
+    Mock: src.logger.writer の SPECTATOR_LOG を tmp_path 配下に差し替え
+    Level: unit
+    Objective: spectator_log.jsonl が空のときアーカイブしないこと。
+    """
+    spectator_log = tmp_path / "spectator_log.jsonl"
+    spectator_log.write_text("", encoding="utf-8")
+
+    with patch("src.logger.writer.SPECTATOR_LOG", spectator_log):
+        archived = archive_state()
+
+    assert archived is None

--- a/tests/unit/ui/test_replay.py
+++ b/tests/unit/ui/test_replay.py
@@ -22,7 +22,7 @@ def _make_event_jsonl(*events: LogEvent) -> str:
 
 @pytest.fixture()
 def tmp_archive(tmp_path: Path) -> Path:
-    """Minimal archive with 2 agents and a public log."""
+    """Minimal archive with 2 agents and a spectator log."""
     archive = tmp_path / "20260101_000000"
     agents_dir = archive / "agents"
     agents_dir.mkdir(parents=True)
@@ -34,7 +34,7 @@ def tmp_archive(tmp_path: Path) -> Path:
         json.dumps(make_split_agent_json("Bob", "Werewolf")), encoding="utf-8"
     )
 
-    event = LogEvent.make(
+    public_event = LogEvent.make(
         day=1,
         phase="day_opening",
         event_type=EventType.SPEECH,
@@ -42,11 +42,17 @@ def tmp_archive(tmp_path: Path) -> Path:
         content="Hello everyone.",
         is_public=True,
     )
-    (archive / "public_log.jsonl").write_text(
-        _make_event_jsonl(event), encoding="utf-8"
+    private_event = LogEvent.make(
+        day=1,
+        phase="night",
+        event_type=EventType.NIGHT_ATTACK,
+        agent="Bob",
+        target="Alice",
+        content="Bob attacks Alice.",
+        is_public=False,
     )
     (archive / "spectator_log.jsonl").write_text(
-        _make_event_jsonl(event), encoding="utf-8"
+        _make_event_jsonl(public_event, private_event), encoding="utf-8"
     )
     return archive
 
@@ -94,6 +100,40 @@ def test_pager_spectator_shows_more_lines(tmp_archive: Path) -> None:
     assert len(spectator_pager._lines) >= len(public_pager._lines)
 
 
+def test_pager_public_mode_filters_private_events_from_spectator_log(
+    tmp_archive: Path,
+) -> None:
+    """
+    SUT: ReplayPager._load_events
+    Mock: なし
+    Level: unit
+    Objective: public モードでは spectator_log.jsonl の is_public=True イベントだけを読み込むこと。
+    """
+    pager = ReplayPager(tmp_archive, spectator_mode=False)
+
+    events = pager._load_events()
+
+    assert events
+    assert all(event.is_public for event in events)
+
+
+def test_pager_spectator_mode_loads_all_events_from_spectator_log(
+    tmp_archive: Path,
+) -> None:
+    """
+    SUT: ReplayPager._load_events
+    Mock: なし
+    Level: unit
+    Objective: spectator モードでは spectator_log.jsonl の公開・非公開イベントを両方読み込むこと。
+    """
+    pager = ReplayPager(tmp_archive, spectator_mode=True)
+
+    events = pager._load_events()
+
+    assert any(event.is_public for event in events)
+    assert any(not event.is_public for event in events)
+
+
 # ── ArchiveSelector ──────────────────────────────────────────────────────────
 
 
@@ -128,7 +168,6 @@ def test_pager_loads_empty_when_agents_dir_missing(tmp_path: Path) -> None:
         content="Hello.",
         is_public=True,
     )
-    (archive / "public_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
     (archive / "spectator_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
 
     import sys
@@ -160,7 +199,6 @@ def test_pager_skips_corrupt_agent_file(tmp_path: Path) -> None:
         content="Hello.",
         is_public=True,
     )
-    (archive / "public_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
     (archive / "spectator_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
 
     import sys
@@ -192,7 +230,6 @@ def test_pager_loads_legacy_agent_json_without_profile(tmp_path: Path) -> None:
         content="Hello.",
         is_public=True,
     )
-    (archive / "public_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
     (archive / "spectator_log.jsonl").write_text(event.model_dump_json(), encoding="utf-8")
 
     pager = ReplayPager(archive, spectator_mode=False)

--- a/tools/generate_archive_index.py
+++ b/tools/generate_archive_index.py
@@ -4,7 +4,7 @@ Run from the repository root:
     python tools/generate_archive_index.py
 
 Reads each session under state_archive/ and extracts game metadata from
-public_log.jsonl and agents/*.json. The resulting index.json is consumed
+spectator_log.jsonl and agents/*.json. The resulting index.json is consumed
 by the frontend via archiveLoader.js.
 """
 
@@ -25,7 +25,7 @@ _SESSION_RE = re.compile(r"^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})$")
 
 
 def parse_session(session_id: str, session_dir: str) -> dict | None:
-    log_path = os.path.join(session_dir, "public_log.jsonl")
+    log_path = os.path.join(session_dir, "spectator_log.jsonl")
     agents_dir = os.path.join(session_dir, "agents")
 
     if not os.path.isfile(log_path) or not os.path.isdir(agents_dir):


### PR DESCRIPTION
## Summary
- Remove `public_log.jsonl` output and keep `spectator_log.jsonl` as the single log source
- Filter `spectator_log.jsonl` by `is_public` for CUI public replay mode
- Update archive indexing, docs, and tests for the single-log flow
- Remove completed issue #349 from `doc/Ideas.md`

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest`
- [x] `uv run pytest --cov=src --cov-report=term-missing`

Closes #349

🤖 Generated with [Codex](https://Codex.com/Codex)