### PR TITLE
fix: merge wolf chat thoughts in replay data

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -465,7 +465,9 @@ parseGameData(jsonlText, agentJsonByName)
 現在は `spectator_log.jsonl` 全体を一括 fetch して行単位に JSON parse する。
 ログ量が増えた場合の変更ポイントは `replayLoader.js` に閉じ、day chunk、cursor pagination、ReadableStream JSONL parser、または FastAPI endpoint に置き換える。
 
-`spectator_log.jsonl` の非公開 `[THINK]` speech 行は、同じ `day` / `agent` / `speech_id` を持つ公開 speech の `thought` に結合する。
+`spectator_log.jsonl` の非公開 `[THINK]` 行は、`parseGameData.js` の Legacy-adapter で表示イベントの `thought` に結合する。
+speech は同じ `day` / `agent` / `speech_id` を持つ公開 speech に結合する。
+wolf_chat は現行ログに `speech_id` がないため、同じ `day` / `agent` の直近 wolf_chat に結合する暫定互換処理とする。
 
 ### viewerMode — spectator / public
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -30,7 +30,6 @@
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#366 | bug | — | — | night event log order is wrong | 夜フェーズの spectator_log 出力順を wolf_chat → guard → inspection → attack → result の自然な順序に直す |
-| yukkie/AgentVillage#365 | bug | — | — | merge [THINK] rows into wolf_chat cards | wolf_chat の private [THINK] 行をカードの thought details にマージして表示する |
 | yukkie/AgentVillage#367 | enhancement | — | — | show reasoning/thought for inspection, guard, medium_result feed cards | 占い・護衛・霊媒結果カードにも thought details を表示する |
 | yukkie/AgentVillage#364 | enhancement | — | — | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
 | yukkie/AgentVillage#371 | tech-debt | — | — | reduce duplication in SpectatorScreen system event rendering | system event 表示の重複 JSX を設定テーブル化し、content そのまま表示と左右アバター配置を維持する |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -29,7 +29,6 @@
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
-| yukkie/AgentVillage#366 | bug | — | — | night event log order is wrong | 夜フェーズの spectator_log 出力順を wolf_chat → guard → inspection → attack → result の自然な順序に直す |
 | yukkie/AgentVillage#367 | enhancement | — | — | show reasoning/thought for inspection, guard, medium_result feed cards | 占い・護衛・霊媒結果カードにも thought details を表示する |
 | yukkie/AgentVillage#364 | enhancement | — | — | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
 | yukkie/AgentVillage#371 | tech-debt | — | — | reduce duplication in SpectatorScreen system event rendering | system event 表示の重複 JSX を設定テーブル化し、content そのまま表示と左右アバター配置を維持する |

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -23,12 +23,29 @@ function stripThinkPrefix(content) {
 }
 
 function eventKey(event) {
-  return `${event.day ?? ''}:${event.agent ?? ''}:${event.speech_id ?? ''}`;
+  return `${event.event_type ?? ''}:${event.day ?? ''}:${event.agent ?? ''}:${event.speech_id ?? ''}`;
 }
 
