### PR TITLE
fix(frontend): connect left pane execution target and night phase label to real log data

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,12 +19,13 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#346 | bug | 🔴 | 2 | SpectatorScreen left pane shows hardcoded execution target and phase labels | 左ペインの処刑対象・夜フェーズラベルが実ログ未接続。elimination / vote / night_attack から導出可能 |
 | yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |
 | yukkie/AgentVillage#344 | tech-debt | 🟡 | 3 | Design: LogEvent cannot express mixed public/private fields in a single speech event | speech イベントの公開/非公開混在問題の設計を定め Architecture.md に記載、[THINK] ハックを廃止する設計Issueを作る |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |
+| yukkie/AgentVillage#357 | tech-debt | 🔴 | 2 | Remove remaining stub fallbacks in SpectatorScreen (NIGHT_RESULTS, VOTE_TABLE_D1, ACTIONS_TIMELINE, ROLE_ASSIGNMENT) | #346 で未対応のスタブ依存4件を実ログ由来データに差し替え、stub/spectator.js の import を完全除去 |
+| yukkie/AgentVillage#358 | enhancement | 🔴 | 2 | Define phase click behavior in SpectatorScreen left pane | 投票・処刑・夜フェーズ行クリック時の中央フィード表示仕様を決定し実装 |
 | yukkie/AgentVillage#350 | enhancement | 🟡 | 3 | Rework SpectatorScreen right pane — role display, real log actions, day-linked view | 容疑度メーター削除・役職表示改善・夜行動実ログ接続・左ペイン日付クリック連動。#314/#346 依存 |
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -93,6 +93,39 @@ function parseAgent(agentJson) {
 }
 
 /**
+ * Aggregate per-day execution target, vote count, and night completion from
+ * elimination / vote / night_attack events. Days with only other event types
+ * (speech, guard, etc.) have no entry in the returned map.
+ *
+ * @param {object[]} events
+ * @returns {Record<number, { target: string|null, votes: number, nightDone: boolean }>}
+ */
+export function aggregateDayResults(events) {
+  const result = {};
+  const voteCounts = {};
+
+  for (const ev of events) {
+    const d = ev.day;
+    if (!d) continue;
+
+    if (ev.event_type === 'elimination' && ev.is_public) {
+      if (!result[d]) result[d] = { target: null, votes: 0, nightDone: false };
+      result[d].target = ev.agent;
+    } else if (ev.event_type === 'vote') {
+      if (!result[d]) result[d] = { target: null, votes: 0, nightDone: false };
+      if (!voteCounts[d]) voteCounts[d] = {};
+      voteCounts[d][ev.target] = (voteCounts[d][ev.target] || 0) + 1;
+      result[d].votes = Math.max(...Object.values(voteCounts[d]));
+    } else if (ev.event_type === 'night_attack' && ev.is_public) {
+      if (!result[d]) result[d] = { target: null, votes: 0, nightDone: false };
+      result[d].nightDone = true;
+    }
+  }
+
+  return result;
+}
+
+/**
  * Parse archive JSONL and agent JSON into the GameData shape consumed by React.
  *
  * This function is intentionally synchronous and pure. I/O stays in
@@ -101,7 +134,7 @@ function parseAgent(agentJson) {
  *
  * @param {string} jsonlText
  * @param {Record<string, object>} agentJsonByName
- * @returns {{ events: object[], agents: Record<string, object> }}
+ * @returns {{ events: object[], agents: Record<string, object>, daySummary: object }}
  */
 export function parseGameData(jsonlText, agentJsonByName = {}) {
   const rawEvents = jsonlText
@@ -115,8 +148,10 @@ export function parseGameData(jsonlText, agentJsonByName = {}) {
     if (agent.name) agents[agent.name] = agent;
   });
 
