### PR TITLE
feat: introduce RTL contract tests

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -18,7 +18,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#360 | enhancement | 🔴 | 3 | Introduce React Testing Library and browser-JS contract tests | RTL 導入 + FeedItem / LeftPane のコンポーネントテスト追加。TestStrategy.md §9.1 の導入判断基準を条件ベースに更新 |
 | yukkie/AgentVillage#362 | bug | 🔴 | 3 | UI polish for vote/execution and night phase feed cards | アイコン重複・「神」アイコン・処刑記号・ホバー背景・THINKの折り畳み・アバター表示など11件。#360 完了後に実装 |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,8 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^4.1.6",
         "jsdom": "^29.1.1",
@@ -302,6 +304,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1428,6 +1440,77 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1663,6 +1746,42 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1839,6 +1958,25 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.353",
@@ -2163,6 +2301,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2334,6 +2483,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2368,6 +2533,14 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,8 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^4.1.6",
     "jsdom": "^29.1.1",

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -148,7 +148,7 @@ function WolfChatCard({ ev }) {
 }
 
 // --- フィードアイテム ---
-function FeedItem({ ev, prevById, roleAssignment, title }) {
+export function FeedItem({ ev, prevById, roleAssignment, title }) {
   if (ev.event_type === 'speech') return <SpeechCard ev={ev} prevById={prevById} roleAssignment={roleAssignment} />;
   if (ev.event_type === 'wolf_chat') return <WolfChatCard ev={ev} />;
 
@@ -215,7 +215,7 @@ function FeedItem({ ev, prevById, roleAssignment, title }) {
 }
 
 // === 左ペイン ===
-function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary }) {
+export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary }) {
   const handlePhase = (d, phase) => {
     setDay(d);
     setPhase(phase);

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeedItem, LeftPane } from './SpectatorScreen.jsx';
+import styles from './SpectatorScreen.module.css';
+
+const roleAssignment = {
+  Alice: 'Seer',
+  Bob: 'Werewolf',
+  Carol: 'Knight',
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderFeedItem(overrides) {
+  const ev = {
+    day: 1,
+    event_type: 'vote',
+    agent: 'Alice',
+    target: 'Bob',
+    content: '',
+    is_public: false,
+    ...overrides,
+  };
+
+  return render(
+    <FeedItem
+      ev={ev}
+      prevById={{}}
+      roleAssignment={roleAssignment}
+      title="Test Village"
+    />
+  );
+}
+
+function renderLeftPane(overrides = {}) {
+  const props = {
+    activeDay: 1,
+    activePhase: 'discuss',
+    setDay: vi.fn(),
+    setPhase: vi.fn(),
+    days: [1],
+    agentNames: ['Alice', 'Bob', 'Carol'],
+    daySummary: {
+      1: {
+        target: 'Bob',
+        nightDone: true,
+      },
+    },
+    ...overrides,
+  };
+
+  return {
+    ...render(<LeftPane {...props} />),
+    props,
+  };
+}
+
+describe('FeedItem event routing', () => {
+  it.each([
+    ['vote', { event_type: 'vote', agent: 'Alice', target: 'Bob' }, /Alice → Bob/],
+    ['elimination', { event_type: 'elimination', agent: 'Bob' }, /Bob が処刑されました/],
+    ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob', content: 'Bob was Werewolf' }, /Bob は人狼陣営/],
+    ['wolf_chat', { event_type: 'wolf_chat', agent: 'Bob', content: 'Attack Alice tonight.' }, /Attack Alice tonight\./],
+    ['inspection', { event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Bob is Werewolf' }, /Bob: 人狼陣営/],
+    ['guard', { event_type: 'guard', agent: 'Carol', target: 'Alice' }, /Carol.*Alice を護衛/],
+    ['guard_block', { event_type: 'guard_block', target: 'Alice', is_public: false }, /護衛成功: Alice は守られた/],
+    ['night_attack', { event_type: 'night_attack', target: 'Alice', is_public: false }, /Alice を襲撃/],
+  ])('renders %s events with the expected card', (_eventType, event, expectedText) => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: unit
+     * Objective: event_type ごとに対応するカード表示へルーティングされることを検証する。
+     */
+    renderFeedItem(event);
+
+    expect(screen.getByText(expectedText)).toBeTruthy();
+  });
+});
+
+describe('LeftPane phase interaction', () => {
+  it.each([
+    ['議論フェーズ', 'discuss'],
+    ['投票・処刑', 'vote'],
+    ['夜フェーズ', 'night'],
+  ])('calls setPhase("%s") when the phase row is clicked', async (label, phase) => {
+    /**
+     * SUT: LeftPane
+     * Mock: vi.fn() で setDay / setPhase state setter を観測
+     * Level: unit
+     * Objective: 左ペインのフェーズ行クリックが対応する phase state 更新を要求することを検証する。
+     */
+    const user = userEvent.setup();
+    const { props } = renderLeftPane();
+
+    await user.click(screen.getByText(label, { exact: false }));
+
+    expect(props.setDay).toHaveBeenCalledWith(1);
+    expect(props.setPhase).toHaveBeenCalledWith(phase);
+  });
+
+  it('marks only the active phase row as active', () => {
+    /**
+     * SUT: LeftPane
+     * Mock: vi.fn() で未使用 state setter を提供
+     * Level: unit
+     * Objective: activeDay / activePhase に一致するフェーズ行だけ active class を持つことを検証する。
+     */
+    const { container } = renderLeftPane({ activeDay: 1, activePhase: 'vote' });
+    const rows = within(container).getAllByText(/議論フェーズ|投票・処刑|夜フェーズ/);
+    const discussRow = rows.find(row => row.textContent.includes('議論フェーズ'));
+    const voteRow = rows.find(row => row.textContent.includes('投票・処刑'));
+    const nightRow = rows.find(row => row.textContent.includes('夜フェーズ'));
+
+    expect(discussRow.className.split(' ')).not.toContain(styles.active);
+    expect(voteRow.className.split(' ')).toContain(styles.active);
+    expect(nightRow.className.split(' ')).not.toContain(styles.active);
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: 'jsdom',
     coverage: {

--- a/tests/TestStrategy.md
+++ b/tests/TestStrategy.md
@@ -392,7 +392,33 @@ test('parses spectator_log.jsonl into events array', () => {
 });
 ```
 
-### 9.5 Mock 使用ポリシー（JS 版）
+### 9.5 Frontend TDD / Contract Test ルール
+
+Python 側の contract テストと同じく、フロントエンドでも **contract が絡む変更は TDD を必須**とする。
+ここでいう contract は、単なる実装詳細ではなく、producer と consumer の間で守るべき振る舞い・データ形状・UI 操作境界を指す。
+
+対象例:
+
+- Python LogEvent / agent JSON → `parseGameData()` / React 画面のデータ契約
+- `FeedItem` の `event_type` → 表示カード種別のルーティング契約
+- `LeftPane` のクリック操作 → `activeDay` / `activePhase` state 更新契約
+- view model / filter 関数 → 画面が必要とする検索・絞り込み結果の契約
+
+手順:
+
+1. AC から contract を先に切り出す
+2. 実装前に Vitest / React Testing Library でテストを書く
+3. `npm test` で **RED を確認する**
+4. 実装して GREEN にする
+5. `npm run test:coverage` で追加・変更行のカバレッジを確認する
+
+RED にならないテストは、既存実装で既に満たされているか、アサートが弱すぎる。
+後者の場合は実装に進まず、テスト観点を見直す。
+
+RTL を使う場合も同じで、先に「ユーザー操作または表示契約」をテストで固定してから実装する。
+CSS の見た目そのものではなく、ユーザーが観測できる DOM、テキスト、クリック結果、選択状態を優先して検証する。
+
+### 9.6 Mock 使用ポリシー（JS 版）
 
 §4 の3分類（Required / Forbidden / Conditional）はそのまま JS にも適用する。
 
@@ -415,12 +441,12 @@ JS 側でも、**Python と JS の境界で受け渡される契約データ**�
 #### Conditional
 上記以外のオブジェクトはデフォルトで Conditional 扱い。
 
-### 9.6 カバレッジ判断フロー（JS 版）
+### 9.7 カバレッジ判断フロー（JS 版）
 
 §7 の3分類チェック（A: 内部不変条件 / B: 外部境界フォールバック / C: テスト不可）はそのまま適用する。
 カバレッジ計測は Vitest の `--coverage` オプションを使う（v8 / istanbul）。
 
-### 9.7 ローカル品質ゲート
+### 9.8 ローカル品質ゲート
 
 **Milestone 2 以降**:
 - `frontend/package.json` に `"test": "vitest run"` スクリプトを追加

--- a/tests/TestStrategy.md
+++ b/tests/TestStrategy.md
@@ -304,12 +304,14 @@ Missing 行を発見
 
 Web UI は段階的に複雑化するため、テスト基盤も段階的に導入する。
 **先回りでテスト基盤を整えると、スタブから実データへの差し替えで陳腐化する**ため避ける。
+ただし、実データ接続済みでコンポーネント構造が安定し、ユーザー操作・state 変化・表示切り替えが
+Acceptance Criteria になった箇所は、FastAPI 化を待たずに React Testing Library で contract test を追加する。
 
 | Sprint | 範囲 | 導入するテスト |
 |---|---|---|
 | Milestone 1（#308〜#311） | スタブデータの描画 | **なし**（AC をスクショで確認） |
-| Milestone 2（#312/#318/#319/#314） | 実データ接続・ロジック追加 | **Vitest によるユニットテスト**（純粋関数のみ） |
-| #315 以降（FastAPI 化） | WebSocket・状態管理・認証 | **コンポーネントテスト + E2E**（React Testing Library + Playwright） |
+| Milestone 2（#312/#318/#319/#314） | 実データ接続・ロジック追加 | **Vitest によるユニットテスト**（純粋関数）+ 条件を満たす箇所の **RTL コンポーネントテスト** |
+| #315 以降（FastAPI 化） | WebSocket・状態管理・認証 | **コンポーネントテスト拡充 + E2E**（React Testing Library + Playwright） |
 
 #### 各段階で何をテストするか
 
@@ -318,28 +320,35 @@ Web UI は段階的に複雑化するため、テスト基盤も段階的に導�
 - スタブから実データに差し替えるとロジックが大きく変わり、Milestone 1 で書いたテストはすぐ陳腐化する。
 - 例外: `Avatar` の「PNG が無いキャラはモノグラムにフォールバック」のような分岐ロジックがあれば、それだけは書いてよい。
 
-**Milestone 2**: `parseGameData.js` のような **純粋関数のみ** ユニットテストを書く。
+**Milestone 2**: `parseGameData.js` のような **純粋関数** はユニットテストを書く。
 - 入出力が明確で陳腐化しにくい。
 - 実ログ（`design/proposal/source_logs/` や `state_archive/{session}/`）をフィクスチャとして使う。
+
+加えて、以下をすべて満たすコンポーネントには React Testing Library を導入してよい。
+
+- スタブ専用ではなく、実ログ・実 agent JSON 由来のデータ構造に接続済みである
+- コンポーネント責務と props が短期的に大きく変わる見込みが低い
+- `onClick` などのブラウザイベント、React state 更新、条件付きレンダリングが AC に含まれる
+- 純粋関数テストだけでは「ユーザー操作から表示更新まで」の contract を検証できない
 
 > **既知のギャップ（Milestone 2 時点）**: コンポーネントの onClick ハンドラや state 変化は
 > Vitest 純粋関数テストでは検証できない。例えば「左ペインのフェーズ行をクリックすると
 > 中央フィードが切り替わる」という AC は、純粋関数テスト（`feedFilter.test.js`）で
 > フィルタロジックは担保できるが、**クリックで `setPhase` が呼ばれること・フィードが
-> 実際に更新されること**は現状 Playwright による手動目視確認のみに依存している。
-> React Testing Library（RTL）の導入（下記 §9.2）でこのギャップを埋めることが望ましいが、
-> #315 以降の作業として後回しにしている。
+> 実際に更新されること**は純粋関数テストでは担保できない。
+> `SpectatorScreen` の `FeedItem` event_type ルーティングや `LeftPane` フェーズ選択のように
+> 条件を満たす箇所から RTL でこのギャップを埋める。
 
-**#315 以降**: コンポーネント・E2E を本格導入する。
+**#315 以降**: WebSocket・認証・複数画面を跨ぐ E2E を本格導入する。
 - WebSocket イベントの順序・再接続、認証フロー、マルチタブ動作などはテストなしでは品質保証できない。
-- 上記「既知のギャップ」も合わせて RTL で解消する。
+- 既存 RTL テストを実データ配信・状態管理の contract に合わせて拡充する。
 
 ### 9.2 採用ツール
 
 | 種別 | ツール | 用途 |
 |---|---|---|
 | Unit / 純粋関数 | **Vitest** | Vite と統合された高速テストランナー。Jest 互換 API |
-| コンポーネント | **React Testing Library**（#315 以降） | DOM 操作ベースでユーザー視点の動作を検証 |
+| コンポーネント | **React Testing Library** | DOM 操作ベースでユーザー視点の動作を検証 |
 | E2E | **Playwright**（#315 以降） | 実ブラウザでの操作シナリオ検証 |
 | WebSocket Mock | **mock-socket** 等（#315 以降） | WS 接続のテスト |
 
@@ -355,7 +364,7 @@ frontend/
 │   │   └── parseGameData.test.js     # コロケーション
 │   ├── components/
 │   │   ├── Avatar.jsx
-│   │   └── Avatar.test.jsx           # コロケーション（#315 以降）
+│   │   └── Avatar.test.jsx           # コロケーション
 │   └── ...
 └── tests/                            # E2E（Playwright）はここ（#315 以降）
     └── e2e/


### PR DESCRIPTION
## Summary
- Add React Testing Library and user-event to the frontend test stack
- Add FeedItem event_type routing tests and LeftPane phase interaction tests
- Update frontend test strategy to allow RTL when component contracts are stable before #315
- Remove completed #360 from Ideas.md

## Test plan
- [x] npm run test:coverage
- [x] npm run build
- [x] uv run ruff check .
- [x] uv run pytest

Closes #360

🤖 Generated with [Codex](https://Codex.com/Codex)