### PR TITLE
fix(frontend): reorder vote feed card layout (#376)

### DIFF
--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -107,18 +107,18 @@ function SystemRow({ kind, icon, label, children, thought, ts, leftName, rightNa
   const defaultIcon = { gm: '👁', death: '💀', exec: '⚑', phase: '☾' }[kind] || '⌘';
   return (
     <div className={`${styles.sysrow} ${styles[kind] || ''}`}>
-      {leftName && (
-        <Avatar name={leftName} role={roleAssignment[leftName]} size="xs" />
-      )}
       <div className={styles.sysIconCol}>
         <div className={styles.sysIcon}>{icon ?? defaultIcon}</div>
         <div className={styles.sysLabel}>{label}</div>
       </div>
+      {leftName && (
+        <Avatar name={leftName} role={roleAssignment[leftName]} size="xs" />
+      )}
       <div className={styles.sysText}>
         {children}
         <ThoughtDetails thought={thought} />
       </div>
-      <div className={styles.sysTs}>{ts}</div>
+      {ts && <div className={styles.sysTs}>{ts}</div>}
       {rightName && (
         <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
       )}
@@ -176,49 +176,49 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
 
   if (ev.event_type === 'vote') {
     return (
-      <SystemRow kind="exec" label="投票" ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="exec" label="投票" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'elimination') {
     return (
-      <SystemRow kind="death" icon="💀" label="処刑" ts="—" rightName={ev.agent} roleAssignment={roleAssignment}>
+      <SystemRow kind="death" icon="💀" label="処刑" rightName={ev.agent} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'medium_result') {
     return (
-      <SystemRow kind="gm" icon="👁" label="霊媒結果" thought={ev.thought} ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="gm" icon="👁" label="霊媒結果" thought={ev.thought} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'inspection') {
     return (
-      <SystemRow kind="gm" icon="🔮" label="占い結果" thought={ev.thought} ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="gm" icon="🔮" label="占い結果" thought={ev.thought} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'guard') {
     return (
-      <SystemRow kind="gm" icon="🛡" label="護衛" thought={ev.thought} ts="—" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="gm" icon="🛡" label="護衛" thought={ev.thought} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'guard_block') {
     return ev.is_public
-      ? <SystemRow kind="gm" icon="🛡" label="護衛" ts="—">{logContent(ev)}</SystemRow>
-      : <SystemRow kind="gm" icon="🛡" label="護衛成功" ts="—" rightName={ev.target} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>;
+      ? <SystemRow kind="gm" icon="🛡" label="護衛">{logContent(ev)}</SystemRow>
+      : <SystemRow kind="gm" icon="🛡" label="護衛成功" rightName={ev.target} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>;
   }
   if (ev.event_type === 'night_attack') {
     const victim = ev.target ?? ev.agent;
     return ev.is_public
-      ? <SystemRow kind="death" icon="💀" label="襲撃結果" ts="—" rightName={victim} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>
-      : <SystemRow kind="exec" icon="🐺" label="人狼の襲撃" ts="—" rightName={ev.target} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>;
+      ? <SystemRow kind="death" icon="💀" label="襲撃結果" rightName={victim} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>
+      : <SystemRow kind="exec" icon="🐺" label="人狼の襲撃" rightName={ev.target} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>;
   }
 
   if (ev.event_type === 'phase_start') {
@@ -231,7 +231,7 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
     }
     if (ev.phase === 'day_vote' || ev.phase === 'night' || ev.phase === 'night_wolf_chat' || ev.phase === 'pre_night') return null;
     if (ev.phase === 'day_opening' || ev.phase === 'day_discussion') return null;
-    return <SystemRow kind="phase" label="フェーズ" ts="—">{ev.content}</SystemRow>;
+    return <SystemRow kind="phase" label="フェーズ">{ev.content}</SystemRow>;
   }
   return null;
 }
@@ -507,12 +507,12 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         </div>
         <div className={styles.feed}>
           {loadError && (
-            <SystemRow kind="death" label="読み込みエラー" ts="—">
+            <SystemRow kind="death" label="読み込みエラー">
               {loadError.message}
             </SystemRow>
           )}
           {(loadingEvents || loadingAgents) && (
-            <SystemRow kind="phase" label="読み込み中" ts="—">
+            <SystemRow kind="phase" label="読み込み中">
               {loadingAgents ? '参加者情報を読み込み中。' : ''}
               {loadingEvents ? '発言ログを読み込み中。' : ''}
             </SystemRow>

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -432,8 +432,8 @@
 /* sysrow inner */
 .sysIconCol { display: flex; flex-direction: column; align-items: center; gap: 3px; flex: 0 0 64px; width: 64px; }
 .sysLabel { font-family: var(--serif); font-size: 10px; color: var(--tx-3); letter-spacing: 0.08em; text-align: center; }
-.sysText { font-size: 13px; color: var(--tx); display: flex; align-items: center; gap: 4px; flex-wrap: wrap; flex: 1; }
-.sysTs { margin-left: auto; font-family: var(--mono); font-size: 10px; color: var(--tx-4); }
+.sysText { font-size: 13px; color: var(--tx); display: flex; align-items: center; gap: 4px; flex-wrap: wrap; }
+.sysTs { font-family: var(--mono); font-size: 10px; color: var(--tx-4); }
 .sysIcon {
   width: 28px; height: 28px; border-radius: 50%;
   display: inline-flex; align-items: center; justify-content: center;


### PR DESCRIPTION
## Summary
- SystemRow の flex 順を「アイコン → 左アバター → テキスト → 右アバター」に修正
- `sysText` の `flex: 1` を削除しテキスト幅に縮むようにし、右アバターの押し出しを解消
- `ts="—"` の固定ダッシュを全 SystemRow から削除し、`ts` が falsy なら非表示に変更

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `npm test` パス（68 tests 全通過確認済み）
- [ ] Playwright で投票フェーズの投票カードレイアウトを目視確認済み

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)