+  const events = normalizeEvents(rawEvents);
   return {
-    events: normalizeEvents(rawEvents),
+    events,
     agents,
+    daySummary: aggregateDayResults(rawEvents),
   };
 }

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseEventLine, parseGameData, normalizeEvents } from './parseGameData.js';
+import { parseEventLine, parseGameData, normalizeEvents, aggregateDayResults } from './parseGameData.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -92,5 +92,70 @@ describe('parseGameData', () => {
 
     expect(miraSpeech.thought).toContain('Day 1');
     expect(miraSpeech.thought).not.toContain('[THINK]');
+  });
+
+  it('includes daySummary in returned GameData', () => {
+    /*
+     * SUT: parseGameData
+     * Mock: なし（design/proposal/source_logs/ の実ログを fixture に使用）
+     * Level: unit
+     * Objective: parseGameData の返り値に daySummary が含まれ、実ログの elimination/night_attack から正しく導出されることを検証する。
+     */
+    const gameData = parseGameData(readFixture('spectator_log.jsonl'));
+    expect(gameData.daySummary).toBeDefined();
+    const day1 = gameData.daySummary[1];
+    expect(day1.target).toBeTruthy();
+    expect(typeof day1.votes).toBe('number');
+    expect(typeof day1.nightDone).toBe('boolean');
+  });
+});
+
+describe('aggregateDayResults', () => {
+  it('extracts elimination target and top vote count', () => {
+    /*
+     * SUT: aggregateDayResults
+     * Mock: なし
+     * Level: unit
+     * Objective: elimination イベントの agent フィールドが daySummary の target に反映され、vote 集計で最多票数が votes に入ることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'elimination', agent: 'Kael', is_public: true },
+      { day: 1, event_type: 'vote', agent: 'Nox',  target: 'Kael' },
+      { day: 1, event_type: 'vote', agent: 'Mira', target: 'Kael' },
+      { day: 1, event_type: 'vote', agent: 'Ren',  target: 'Sora' },
+    ];
+    const summary = aggregateDayResults(events);
+    expect(summary[1].target).toBe('Kael');
+    expect(summary[1].votes).toBe(2);
+  });
+
+  it('sets nightDone true when public night_attack exists', () => {
+    /*
+     * SUT: aggregateDayResults
+     * Mock: なし
+     * Level: unit
+     * Objective: is_public な night_attack イベントがある日は nightDone が true、ない日は false になることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', agent: 'Rei',  is_public: true },
+      { day: 2, event_type: 'night_attack', agent: 'Sora', is_public: false },
+    ];
+    const summary = aggregateDayResults(events);
+    expect(summary[1].nightDone).toBe(true);
+    expect(summary[2]).toBeUndefined();
+  });
+
+  it('returns no entry for days with only speech events', () => {
+    /*
+     * SUT: aggregateDayResults
+     * Mock: なし
+     * Level: unit
+     * Objective: speech のみのイベント列では daySummary にエントリが作られないことを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'speech', agent: 'Mira', speech_id: 1 },
+    ];
+    const summary = aggregateDayResults(events);
+    expect(summary[1]).toBeUndefined();
   });
 });

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -3,10 +3,10 @@ import Avatar from '../components/Avatar.jsx';
 import RoleTag from '../components/RoleTag.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
-import { ROLES, AGENT_PALETTE } from '../lib/constants.js';
+import { ROLES } from '../lib/constants.js';
 import {
-  ROLE_ASSIGNMENT, NIGHT_RESULTS, EXEC_RESULTS,
-  VOTE_TABLE_D1, ACTIONS_TIMELINE, EVENTS,
+  ROLE_ASSIGNMENT, NIGHT_RESULTS,
+  VOTE_TABLE_D1, ACTIONS_TIMELINE,
 } from '../../stub/spectator.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
 import { parseGameData } from '../lib/parseGameData.js';
@@ -105,9 +105,10 @@ function SystemRow({ kind, label, children, ts }) {
 }
 
 // --- 投票内訳カード ---
-function VoteDetail({ day }) {
+function VoteDetail({ day, daySummary }) {
   if (day !== 1) return null;
-  const exec = EXEC_RESULTS[1];
+  const exec = daySummary[1];
+  if (!exec) return null;
   return (
     <div className={styles.voteDetail}>
       <h4>
@@ -146,7 +147,7 @@ function FeedItem({ ev, prevById, roleAssignment, title }) {
 }
 
 // === 左ペイン ===
-function LeftPane({ activeDay, setDay, days, agentNames }) {
+function LeftPane({ activeDay, setDay, days, agentNames, daySummary }) {
   return (
     <>
       <div className={styles.phaseNav}>
@@ -165,10 +166,10 @@ function LeftPane({ activeDay, setDay, days, agentNames }) {
                 <span className={styles.dot} /> 議論フェーズ <span className={styles.phaseTurn}>12 発言</span>
               </div>
               <div className={`${styles.phaseItem} ${styles.phaseExec}`}>
-                <span className={styles.dot} /> 投票・処刑 <span className={styles.phaseTurn}>{EXEC_RESULTS[d]?.target || '—'}</span>
+                <span className={styles.dot} /> 投票・処刑 <span className={styles.phaseTurn}>{daySummary[d]?.target || '—'}</span>
               </div>
               <div className={`${styles.phaseItem} ${styles.phaseNight}`}>
-                <span className={styles.dot} /> 夜フェーズ <span className={styles.phaseTurn}>{d < 3 ? '完了' : '進行中'}</span>
+                <span className={styles.dot} /> 夜フェーズ <span className={styles.phaseTurn}>{daySummary[d]?.nightDone ? '完了' : '進行中'}</span>
               </div>
             </div>
           </div>
@@ -310,6 +311,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   const [activeDay, setActiveDay] = useState(2);
   const [replayEvents, setReplayEvents] = useState(null);
   const [replayAgents, setReplayAgents] = useState({});
+  const [replayDaySummary, setReplayDaySummary] = useState(null);
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
   const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
   const [loadError, setLoadError] = useState(null);
@@ -320,6 +322,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     let cancelled = false;
     setReplayEvents(null);
     setReplayAgents({});
+    setReplayDaySummary(null);
     setLoadingEvents(true);
     setLoadingAgents(true);
     setLoadError(null);
@@ -341,6 +344,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         if (cancelled) return;
         const parsed = parseGameData(jsonlText);
         setReplayEvents(parsed.events);
+        setReplayDaySummary(parsed.daySummary);
         const firstDay = parsed.events.find(event => event.day)?.day;
         if (firstDay) setActiveDay(firstDay);
       })
@@ -356,47 +360,28 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     };
   }, [sessionId, cast]);
 
-  const events = replayEvents ?? EVENTS;
+  const events = replayEvents ?? [];
   const agents = replayAgents;
-  const roleAssignment = useMemo(() => {
-    if (!Object.keys(agents).length) return ROLE_ASSIGNMENT;
-    return Object.fromEntries(
-      Object.entries(agents).map(([name, agent]) => [name, agent.role])
-    );
-  }, [agents]);
-  const agentNames = Object.keys(agents).length ? Object.keys(agents) : Object.keys(AGENT_PALETTE);
-  const days = [...new Set(events.map(event => event.day).filter(Boolean))].sort((a, b) => a - b);
-  const visibleDays = days.length ? days : [1, 2, 3];
+  const daySummary = replayDaySummary ?? {};
+  const roleAssignment = useMemo(() => Object.fromEntries(
+    Object.entries(agents).map(([name, agent]) => [name, agent.role])
+  ), [agents]);
+  const agentNames = Object.keys(agents);
+  const visibleDays = [...new Set(events.map(event => event.day).filter(Boolean))].sort((a, b) => a - b);
 
   const prevById = {};
   events.forEach(e => {
     if (e.speech_id != null) prevById[`${e.day}-${e.speech_id}`] = e;
   });
 
-  const d1 = events.filter(e =>
-    e.day === 1 && (
-      e.event_type === 'speech' ||
-      (e.event_type === 'phase_start' && e.content.includes('GAME START'))
-    )
-  );
-  const d2 = events.filter(e => e.day === 2 && e.event_type === 'speech');
-  const activeEvents = events.filter(e =>
+  const feedEvents = events.filter(e =>
     e.day === activeDay && (
       e.event_type === 'speech' ||
       e.event_type === 'phase_start'
     )
   );
-  const feedEvents = sessionId
-    ? activeEvents
-    : [...d1, ...d2];
   const speechCount = events.filter(e => e.event_type === 'speech').length;
   const coCount = events.filter(e => e.claimed_role).length;
-
-  const annotate = (e) => {
-    if (e.day === 2 && e.agent === 'Ren' && e.speech_id === 1) return { ...e, claimed_role: 'Seer' };
-    if (e.day === 2 && e.agent === 'Nox' && e.speech_id === 2) return { ...e, claimed_role: 'Seer' };
-    return e;
-  };
 
   return (
     <div className={styles.frame}>
@@ -411,7 +396,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
       <ThreePaneLayout
         collapsibleLeft
         collapsibleRight
-        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} days={visibleDays} agentNames={agentNames} />}
+        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} days={visibleDays} agentNames={agentNames} daySummary={daySummary} />}
         right={<RightPane agents={agents} roleAssignment={roleAssignment} />}
       >
         <div className={styles.feedHead}>
@@ -438,25 +423,12 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
           {feedEvents.map((e, i) => (
             <FeedItem
               key={e.id || `${e.day}-${e.event_type}-${e.agent}-${e.speech_id}-${i}`}
-              ev={annotate(e)}
+              ev={e}
               prevById={prevById}
               roleAssignment={roleAssignment}
               title={title || sessionId}
             />
           ))}
-          {!sessionId && (
-            <>
-              <SystemRow kind="exec" label="処刑" ts="11:14">
-                <strong>Toma</strong> が処刑された（4票）。役職は <strong style={{ color: 'var(--r-villager)' }}>村人</strong> でした。
-              </SystemRow>
-              <VoteDetail day={1} />
-              <SystemRow kind="phase" label="夜フェーズ" ts="11:20">夜が訪れた。占い師・人狼・狩人が行動を選択中…</SystemRow>
-              <SystemRow kind="death" label="襲撃" ts="08:00">
-                朝、<strong>Sora</strong> が無残な姿で発見された。村は大きく動揺している。
-              </SystemRow>
-              <SystemRow kind="phase" label="Day 2 議論開始" ts="08:05">2日目の議論が始まりました。</SystemRow>
-            </>
-          )}
         </div>
       </ThreePaneLayout>
     </div>


### PR DESCRIPTION
## Summary

- `parseGameData.js` に `aggregateDayResults()` を追加。`elimination` / `vote` / `night_attack` イベントを1パスで集計し、日単位の処刑対象・最多得票数・夜フェーズ完了フラグを返す
- `parseGameData()` の返り値に `daySummary` を追加。`SpectatorScreen` は `replayDaySummary` として state 管理
- 左ペインの「投票・処刑」欄を `EXEC_RESULTS` スタブから `daySummary[d]?.target` に差し替え
- 夜フェーズラベルを `d < 3 ? '完了' : '進行中'` ハードコードから `daySummary[d]?.nightDone` に差し替え
- `events` / `daySummary` / `roleAssignment` / `agentNames` / `visibleDays` のスタブフォールバックを除去（`sessionId` が常に存在する実運用では、フォールバックがロードエラーをスタブで隠す不具合になっていた）
- スタブ専用のデッドコード（`d1`/`d2` 分割、`annotate()`、`!sessionId` 静的フィードブロック）を削除
- follow-up Issue #357（残スタブ除去）・#358（フェーズクリック仕様）を起票

## Test plan

- [x] `ruff check .` パス
- [x] `pytest` パス
- [x] `aggregateDayResults` のユニットテスト（elimination target / vote 集計 / nightDone / speech-only 日）
- [x] `parseGameData` が `daySummary` を返すことを実 fixture で確認
- [x] Playwright で実アーカイブを開き、左ペインの処刑対象・夜フェーズラベルが実ログ値で表示されることを目視確認

Closes #346
🤖 Generated with [Claude Code](https://claude.com/claude-code)