### PR TITLE
fix(frontend): use ev.reasoning for thought details on all feed cards

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -34,6 +34,7 @@
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |
+| yukkie/AgentVillage#379 | enhancement | 🟢 | — | Add static type checking to frontend JS (JSDoc or TypeScript) | フィールド名ミスをエディタ/CIで検出できるようにする。スタブ撤廃（#318）以降に検討 |
 
 ### ゲームロジック系（Web UI 軸とは別系統）
 

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -73,15 +73,15 @@ export function normalizeEvents(rawEvents) {
     if (isPrivateThinkEvent(event)) {
       const key = eventKey(event);
       const fallbackKey = fallbackEventKey(event);
-      const thought = stripThinkPrefix(event.content);
+      const reasoning = stripThinkPrefix(event.content);
       const visibleEvent = eventByKey.get(key) ?? latestEventByFallbackKey.get(fallbackKey);
       if (visibleEvent) {
-        visibleEvent.thought = thought;
+        visibleEvent.reasoning = reasoning;
       } else {
         if (event.speech_id != null) {
-          pendingThoughts.set(key, thought);
+          pendingThoughts.set(key, reasoning);
         } else {
-          pendingFallbackThoughts.set(fallbackKey, thought);
+          pendingFallbackThoughts.set(fallbackKey, reasoning);
         }
       }
       return;
@@ -92,10 +92,10 @@ export function normalizeEvents(rawEvents) {
       const key = eventKey(normalized);
       const fallbackKey = fallbackEventKey(normalized);
       if (pendingThoughts.has(key)) {
-        normalized.thought = pendingThoughts.get(key);
+        normalized.reasoning = pendingThoughts.get(key);
         pendingThoughts.delete(key);
       } else if (pendingFallbackThoughts.has(fallbackKey)) {
-        normalized.thought = pendingFallbackThoughts.get(fallbackKey);
+        normalized.reasoning = pendingFallbackThoughts.get(fallbackKey);
         pendingFallbackThoughts.delete(fallbackKey);
       }
       eventByKey.set(key, normalized);

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -54,7 +54,7 @@ describe('normalizeEvents', () => {
 
     expect(events).toHaveLength(1);
     expect(events[0].content).toBe('おはよう');
-    expect(events[0].thought).toBe('内心');
+    expect(events[0].reasoning).toBe('内心');
   });
 
   it('merges private THINK wolf_chat rows into their visible wolf_chat event', () => {
@@ -62,7 +62,7 @@ describe('normalizeEvents', () => {
      * SUT: normalizeEvents
      * Mock: なし
      * Level: unit
-     * Objective: speech_id を持たない wolf_chat の THINK 行が同じカードの thought に結合されることを検証する。
+     * Objective: speech_id を持たない wolf_chat の THINK 行が同じカードの reasoning に結合されることを検証する。
      */
     const events = normalizeEvents([
       { day: 1, phase: 'night_wolf_chat', event_type: 'wolf_chat', agent: 'Nox', is_public: false, content: 'Nox: Renを噛みたい' },
@@ -71,7 +71,7 @@ describe('normalizeEvents', () => {
 
     expect(events).toHaveLength(1);
     expect(events[0].content).toBe('Nox: Renを噛みたい');
-    expect(events[0].thought).toBe('Renは騎士ではなさそう');
+    expect(events[0].reasoning).toBe('Renは騎士ではなさそう');
   });
 
   it('merges pending private THINK wolf_chat rows when they appear before visible chat', () => {
@@ -88,7 +88,48 @@ describe('normalizeEvents', () => {
 
     expect(events).toHaveLength(1);
     expect(events[0].content).toBe('Nox: Soraを噛もう');
-    expect(events[0].thought).toBe('先に考えた内容');
+    expect(events[0].reasoning).toBe('先に考えた内容');
+  });
+});
+
+describe('normalizeEvents: reasoning passthrough for non-THINK event types', () => {
+  it.each([
+    ['vote',          { event_type: 'vote',          agent: 'Alice', target: 'Bob',  content: 'Alice votes for Bob',              is_public: true  }],
+    ['inspection',    { event_type: 'inspection',    agent: 'Alice', target: 'Bob',  content: 'Alice inspects Bob: Werewolf',     is_public: false }],
+    ['guard',         { event_type: 'guard',         agent: 'Carol', target: 'Alice', content: 'Carol guards Alice',             is_public: false }],
+    ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob',  content: 'Alice senses: Bob was Werewolf',  is_public: false }],
+  ])('preserves ev.reasoning for %s events', (_eventType, rawEvent) => {
+    /**
+     * SUT: normalizeEvents
+     * Mock: なし
+     * Level: unit
+     * Objective: vote / inspection / guard / medium_result の reasoning フィールドが
+     *            normalizeEvents を通過しても失われないことを検証する。
+     *            これらはTHINKハックの対象外であり、ログの reasoning フィールドをそのまま
+     *            FeedItem に渡す必要がある（contract テスト）。
+     */
+    const events = normalizeEvents([{ ...rawEvent, reasoning: '対象選択の理由。' }]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].reasoning).toBe('対象選択の理由。');
+  });
+
+  it.each([
+    ['vote',          { event_type: 'vote',          agent: 'Alice', target: 'Bob',  content: 'Alice votes for Bob',              is_public: true  }],
+    ['inspection',    { event_type: 'inspection',    agent: 'Alice', target: 'Bob',  content: 'Alice inspects Bob: Werewolf',     is_public: false }],
+    ['guard',         { event_type: 'guard',         agent: 'Carol', target: 'Alice', content: 'Carol guards Alice',             is_public: false }],
+    ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob',  content: 'Alice senses: Bob was Werewolf',  is_public: false }],
+  ])('reasoning is undefined when absent for %s events', (_eventType, rawEvent) => {
+    /**
+     * SUT: normalizeEvents
+     * Mock: なし
+     * Level: unit
+     * Objective: reasoning フィールドがないイベントでは undefined のまま出力されることを検証する。
+     */
+    const events = normalizeEvents([rawEvent]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].reasoning).toBeUndefined();
   });
 });
 
@@ -117,15 +158,15 @@ describe('parseGameData', () => {
      * SUT: parseGameData
      * Mock: なし（design/proposal/source_logs/ の実ログを fixture に使用）
      * Level: unit
-     * Objective: 実 spectator log の THINK 行が speech.thought として利用できることを検証する。
+     * Objective: 実 spectator log の THINK 行が speech.reasoning として利用できることを検証する。
      */
     const gameData = parseGameData(readFixture('spectator_log.jsonl'));
     const miraSpeech = gameData.events.find(
       event => event.event_type === 'speech' && event.agent === 'Mira' && event.speech_id === 1
     );
 
-    expect(miraSpeech.thought).toContain('Day 1');
-    expect(miraSpeech.thought).not.toContain('[THINK]');
+    expect(miraSpeech.reasoning).toContain('Day 1');
+    expect(miraSpeech.reasoning).not.toContain('[THINK]');
   });
 
   it('includes daySummary in returned GameData', () => {

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -31,8 +31,8 @@ function Mentioned({ text }) {
   );
 }
 
-function ThoughtDetails({ thought }) {
-  if (!thought) return null;
+function ThoughtDetails({ reasoning }) {
+  if (!reasoning) return null;
 
   return (
     <details className={styles.spThink}>
@@ -47,10 +47,10 @@ function ThoughtDetails({ thought }) {
           <circle cx="10.5" cy="6.5" r="0.7" fill="currentColor" />
         </svg>
         <span className={styles.thinkLabel}>思考ログを読む</span>
-        <span className={styles.conf}>{thought.length} 字 · spectator限定</span>
+        <span className={styles.conf}>{reasoning.length} 字 · spectator限定</span>
       </summary>
       <div className={styles.thinkBody}>
-        {thought.slice(0, 380)}{thought.length > 380 ? '…' : ''}
+        {reasoning.slice(0, 380)}{reasoning.length > 380 ? '…' : ''}
       </div>
     </details>
   );
@@ -92,7 +92,7 @@ function SpeechCard({ ev, prevById, roleAssignment }) {
         <div className={styles.spBody}>
           <Mentioned text={ev.content} />
         </div>
-        <ThoughtDetails thought={ev.thought} />
+        <ThoughtDetails reasoning={ev.reasoning} />
       </div>
     </div>
   );
@@ -103,7 +103,7 @@ function logContent(ev) {
 }
 
 // --- システム行 ---
-function SystemRow({ kind, icon, label, children, thought, ts, leftName, rightName, roleAssignment = {} }) {
+function SystemRow({ kind, icon, label, children, reasoning, ts, leftName, rightName, roleAssignment = {} }) {
   const defaultIcon = { gm: '👁', death: '💀', exec: '⚑', phase: '☾' }[kind] || '⌘';
   return (
     <div className={`${styles.sysrow} ${styles[kind] || ''}`}>
@@ -111,17 +111,19 @@ function SystemRow({ kind, icon, label, children, thought, ts, leftName, rightNa
         <div className={styles.sysIcon}>{icon ?? defaultIcon}</div>
         <div className={styles.sysLabel}>{label}</div>
       </div>
-      {leftName && (
-        <Avatar name={leftName} role={roleAssignment[leftName]} size="xs" />
-      )}
-      <div className={styles.sysText}>
-        {children}
-        <ThoughtDetails thought={thought} />
+      <div className={styles.sysContent}>
+        <div className={styles.sysMain}>
+          {leftName && (
+            <Avatar name={leftName} role={roleAssignment[leftName]} size="xs" />
+          )}
+          <div className={styles.sysText}>{children}</div>
+          {ts && <div className={styles.sysTs}>{ts}</div>}
+          {rightName && (
+            <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
+          )}
+        </div>
+        <ThoughtDetails reasoning={reasoning} />
       </div>
-      {ts && <div className={styles.sysTs}>{ts}</div>}
-      {rightName && (
-        <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
-      )}
     </div>
   );
 }
@@ -163,7 +165,7 @@ function WolfChatCard({ ev }) {
           <span className={styles.alias}>人狼</span>
         </div>
         <div className={styles.spBody}>{ev.content}</div>
-        <ThoughtDetails thought={ev.thought} />
+        <ThoughtDetails reasoning={ev.reasoning} />
       </div>
     </div>
   );
@@ -176,7 +178,7 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
 
   if (ev.event_type === 'vote') {
     return (
-      <SystemRow kind="exec" label="投票" leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="exec" label="投票" reasoning={ev.reasoning} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
@@ -190,21 +192,21 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
   }
   if (ev.event_type === 'medium_result') {
     return (
-      <SystemRow kind="gm" icon="👁" label="霊媒結果" thought={ev.thought} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="gm" icon="👁" label="霊媒結果" reasoning={ev.reasoning} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'inspection') {
     return (
-      <SystemRow kind="gm" icon="🔮" label="占い結果" thought={ev.thought} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="gm" icon="🔮" label="占い結果" reasoning={ev.reasoning} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );
   }
   if (ev.event_type === 'guard') {
     return (
-      <SystemRow kind="gm" icon="🛡" label="護衛" thought={ev.thought} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
+      <SystemRow kind="gm" icon="🛡" label="護衛" reasoning={ev.reasoning} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
         {logContent(ev)}
       </SystemRow>
     );

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -268,8 +268,14 @@
 .sysrow {
   padding: 12px 24px;
   border-bottom: 1px solid var(--bd-soft);
-  display: flex; align-items: center; gap: 12px;
+  display: flex; flex-direction: row; align-items: center; gap: 12px;
   background: var(--bg-1);
+}
+.sysContent {
+  display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0;
+}
+.sysMain {
+  display: flex; align-items: center; gap: 12px;
 }
 .sysrow .icon {
   width: 28px; height: 28px;

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -220,23 +220,23 @@ describe('FeedItem: elimination card', () => {
 });
 
 describe('FeedItem: wolf_chat card', () => {
-  it('folds thought into details when ev.thought is present', () => {
+  it('folds thought into details when ev.reasoning is present', () => {
     /**
      * SUT: FeedItem (WolfChatCard)
      * Mock: なし
      * Level: unit
-     * Objective: wolf_chat に thought がある場合「思考ログを読む」details が表示されることを検証する。
+     * Objective: wolf_chat に reasoning がある場合「思考ログを読む」details が表示されることを検証する。
      */
-    renderFeedItem({ event_type: 'wolf_chat', agent: 'Bob', content: 'Attack tonight.', thought: '狼として最適な標的を選ぶ。' });
+    renderFeedItem({ event_type: 'wolf_chat', agent: 'Bob', content: 'Attack tonight.', reasoning: '狼として最適な標的を選ぶ。' });
     expect(screen.getByText(/思考ログを読む/)).toBeTruthy();
   });
 
-  it('does not show thought details when ev.thought is absent', () => {
+  it('does not show thought details when ev.reasoning is absent', () => {
     /**
      * SUT: FeedItem (WolfChatCard)
      * Mock: なし
      * Level: unit
-     * Objective: wolf_chat に thought がない場合「思考ログを読む」が表示されないことを検証する。
+     * Objective: wolf_chat に reasoning がない場合「思考ログを読む」が表示されないことを検証する。
      */
     renderFeedItem({ event_type: 'wolf_chat', agent: 'Bob', content: 'Attack tonight.' });
     expect(screen.queryByText(/思考ログを読む/)).toBeNull();
@@ -248,14 +248,14 @@ describe('FeedItem: private action thought details', () => {
     ['inspection', { event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf' }],
     ['guard', { event_type: 'guard', agent: 'Carol', target: 'Alice', content: 'Carol guards Alice' }],
     ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob', content: 'Alice senses: Bob was Werewolf' }],
-  ])('folds thought into details for %s when ev.thought is present', (_eventType, event) => {
+  ])('folds thought into details for %s when ev.reasoning is present', (_eventType, event) => {
     /**
      * SUT: FeedItem (SystemRow)
      * Mock: なし（LogEvent 形状の plain object を入力）
      * Level: unit
-     * Objective: inspection / guard / medium_result に thought がある場合「思考ログを読む」details が表示されることを検証する。
+     * Objective: inspection / guard / medium_result に reasoning がある場合「思考ログを読む」details が表示されることを検証する。
      */
-    renderFeedItem({ ...event, thought: '非公開能力の対象選択理由。' });
+    renderFeedItem({ ...event, reasoning: '非公開能力の対象選択理由。' });
 
     expect(screen.getByText(/思考ログを読む/)).toBeTruthy();
     expect(screen.getByText(/非公開能力の対象選択理由/)).toBeTruthy();
@@ -265,12 +265,12 @@ describe('FeedItem: private action thought details', () => {
     ['inspection', { event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf' }],
     ['guard', { event_type: 'guard', agent: 'Carol', target: 'Alice', content: 'Carol guards Alice' }],
     ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob', content: 'Alice senses: Bob was Werewolf' }],
-  ])('does not show thought details for %s when ev.thought is absent', (_eventType, event) => {
+  ])('does not show thought details for %s when ev.reasoning is absent', (_eventType, event) => {
     /**
      * SUT: FeedItem (SystemRow)
      * Mock: なし（LogEvent 形状の plain object を入力）
      * Level: unit
-     * Objective: inspection / guard / medium_result に thought がない場合「思考ログを読む」が表示されないことを検証する。
+     * Objective: inspection / guard / medium_result に reasoning がない場合「思考ログを読む」が表示されないことを検証する。
      */
     renderFeedItem(event);
 


### PR DESCRIPTION
## Summary
- `ev.thought` → `ev.reasoning` にリネーム（`parseGameData.js`・`SpectatorScreen.jsx` 全箇所）
- `normalizeEvents` がTHINKハックでセットするフィールドも `.thought` → `.reasoning` に統一
- `vote` / `inspection` / `guard` / `medium_result` カードの `SystemRow` に `reasoning={ev.reasoning}` を追加（これが今回のバグの本体）
- `SystemRow` レイアウト改善: アイコン列 + `sysContent`（本文行 ＋ 思考ログ行）の縦2段構造に変更し、右アバターが正しく本文行に収まるよう修正
- `normalizeEvents` の reasoning パススルーを検証する contract テスト8件追加
- Issue #379（フロントエンド静的型チェック）を Ideas.md に追記

## Test plan
- [x] `npm --prefix frontend test` — 76件パス
- [x] `npm --prefix frontend run test:coverage` — パス
- [x] `uv run ruff check .` — パス
- [x] `uv run pytest` — パス
- [x] Playwright でブラウザ動作確認（投票・占い・護衛フェーズで「思考ログを読む」表示・展開を確認）

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)