### PR TITLE
fix: render spectator system logs as-is

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -501,16 +501,16 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 
 | イベント | 表示 |
 |---|---|
-| `vote` | `⚑ {agent} → {target}`（SystemRow kind="exec"） |
-| `elimination` | `☩ {agent} が処刑されました`（SystemRow kind="death"） |
-| `medium_result` | `🔮 [霊媒] {agent} の判定: {target} は村人/人狼陣営`（SystemRow kind="gm"） |
+| `vote` | `{content}`（SystemRow kind="exec"、左に agent アバター / 右に target アバター） |
+| `elimination` | `{content}`（SystemRow kind="death"、右に agent アバター） |
+| `medium_result` | `{content}`（SystemRow kind="gm"、左に agent アバター / 右に target アバター。フロントエンドでは翻訳しない） |
 | `wolf_chat` | WolfChatCard（発言形式・赤背景・🐺バッジ） |
-| `inspection` | `🔮 [占い師] {agent} → {target}: 村人/人狼陣営`（SystemRow kind="gm"） |
-| `guard` | `🛡 [騎士] {agent} が {target} を護衛`（SystemRow kind="gm"） |
-| `guard_block`（private） | `🛡 護衛成功: {target} は守られた`（SystemRow kind="gm"） |
-| `guard_block`（public） | `🛡 全員無事でした`（SystemRow kind="gm"） |
-| `night_attack`（private） | `🐺 [人狼] {target} を襲撃`（SystemRow kind="exec"） |
-| `night_attack`（public） | `☩ {target} が死亡しました`（SystemRow kind="death"） |
+| `inspection` | `{content}`（SystemRow kind="gm"、左に agent アバター / 右に target アバター。フロントエンドでは翻訳しない） |
+| `guard` | `{content}`（SystemRow kind="gm"、左に agent アバター / 右に target アバター） |
+| `guard_block`（private） | `{content}`（SystemRow kind="gm"、右に target アバター） |
+| `guard_block`（public） | `{content}`（SystemRow kind="gm"） |
+| `night_attack`（private） | `{content}`（SystemRow kind="exec"、右に target アバター） |
+| `night_attack`（public） | `{content}`（SystemRow kind="death"、右に target アバター） |
 
 データソース: `stub/spectator.js`（`EVENTS`, `ROLE_ASSIGNMENT`, `NIGHT_RESULTS`, `EXEC_RESULTS`, `VOTE_TABLE_D1`, `ACTIONS_TIMELINE`）。
 

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -13,6 +13,8 @@ import { parseGameData } from '../lib/parseGameData.js';
 import { filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
 
+const MISSING_CONTENT = '[missing content]';
+
 // --- ユーティリティ ---
 function fmtTurn(day, speechId) {
   return `D${day}-${String(speechId).padStart(2, '0')}`;
@@ -90,17 +92,27 @@ function SpeechCard({ ev, prevById, roleAssignment }) {
   );
 }
 
+function logContent(ev) {
+  return ev.content || MISSING_CONTENT;
+}
+
 // --- システム行 ---
-function SystemRow({ kind, icon, label, children, ts }) {
+function SystemRow({ kind, icon, label, children, ts, leftName, rightName, roleAssignment = {} }) {
   const defaultIcon = { gm: '👁', death: '💀', exec: '⚑', phase: '☾' }[kind] || '⌘';
   return (
     <div className={`${styles.sysrow} ${styles[kind] || ''}`}>
+      {leftName && (
+        <Avatar name={leftName} role={roleAssignment[leftName]} size="xs" />
+      )}
       <div className={styles.sysIconCol}>
         <div className={styles.sysIcon}>{icon ?? defaultIcon}</div>
         <div className={styles.sysLabel}>{label}</div>
       </div>
       <div className={styles.sysText}>{children}</div>
       <div className={styles.sysTs}>{ts}</div>
+      {rightName && (
+        <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
+      )}
     </div>
   );
 }
@@ -174,51 +186,49 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
 
   if (ev.event_type === 'vote') {
     return (
-      <SystemRow kind="exec" label="投票" ts="—">
-        <Avatar name={ev.agent} size="xs" /> {ev.agent} → <Avatar name={ev.target} size="xs" /> {ev.target}
+      <SystemRow kind="exec" label="投票" ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+        {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'elimination') {
     return (
-      <SystemRow kind="death" icon="💀" label="処刑" ts="—">
-        <Avatar name={ev.agent} size="xs" /> {ev.agent} が処刑されました
+      <SystemRow kind="death" icon="💀" label="処刑" ts="—" rightName={ev.agent} roleAssignment={roleAssignment}>
+        {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'medium_result') {
-    const isWolf = ev.content?.toLowerCase().includes('werewolf');
     return (
-      <SystemRow kind="gm" icon="👁" label="霊媒結果" ts="—">
-        <Avatar name={ev.agent} size="xs" /> {ev.agent} の判定: <Avatar name={ev.target} size="xs" /> {ev.target} は{isWolf ? '人狼陣営' : '村人陣営'}
+      <SystemRow kind="gm" icon="👁" label="霊媒結果" ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+        {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'inspection') {
-    const isWolf = ev.content?.toLowerCase().includes('werewolf');
     return (
-      <SystemRow kind="gm" icon="🔮" label="占い結果" ts="—">
-        <Avatar name={ev.agent} size="xs" /> {ev.agent} → <Avatar name={ev.target} size="xs" /> {ev.target}: {isWolf ? '人狼陣営' : '村人陣営'}
+      <SystemRow kind="gm" icon="🔮" label="占い結果" ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+        {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'guard') {
     return (
-      <SystemRow kind="gm" icon="🛡" label="護衛" ts="—">
-        <Avatar name={ev.agent} size="xs" /> {ev.agent} が <Avatar name={ev.target} size="xs" /> {ev.target} を護衛
+      <SystemRow kind="gm" icon="🛡" label="護衛" ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+        {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'guard_block') {
     return ev.is_public
-      ? <SystemRow kind="gm" icon="🛡" label="護衛" ts="—">全員無事でした</SystemRow>
-      : <SystemRow kind="gm" icon="🛡" label="護衛成功" ts="—">護衛成功: <Avatar name={ev.target} size="xs" /> {ev.target} は守られた</SystemRow>;
+      ? <SystemRow kind="gm" icon="🛡" label="護衛" ts="—">{logContent(ev)}</SystemRow>
+      : <SystemRow kind="gm" icon="🛡" label="護衛成功" ts="—" rightName={ev.target} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>;
   }
   if (ev.event_type === 'night_attack') {
     const victim = ev.target ?? ev.agent;
     return ev.is_public
-      ? <SystemRow kind="death" icon="💀" label="襲撃結果" ts="—"><Avatar name={victim} size="xs" /> {victim} が死亡しました</SystemRow>
-      : <SystemRow kind="exec" icon="🐺" label="人狼の襲撃" ts="—"><Avatar name={ev.target} size="xs" /> {ev.target} を襲撃</SystemRow>;
+      ? <SystemRow kind="death" icon="💀" label="襲撃結果" ts="—" rightName={victim} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>
+      : <SystemRow kind="exec" icon="🐺" label="人狼の襲撃" ts="—" rightName={ev.target} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>;
   }
 
   if (ev.event_type === 'phase_start') {

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -60,14 +60,14 @@ function renderLeftPane(overrides = {}) {
 
 describe('FeedItem event routing', () => {
   it.each([
-    ['vote', { event_type: 'vote', agent: 'Alice', target: 'Bob' }, /Alice → Bob/],
-    ['elimination', { event_type: 'elimination', agent: 'Bob' }, /Bob が処刑されました/],
-    ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob', content: 'Bob was Werewolf' }, /Bob は人狼陣営/],
+    ['vote', { event_type: 'vote', agent: 'Alice', target: 'Bob', content: 'Alice votes for Bob' }, /Alice votes for Bob/],
+    ['elimination', { event_type: 'elimination', agent: 'Bob', content: 'Bob was executed by the village vote.' }, /Bob was executed by the village vote\./],
+    ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob', content: 'Alice senses: Bob was Werewolf' }, /Alice senses: Bob was Werewolf/],
     ['wolf_chat', { event_type: 'wolf_chat', agent: 'Bob', content: 'Attack Alice tonight.' }, /Attack Alice tonight\./],
-    ['inspection', { event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Bob is Werewolf' }, /Bob: 人狼陣営/],
-    ['guard', { event_type: 'guard', agent: 'Carol', target: 'Alice' }, /Carol.*Alice を護衛/],
-    ['guard_block', { event_type: 'guard_block', target: 'Alice', is_public: false }, /護衛成功: Alice は守られた/],
-    ['night_attack', { event_type: 'night_attack', target: 'Alice', is_public: false }, /Alice を襲撃/],
+    ['inspection', { event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf' }, /Alice inspects Bob: Werewolf/],
+    ['guard', { event_type: 'guard', agent: 'Carol', target: 'Alice', content: 'Carol guards Alice' }, /Carol guards Alice/],
+    ['guard_block', { event_type: 'guard_block', target: 'Alice', is_public: false, content: 'Alice was protected by the Knight! The attack was blocked.' }, /Alice was protected by the Knight! The attack was blocked\./],
+    ['night_attack', { event_type: 'night_attack', target: 'Alice', is_public: false, content: 'Werewolves attack Alice' }, /Werewolves attack Alice/],
   ])('renders %s events with the expected card', (_eventType, event, expectedText) => {
     /**
      * SUT: FeedItem
@@ -78,6 +78,79 @@ describe('FeedItem event routing', () => {
     renderFeedItem(event);
 
     expect(screen.getByText(expectedText)).toBeTruthy();
+  });
+
+  it.each([
+    ['medium_result villager-side result', { event_type: 'medium_result', agent: 'Alice', target: 'Carol', content: 'Alice senses: Carol was Not Werewolf' }],
+    ['medium_result werewolf result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob', content: 'Alice senses: Bob was Werewolf' }],
+    ['inspection villager-side result', { event_type: 'inspection', agent: 'Alice', target: 'Carol', content: 'Alice inspects Carol: Not Werewolf', inspection_role: 'Villager' }],
+    ['inspection werewolf result', { event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf', inspection_role: 'Werewolf' }],
+  ])('renders %s without frontend translation', (_caseName, event) => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: unit
+     * Objective: 霊媒/占い結果をフロントエンドで陣営文言へ翻訳せず、ログ content のまま表示することを検証する。
+     */
+    renderFeedItem(event);
+
+    expect(screen.getByText(event.content)).toBeTruthy();
+    expect(screen.queryByText(/村人陣営|人狼陣営/)).toBeNull();
+  });
+
+  it('renders actor avatars around two-party system logs', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: unit
+     * Objective: 二者が関わるシステムログで agent / target のアバターが左右に表示されることを検証する。
+     */
+    renderFeedItem({
+      event_type: 'inspection',
+      agent: 'Alice',
+      target: 'Bob',
+      content: 'Alice inspects Bob: Werewolf',
+    });
+
+    expect(screen.getByAltText('Alice')).toBeTruthy();
+    expect(screen.getByAltText('Bob')).toBeTruthy();
+  });
+
+  it('renders a missing-content marker instead of reconstructing a system log message', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: unit
+     * Objective: content が欠損したシステムログでは表示文を再構築せず、欠損マーカーを表示することを検証する。
+     */
+    renderFeedItem({
+      event_type: 'medium_result',
+      agent: 'Alice',
+      target: 'Bob',
+      content: '',
+    });
+
+    expect(screen.getByText('[missing content]')).toBeTruthy();
+    expect(screen.queryByText(/Alice senses|Bob was|村人陣営|人狼陣営/)).toBeNull();
+  });
+
+  it('renders the only actor avatar on the right side for single-actor system logs', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: unit
+     * Objective: 一者だけが関わるシステムログでは右側に対象アバターが表示されることを検証する。
+     */
+    const { container } = renderFeedItem({
+      event_type: 'elimination',
+      agent: 'Bob',
+      content: 'Bob was executed by the village vote.',
+    });
+
+    const row = container.querySelector(`.${styles.sysrow}`);
+    const avatar = screen.getByAltText('Bob');
+
+    expect(row.lastElementChild.querySelector('img[alt="Bob"]')).toBe(avatar);
   });
 });
 


### PR DESCRIPTION
## Summary
- Stop translating/reconstructing medium_result and inspection log content in the frontend
- Render spectator system log content as emitted by the backend, with a visible [missing content] marker for malformed events
- Add left/right avatars for system logs involving agent/target actors
- Update FrontendDesign.md to document content-as-is rendering

## Test plan
- [x] npm test -- SpectatorScreen.test.jsx
- [x] npm test
- [x] npm run build
- [x] uv run ruff check .
- [x] uv run pytest

Closes #369