+function fallbackEventKey(event) {
+  return `${event.event_type ?? ''}:${event.day ?? ''}:${event.agent ?? ''}`;
+}
+
+function mergeableThoughtEventType(event) {
+  return event.event_type === 'speech' || event.event_type === 'wolf_chat';
+}
+
+function isVisibleThoughtTarget(event) {
+  if (event.event_type === 'speech') return event.is_public !== false;
+  if (event.event_type === 'wolf_chat') return true;
+  return false;
+}
+
+// Legacy-adapter: archived logs store private thoughts as sibling "[THINK]"
+// events. Keep this bridge searchable until LogEvent can carry mixed
+// public/private fields directly.
 function isPrivateThinkEvent(event) {
   return (
-    event.event_type === 'speech' &&
+    mergeableThoughtEventType(event) &&
     event.is_public === false &&
     typeof event.content === 'string' &&
     event.content.startsWith(THINK_PREFIX)
@@ -47,29 +64,42 @@ function isPrivateThinkEvent(event) {
  */
 export function normalizeEvents(rawEvents) {
   const publicEvents = [];
-  const speechByKey = new Map();
+  const eventByKey = new Map();
+  const latestEventByFallbackKey = new Map();
   const pendingThoughts = new Map();
+  const pendingFallbackThoughts = new Map();
 
   rawEvents.forEach(event => {
     if (isPrivateThinkEvent(event)) {
       const key = eventKey(event);
+      const fallbackKey = fallbackEventKey(event);
       const thought = stripThinkPrefix(event.content);
-      const speech = speechByKey.get(key);
-      if (speech) {
-        speech.thought = thought;
+      const visibleEvent = eventByKey.get(key) ?? latestEventByFallbackKey.get(fallbackKey);
+      if (visibleEvent) {
+        visibleEvent.thought = thought;
       } else {
-        pendingThoughts.set(key, thought);
+        if (event.speech_id != null) {
+          pendingThoughts.set(key, thought);
+        } else {
+          pendingFallbackThoughts.set(fallbackKey, thought);
+        }
       }
       return;
     }
 
     const normalized = { ...event };
-    if (normalized.event_type === 'speech' && normalized.is_public !== false) {
+    if (isVisibleThoughtTarget(normalized)) {
       const key = eventKey(normalized);
+      const fallbackKey = fallbackEventKey(normalized);
       if (pendingThoughts.has(key)) {
         normalized.thought = pendingThoughts.get(key);
+        pendingThoughts.delete(key);
+      } else if (pendingFallbackThoughts.has(fallbackKey)) {
+        normalized.thought = pendingFallbackThoughts.get(fallbackKey);
+        pendingFallbackThoughts.delete(fallbackKey);
       }
-      speechByKey.set(key, normalized);
+      eventByKey.set(key, normalized);
+      latestEventByFallbackKey.set(fallbackKey, normalized);
     }
     publicEvents.push(normalized);
   });

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -56,6 +56,40 @@ describe('normalizeEvents', () => {
     expect(events[0].content).toBe('おはよう');
     expect(events[0].thought).toBe('内心');
   });
+
+  it('merges private THINK wolf_chat rows into their visible wolf_chat event', () => {
+    /**
+     * SUT: normalizeEvents
+     * Mock: なし
+     * Level: unit
+     * Objective: speech_id を持たない wolf_chat の THINK 行が同じカードの thought に結合されることを検証する。
+     */
+    const events = normalizeEvents([
+      { day: 1, phase: 'night_wolf_chat', event_type: 'wolf_chat', agent: 'Nox', is_public: false, content: 'Nox: Renを噛みたい' },
+      { day: 1, phase: 'night_wolf_chat', event_type: 'wolf_chat', agent: 'Nox', is_public: false, content: '[THINK] Renは騎士ではなさそう' },
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].content).toBe('Nox: Renを噛みたい');
+    expect(events[0].thought).toBe('Renは騎士ではなさそう');
+  });
+
+  it('merges pending private THINK wolf_chat rows when they appear before visible chat', () => {
+    /**
+     * SUT: normalizeEvents
+     * Mock: なし
+     * Level: unit
+     * Objective: JSONL 順序が逆転しても wolf_chat THINK 行を後続の表示イベントへ結合できることを検証する。
+     */
+    const events = normalizeEvents([
+      { day: 1, phase: 'night_wolf_chat', event_type: 'wolf_chat', agent: 'Nox', is_public: false, content: '[THINK] 先に考えた内容' },
+      { day: 1, phase: 'night_wolf_chat', event_type: 'wolf_chat', agent: 'Nox', is_public: false, content: 'Nox: Soraを噛もう' },
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].content).toBe('Nox: Soraを噛もう');
+    expect(events[0].thought).toBe('先に考えた内容');
+  });
 });
 
 describe('parseGameData', () => {


### PR DESCRIPTION
## Summary
- Merge private `[THINK]` `wolf_chat` rows into visible wolf chat events in `normalizeEvents`
- Add `Legacy-adapter` marker around the temporary archived-log compatibility path
- Document the temporary `wolf_chat` thought merge behavior and remove #365 from Ideas.md

## Test plan
- [x] `npm test -- src/lib/parseGameData.test.js`
- [x] `npm test`
- [x] `npm run build`
- [x] `uv run ruff check .`
- [x] `uv run pytest`

Closes #365

🤖 Generated with [Codex](https://Codex.com/Codex)