### PR TITLE
feat: show thought details for private feed cards

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -29,7 +29,6 @@
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
-| yukkie/AgentVillage#367 | enhancement | — | — | show reasoning/thought for inspection, guard, medium_result feed cards | 占い・護衛・霊媒結果カードにも thought details を表示する |
 | yukkie/AgentVillage#364 | enhancement | — | — | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
 | yukkie/AgentVillage#371 | tech-debt | — | — | reduce duplication in SpectatorScreen system event rendering | system event 表示の重複 JSX を設定テーブル化し、content そのまま表示と左右アバター配置を維持する |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -31,6 +31,31 @@ function Mentioned({ text }) {
   );
 }
 
+function ThoughtDetails({ thought }) {
+  if (!thought) return null;
+
+  return (
+    <details className={styles.spThink}>
+      <summary>
+        <svg className={styles.bubbleIco} width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M2 3.5C2 2.67 2.67 2 3.5 2h9c.83 0 1.5.67 1.5 1.5v6c0 .83-.67 1.5-1.5 1.5H7.5L4.7 13.4a.4.4 0 0 1-.7-.28V11H3.5C2.67 11 2 10.33 2 9.5v-6Z"
+            stroke="currentColor" strokeWidth="1.2"
+          />
+          <circle cx="5.5" cy="6.5" r="0.7" fill="currentColor" />
+          <circle cx="8"   cy="6.5" r="0.7" fill="currentColor" />
+          <circle cx="10.5" cy="6.5" r="0.7" fill="currentColor" />
+        </svg>
+        <span className={styles.thinkLabel}>思考ログを読む</span>
+        <span className={styles.conf}>{thought.length} 字 · spectator限定</span>
+      </summary>
+      <div className={styles.thinkBody}>
+        {thought.slice(0, 380)}{thought.length > 380 ? '…' : ''}
+      </div>
+    </details>
+  );
+}
+
 // --- 発言カード ---
 function SpeechCard({ ev, prevById, roleAssignment }) {
   const role = roleAssignment[ev.agent];
@@ -67,26 +92,7 @@ function SpeechCard({ ev, prevById, roleAssignment }) {
         <div className={styles.spBody}>
           <Mentioned text={ev.content} />
         </div>
-        {ev.thought && (
-          <details className={styles.spThink}>
-            <summary>
-              <svg className={styles.bubbleIco} width="14" height="14" viewBox="0 0 16 16" fill="none">
-                <path
-                  d="M2 3.5C2 2.67 2.67 2 3.5 2h9c.83 0 1.5.67 1.5 1.5v6c0 .83-.67 1.5-1.5 1.5H7.5L4.7 13.4a.4.4 0 0 1-.7-.28V11H3.5C2.67 11 2 10.33 2 9.5v-6Z"
-                  stroke="currentColor" strokeWidth="1.2"
-                />
-                <circle cx="5.5" cy="6.5" r="0.7" fill="currentColor" />
-                <circle cx="8"   cy="6.5" r="0.7" fill="currentColor" />
-                <circle cx="10.5" cy="6.5" r="0.7" fill="currentColor" />
-              </svg>
-              <span className={styles.thinkLabel}>思考ログを読む</span>
-              <span className={styles.conf}>{ev.thought.length} 字 · spectator限定</span>
-            </summary>
-            <div className={styles.thinkBody}>
-              {ev.thought.slice(0, 380)}{ev.thought.length > 380 ? '…' : ''}
-            </div>
-          </details>
-        )}
+        <ThoughtDetails thought={ev.thought} />
       </div>
     </div>
   );
@@ -97,7 +103,7 @@ function logContent(ev) {
 }
 
 // --- システム行 ---
-function SystemRow({ kind, icon, label, children, ts, leftName, rightName, roleAssignment = {} }) {
+function SystemRow({ kind, icon, label, children, thought, ts, leftName, rightName, roleAssignment = {} }) {
   const defaultIcon = { gm: '👁', death: '💀', exec: '⚑', phase: '☾' }[kind] || '⌘';
   return (
     <div className={`${styles.sysrow} ${styles[kind] || ''}`}>
@@ -108,7 +114,10 @@ function SystemRow({ kind, icon, label, children, ts, leftName, rightName, roleA
         <div className={styles.sysIcon}>{icon ?? defaultIcon}</div>
         <div className={styles.sysLabel}>{label}</div>
       </div>
-      <div className={styles.sysText}>{children}</div>
+      <div className={styles.sysText}>
+        {children}
+        <ThoughtDetails thought={thought} />
+      </div>
       <div className={styles.sysTs}>{ts}</div>
       {rightName && (
         <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
@@ -154,26 +163,7 @@ function WolfChatCard({ ev }) {
           <span className={styles.alias}>人狼</span>
         </div>
         <div className={styles.spBody}>{ev.content}</div>
-        {ev.thought && (
-          <details className={styles.spThink}>
-            <summary>
-              <svg className={styles.bubbleIco} width="14" height="14" viewBox="0 0 16 16" fill="none">
-                <path
-                  d="M2 3.5C2 2.67 2.67 2 3.5 2h9c.83 0 1.5.67 1.5 1.5v6c0 .83-.67 1.5-1.5 1.5H7.5L4.7 13.4a.4.4 0 0 1-.7-.28V11H3.5C2.67 11 2 10.33 2 9.5v-6Z"
-                  stroke="currentColor" strokeWidth="1.2"
-                />
-                <circle cx="5.5" cy="6.5" r="0.7" fill="currentColor" />
-                <circle cx="8"   cy="6.5" r="0.7" fill="currentColor" />
-                <circle cx="10.5" cy="6.5" r="0.7" fill="currentColor" />
-              </svg>
-              <span className={styles.thinkLabel}>思考ログを読む</span>
-              <span className={styles.conf}>{ev.thought.length} 字 · spectator限定</span>
-            </summary>
-            <div className={styles.thinkBody}>
-              {ev.thought.slice(0, 380)}{ev.thought.length > 380 ? '…' : ''}
-            </div>
-          </details>
-        )}
+        <ThoughtDetails thought={ev.thought} />
       </div>
     </div>
   );
@@ -200,21 +190,21 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
   }
   if (ev.event_type === 'medium_result') {
     return (
-      <SystemRow kind="gm" icon="👁" label="霊媒結果" ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="gm" icon="👁" label="霊媒結果" thought={ev.thought} ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'inspection') {
     return (
-      <SystemRow kind="gm" icon="🔮" label="占い結果" ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="gm" icon="🔮" label="占い結果" thought={ev.thought} ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'guard') {
     return (
-      <SystemRow kind="gm" icon="🛡" label="護衛" ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="gm" icon="🛡" label="護衛" thought={ev.thought} ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -243,6 +243,41 @@ describe('FeedItem: wolf_chat card', () => {
   });
 });
 
+describe('FeedItem: private action thought details', () => {
+  it.each([
+    ['inspection', { event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf' }],
+    ['guard', { event_type: 'guard', agent: 'Carol', target: 'Alice', content: 'Carol guards Alice' }],
+    ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob', content: 'Alice senses: Bob was Werewolf' }],
+  ])('folds thought into details for %s when ev.thought is present', (_eventType, event) => {
+    /**
+     * SUT: FeedItem (SystemRow)
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: unit
+     * Objective: inspection / guard / medium_result に thought がある場合「思考ログを読む」details が表示されることを検証する。
+     */
+    renderFeedItem({ ...event, thought: '非公開能力の対象選択理由。' });
+
+    expect(screen.getByText(/思考ログを読む/)).toBeTruthy();
+    expect(screen.getByText(/非公開能力の対象選択理由/)).toBeTruthy();
+  });
+
+  it.each([
+    ['inspection', { event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf' }],
+    ['guard', { event_type: 'guard', agent: 'Carol', target: 'Alice', content: 'Carol guards Alice' }],
+    ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob', content: 'Alice senses: Bob was Werewolf' }],
+  ])('does not show thought details for %s when ev.thought is absent', (_eventType, event) => {
+    /**
+     * SUT: FeedItem (SystemRow)
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: unit
+     * Objective: inspection / guard / medium_result に thought がない場合「思考ログを読む」が表示されないことを検証する。
+     */
+    renderFeedItem(event);
+
+    expect(screen.queryByText(/思考ログを読む/)).toBeNull();
+  });
+});
+
 describe('FeedItem: system event icons', () => {
   it('guard uses 🛡 icon in SystemRow', () => {
     /**


### PR DESCRIPTION
## Summary
- Reuse the existing thought-details UI for speech and wolf_chat cards
- Show folded thought details on inspection, guard, and medium_result feed cards
- Remove completed issue #367 from Ideas.md

## Test plan
- [x] `npm --prefix frontend test -- SpectatorScreen.test.jsx`
- [x] `npm --prefix frontend test`
- [x] `uv run ruff check .`
- [x] `uv run pytest`

Closes #367

🤖 Generated with [Codex](https://Codex.com/Codex)