### PR TITLE
feat(frontend): rework SpectatorScreen right pane for real log data

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -25,7 +25,6 @@
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |
 | yukkie/AgentVillage#357 | tech-debt | 🔴 | 2 | Remove remaining stub fallbacks in SpectatorScreen (NIGHT_RESULTS, VOTE_TABLE_D1, ACTIONS_TIMELINE, ROLE_ASSIGNMENT) | #346 で未対応のスタブ依存4件を実ログ由来データに差し替え、stub/spectator.js の import を完全除去 |
-| yukkie/AgentVillage#350 | enhancement | 🟡 | 3 | Rework SpectatorScreen right pane — role display, real log actions, day-linked view | 容疑度メーター削除・役職表示改善・夜行動実ログ接続・左ペイン日付クリック連動。#314/#346 依存 |
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -12,6 +12,7 @@
 ## GitHub Issues（未実装タスク）
 
 並び順は Sprint Goal に沿って Milestone 2 優先 → ゲームロジック系 → 将来フェーズの順。
+| yukkie/AgentVillage#382 | bug | 🟡 | 2 | fix(frontend): show day-accurate alive/dead status in SpectatorScreen right pane | 右ペインの生存/死亡リストを activeDay 時点の状態に切り替える |
 同一区分内では優先度（🔴 → 🟡 → 🟢）で並べる。
 
 ### Milestone 2（実データ観戦）— 現 Sprint

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -156,6 +156,62 @@ export function aggregateDayResults(events) {
 }
 
 /**
+ * Aggregate CO (coming-out) status from co_announcement events.
+ *
+ * @param {object[]} events
+ * @returns {Record<string, string>} agent name → claimed_role
+ */
+export function aggregateCoStatus(events) {
+  const result = {};
+  for (const ev of events) {
+    if (ev.event_type === 'co_announcement' && ev.agent && ev.claimed_role) {
+      result[ev.agent] = ev.claimed_role;
+    }
+  }
+  return result;
+}
+
+/**
+ * Aggregate per-day night actions and execution results.
+ *
+ * nightActions: inspection / guard / private night_attack (is_public=false)
+ * execResult:   elimination target + vote breakdown
+ *
+ * @param {object[]} events
+ * @returns {Record<number, { nightActions: object[], execResult: { target: string, voteTable: {from:string,to:string}[] } | null }>}
+ */
+export function aggregateDayActions(events) {
+  const result = {};
+
+  function ensureDay(d) {
+    if (!result[d]) result[d] = { nightActions: [], execResult: null };
+  }
+
+  for (const ev of events) {
+    const d = ev.day;
+    if (!d) continue;
+
+    if (
+      (ev.event_type === 'inspection' || ev.event_type === 'guard') ||
+      (ev.event_type === 'night_attack' && !ev.is_public)
+    ) {
+      ensureDay(d);
+      result[d].nightActions.push(ev);
+    } else if (ev.event_type === 'vote') {
+      ensureDay(d);
+      if (!result[d].execResult) result[d].execResult = { target: null, voteTable: [] };
+      result[d].execResult.voteTable.push({ from: ev.agent, to: ev.target });
+    } else if (ev.event_type === 'elimination') {
+      ensureDay(d);
+      if (!result[d].execResult) result[d].execResult = { target: null, voteTable: [] };
+      result[d].execResult.target = ev.agent;
+    }
+  }
+
+  return result;
+}
+
+/**
  * Parse archive JSONL and agent JSON into the GameData shape consumed by React.
  *
  * This function is intentionally synchronous and pure. I/O stays in

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseEventLine, parseGameData, normalizeEvents, aggregateDayResults } from './parseGameData.js';
+import { parseEventLine, parseGameData, normalizeEvents, aggregateDayResults, aggregateCoStatus, aggregateDayActions } from './parseGameData.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -232,5 +232,112 @@ describe('aggregateDayResults', () => {
     ];
     const summary = aggregateDayResults(events);
     expect(summary[1]).toBeUndefined();
+  });
+});
+
+describe('aggregateCoStatus', () => {
+  it('returns agent→claimed_role map from co_announcement events', () => {
+    /*
+     * SUT: aggregateCoStatus
+     * Mock: なし
+     * Level: unit
+     * Objective: co_announcement イベントから { エージェント名: claimed_role } マップを生成できることを検証する。
+     */
+    const events = [
+      { day: 2, event_type: 'co_announcement', agent: 'Jonas', claimed_role: 'Seer', is_public: true },
+      { day: 3, event_type: 'co_announcement', agent: 'SQ',    claimed_role: 'Medium', is_public: true },
+    ];
+    expect(aggregateCoStatus(events)).toEqual({ Jonas: 'Seer', SQ: 'Medium' });
+  });
+
+  it('returns empty object when no co_announcement events', () => {
+    /*
+     * SUT: aggregateCoStatus
+     * Mock: なし
+     * Level: unit
+     * Objective: co_announcement がない場合は空オブジェクトを返すことを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'speech', agent: 'Mira', speech_id: 1, is_public: true },
+    ];
+    expect(aggregateCoStatus(events)).toEqual({});
+  });
+
+  it('uses the last co_announcement when the same agent CO twice', () => {
+    /*
+     * SUT: aggregateCoStatus
+     * Mock: なし
+     * Level: unit
+     * Objective: 同一エージェントが複数回COした場合、最後のCOが上書きされることを検証する。
+     */
+    const events = [
+      { day: 2, event_type: 'co_announcement', agent: 'Ren', claimed_role: 'Seer',   is_public: true },
+      { day: 3, event_type: 'co_announcement', agent: 'Ren', claimed_role: 'Villager', is_public: true },
+    ];
+    expect(aggregateCoStatus(events)).toEqual({ Ren: 'Villager' });
+  });
+});
+
+describe('aggregateDayActions', () => {
+  it('collects night actions and exec result per day', () => {
+    /*
+     * SUT: aggregateDayActions
+     * Mock: なし
+     * Level: unit
+     * Objective: inspection / guard / night_attack(private) / elimination / vote から日別サマリを生成することを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'inspection',  agent: 'Nox',   target: 'Kai', content: 'Nox inspects Kai: Werewolf', is_public: false },
+      { day: 1, event_type: 'guard',       agent: 'Rei',   target: 'Nox', content: 'Rei guards Nox',             is_public: false },
+      { day: 1, event_type: 'night_attack', agent: 'Kai',  target: 'Sora', content: 'Werewolves attack Sora',    is_public: false },
+      { day: 1, event_type: 'vote',         agent: 'Nox',  target: 'Toma', content: 'Nox votes for Toma',        is_public: true },
+      { day: 1, event_type: 'vote',         agent: 'Mira', target: 'Toma', content: 'Mira votes for Toma',       is_public: true },
+      { day: 1, event_type: 'vote',         agent: 'Kai',  target: 'Nox',  content: 'Kai votes for Nox',         is_public: true },
+      { day: 1, event_type: 'elimination',  agent: 'Toma', target: null,   content: 'Toma was executed.',        is_public: true },
+    ];
+    const result = aggregateDayActions(events);
+    const d1 = result[1];
+
+    expect(d1.nightActions).toHaveLength(3);
+    expect(d1.nightActions.find(a => a.event_type === 'inspection')).toBeTruthy();
+    expect(d1.nightActions.find(a => a.event_type === 'guard')).toBeTruthy();
+    expect(d1.nightActions.find(a => a.event_type === 'night_attack' && !a.is_public)).toBeTruthy();
+
+    expect(d1.execResult.target).toBe('Toma');
+    expect(d1.execResult.voteTable).toEqual([
+      { from: 'Nox',  to: 'Toma' },
+      { from: 'Mira', to: 'Toma' },
+      { from: 'Kai',  to: 'Nox' },
+    ]);
+  });
+
+  it('excludes public night_attack from nightActions (already shown in feed)', () => {
+    /*
+     * SUT: aggregateDayActions
+     * Mock: なし
+     * Level: unit
+     * Objective: is_public な night_attack（夜明け公知イベント）は nightActions に含まれないことを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', agent: 'Kai',  target: 'Sora', is_public: false },
+      { day: 1, event_type: 'night_attack', agent: 'Sora', target: null,   is_public: true },
+    ];
+    const result = aggregateDayActions(events);
+    expect(result[1].nightActions).toHaveLength(1);
+    expect(result[1].nightActions[0].is_public).toBe(false);
+  });
+
+  it('returns empty nightActions and null execResult for days with no relevant events', () => {
+    /*
+     * SUT: aggregateDayActions
+     * Mock: なし
+     * Level: unit
+     * Objective: 該当イベントがない日はデフォルト値を返すことを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'speech', agent: 'Mira', speech_id: 1 },
+    ];
+    const result = aggregateDayActions(events);
+    expect(result[1]).toBeUndefined();
   });
 });

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -4,12 +4,8 @@ import RoleTag from '../components/RoleTag.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
-import {
-  ROLE_ASSIGNMENT, NIGHT_RESULTS,
-  VOTE_TABLE_D1, ACTIONS_TIMELINE,
-} from '../../stub/spectator.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
-import { parseGameData } from '../lib/parseGameData.js';
+import { parseGameData, aggregateCoStatus, aggregateDayActions } from '../lib/parseGameData.js';
 import { filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
 
@@ -128,31 +124,6 @@ function SystemRow({ kind, icon, label, children, reasoning, ts, leftName, right
   );
 }
 
-// --- 投票内訳カード ---
-function VoteDetail({ day, daySummary }) {
-  if (day !== 1) return null;
-  const exec = daySummary[1];
-  if (!exec) return null;
-  return (
-    <div className={styles.voteDetail}>
-      <h4>
-        Day {day} 投票結果{' '}
-        <span className={styles.pill}>処刑: {exec.target}（{exec.votes}票）</span>
-      </h4>
-      <div className={styles.voteGrid}>
-        {VOTE_TABLE_D1.map((v, i) => (
-          <div className={styles.voteCell} key={i}>
-            <Avatar name={v.from} size="xs" />
-            <span className={styles.voteFrom}>{v.from}</span>
-            <span className={styles.voteArrow}>▶</span>
-            <span className={v.to === exec.target ? styles.targetBad : styles.voteTo}>{v.to}</span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 // --- 人狼会話カード ---
 function WolfChatCard({ ev }) {
   return (
@@ -239,7 +210,7 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
 }
 
 // === 左ペイン ===
-export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary }) {
+export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary, dayActions = {} }) {
   const handlePhase = (d, phase) => {
     setDay(d);
     setPhase(phase);
@@ -253,7 +224,9 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
           <div key={d}>
             <div className={styles.phaseDay}>
               <h3>第 {d} 日 <small>{d === 1 ? '初日' : d === 2 ? '荒れる' : '進行中'}</small></h3>
-              {NIGHT_RESULTS[d] && <div className={styles.deathline}>⚰ {NIGHT_RESULTS[d].attacked}</div>}
+              {dayActions[d]?.nightActions?.find(a => a.event_type === 'night_attack') && (
+                <div className={styles.deathline}>⚰ {dayActions[d].nightActions.find(a => a.event_type === 'night_attack').target}</div>
+              )}
             </div>
             <div className={styles.phaseList}>
               <div
@@ -308,15 +281,19 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
   );
 }
 
+const NIGHT_ACTION_ICON = { inspection: '🔮', guard: '🛡', night_attack: '🐺' };
+const NIGHT_ACTION_LABEL = { inspection: '占い', guard: '護衛', night_attack: '襲撃' };
+
+// TODO(#314): public モードでは真の役職タグを非表示にし、CO役職のみ表示する
 // === 右ペイン ===
-function RightPane({ agents, roleAssignment }) {
-  const order = Object.keys(agents).length
-    ? Object.keys(agents)
-    : ['Nox','Mira','Ren','Kai','Toma','Shiki','Rei','Sable','Sera','Kael','Sora'];
-  const dead = order.filter(n => agents[n]?.is_alive === false);
-  const fallbackDead = Object.keys(agents).length ? [] : ['Sora', 'Toma'];
-  const deadNames = dead.length ? dead : fallbackDead;
+export function RightPane({ agents, roleAssignment, coStatus = {}, dayActions = {}, activeDay, viewerMode = 'spectator' }) {
+  const order = Object.keys(agents);
+  const deadNames = order.filter(n => agents[n]?.is_alive === false);
   const alive = order.filter(n => !deadNames.includes(n));
+
+  const dayData = dayActions[activeDay];
+  const nightActions = dayData?.nightActions ?? [];
+  const execResult = dayData?.execResult ?? null;
 
   return (
     <div className={styles.roster}>
@@ -330,20 +307,19 @@ function RightPane({ agents, roleAssignment }) {
         {alive.map(n => {
           const role = roleAssignment[n];
           const r = ROLES[role];
-          const sus = (n.charCodeAt(0) * 13) % 100;
+          const coRole = coStatus[n];
           return (
             <div key={n} className={styles.rosterRow} style={{ '--r-color': r?.color }}>
               <Avatar name={n} role={role} size="sm" />
               <div className={styles.who}>
-                <span className={styles.rosterName}>{n} <RoleTag role={role} /></span>
-                <span className={styles.sub}>
-                  {(n === 'Ren' || n === 'Nox') && <span style={{ color: 'var(--acc)' }}>占CO</span>}
-                  <span>発言 {(n.length * 3) + 4}</span>
+                <span className={styles.rosterName}>
+                  {n}
+                  {/* spectator mode: true role tag always shown; TODO(#314): hide in public mode */}
+                  {viewerMode === 'spectator' && <RoleTag role={role} />}
+                  {coRole && (
+                    <span className={styles.coBadge}>▶ {ROLES[coRole]?.ja || coRole} CO</span>
+                  )}
                 </span>
-              </div>
-              <div className={styles.meter}>
-                <div className={styles.bar}><i style={{ width: `${sus}%` }} /></div>
-                <small><span>容疑</span><span>{sus}</span></small>
               </div>
             </div>
           );
@@ -362,7 +338,6 @@ function RightPane({ agents, roleAssignment }) {
                 <span className={styles.rosterName}>{n}</span>
                 <span className={styles.sub}>
                   <RoleTag role={role} />
-                  <span>{n === 'Sora' ? 'Day1 夜・襲撃' : 'Day1 昼・処刑'}</span>
                 </span>
               </div>
             </div>
@@ -372,53 +347,79 @@ function RightPane({ agents, roleAssignment }) {
 
       <div className={styles.sectionLabel}>カミングアウト状況</div>
       <div className={styles.coBoard}>
-        {[
-          { roleKey: 'Seer',   coName: 'Ren', meta: '→ Mira（白）' },
-          { roleKey: 'Seer',   coName: 'Nox', meta: '→ Kai（黒）' },
-          { roleKey: 'Medium', coName: null,   meta: '—' },
-          { roleKey: 'Knight', coName: null,   meta: '—' },
-        ].map(({ roleKey, coName, meta }, i) => (
-          <div key={i} className={styles.coRow} style={{ '--r-color': ROLES[roleKey]?.color }}>
-            <span className={styles.coRole}>{ROLES[roleKey]?.ja}</span>
-            <span className={styles.coName} style={{ color: coName ? 'var(--tx)' : 'var(--tx-3)' }}>
-              {coName || '未CO'}
-            </span>
-            <span className={styles.coMeta}>{meta}</span>
-          </div>
-        ))}
+        {Object.entries(ROLES)
+          .filter(([k]) => k !== 'Villager' && k !== 'Werewolf' && k !== 'Madman')
+          .map(([roleKey, roleDef]) => {
+            const coAgents = Object.entries(coStatus)
+              .filter(([, cr]) => cr === roleKey)
+              .map(([name]) => name);
+            return (
+              <div key={roleKey} className={styles.coRow} style={{ '--r-color': roleDef.color }}>
+                <span className={styles.coRole}>{roleDef.ja}</span>
+                <span className={styles.coName} style={{ color: coAgents.length ? 'var(--tx)' : 'var(--tx-3)' }}>
+                  {coAgents.length ? coAgents.join(', ') : '未CO'}
+                </span>
+              </div>
+            );
+          })}
       </div>
 
-      <div className={styles.sectionLabel}>夜の行動・推測</div>
+      <div className={styles.sectionLabel}>Day {activeDay} 夜の行動</div>
       <div className={styles.actionList}>
-        {ACTIONS_TIMELINE.map((a, i) => (
-          <div key={i} className={`${styles.action} ${styles[a.kind] || ''}`}>
-            <div className={styles.when}>D{a.day}{a.when}</div>
-            <div className={styles.actionIco}>
-              {a.kind === 'divine' ? '◉' : a.kind === 'guard' ? '盾' : a.kind === 'attack' ? '✕' : a.kind === 'exec' ? '⚑' : '・'}
-            </div>
+        {nightActions.map((a, i) => (
+          <div key={i} className={`${styles.action} ${styles[a.event_type] || ''}`}>
+            <div className={styles.actionIco}>{NIGHT_ACTION_ICON[a.event_type] || '・'}</div>
             <div className={styles.what}>
-              <strong>{a.who}</strong> → <em style={{ '--r-color': ROLES[ROLE_ASSIGNMENT[a.target]]?.color }}>{a.target}</em>
-              <span style={{ color: 'var(--tx-4)', marginLeft: 6 }}>{a.label}</span>
+              <strong>{a.agent}</strong>
+              {a.target && <> → <em style={{ '--r-color': ROLES[roleAssignment[a.target]]?.color }}>{a.target}</em></>}
+              <span style={{ color: 'var(--tx-4)', marginLeft: 6 }}>{NIGHT_ACTION_LABEL[a.event_type]}</span>
             </div>
-            {a.result && <div className={`${styles.res} ${styles[a.result]}`}>{a.result === 'black' ? '黒' : '白'}</div>}
-            {a.votes  && <div className={styles.res} style={{ color: 'var(--tx-3)' }}>{a.votes}票</div>}
           </div>
         ))}
+        {nightActions.length === 0 && (
+          <div className={styles.action} style={{ color: 'var(--tx-3)' }}>夜の行動ログなし</div>
+        )}
       </div>
+
+      {execResult && (
+        <>
+          <div className={styles.sectionLabel}>Day {activeDay} 処刑結果</div>
+          <div className={styles.voteDetail}>
+            <h4>
+              処刑: <span className={styles.pill}>{execResult.target}</span>
+            </h4>
+            <div className={styles.voteGrid}>
+              {execResult.voteTable.map((v, i) => (
+                <div className={styles.voteCell} key={i}>
+                  <Avatar name={v.from} size="xs" />
+                  <span className={styles.voteFrom}>{v.from}</span>
+                  <span className={styles.voteArrow}>▶</span>
+                  <span className={v.to === execResult.target ? styles.targetBad : styles.voteTo}>{v.to}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }
 
 // === メイン観戦画面 ===
+// TODO(#314): viewerMode の切り替えUI（spectator/public トグル）を追加する
 export default function SpectatorScreen({ sessionId, cast = [], title, onBack }) {
   const [activeDay, setActiveDay] = useState(2);
   const [activePhase, setActivePhase] = useState('discuss');
   const [replayEvents, setReplayEvents] = useState(null);
   const [replayAgents, setReplayAgents] = useState({});
   const [replayDaySummary, setReplayDaySummary] = useState(null);
+  const [replayCoStatus, setReplayCoStatus] = useState({});
+  const [replayDayActions, setReplayDayActions] = useState({});
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
   const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
   const [loadError, setLoadError] = useState(null);
+  // TODO(#314): public モード切り替えUIを追加したらここで toggle する
+  const viewerMode = 'spectator';
 
   useEffect(() => {
     if (!sessionId) return undefined;
@@ -427,6 +428,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     setReplayEvents(null);
     setReplayAgents({});
     setReplayDaySummary(null);
+    setReplayCoStatus({});
+    setReplayDayActions({});
     setLoadingEvents(true);
     setLoadingAgents(true);
     setLoadError(null);
@@ -449,6 +452,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         const parsed = parseGameData(jsonlText);
         setReplayEvents(parsed.events);
         setReplayDaySummary(parsed.daySummary);
+        setReplayCoStatus(aggregateCoStatus(parsed.events));
+        setReplayDayActions(aggregateDayActions(parsed.events));
         const firstDay = parsed.events.find(event => event.day)?.day;
         if (firstDay) { setActiveDay(firstDay); setActivePhase('discuss'); }
       })
@@ -480,7 +485,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
 
   const feedEvents = filterFeedEvents(events, activeDay, activePhase);
   const speechCount = events.filter(e => e.event_type === 'speech').length;
-  const coCount = events.filter(e => e.claimed_role).length;
+  const coCount = Object.keys(replayCoStatus).length;
 
   return (
     <div className={styles.frame}>
@@ -495,14 +500,13 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
       <ThreePaneLayout
         collapsibleLeft
         collapsibleRight
-        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} />}
-        right={<RightPane agents={agents} roleAssignment={roleAssignment} />}
+        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} dayActions={replayDayActions} />}
+        right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} dayActions={replayDayActions} activeDay={activeDay} viewerMode={viewerMode} />}
       >
         <div className={styles.feedHead}>
           <h2>Day {activeDay} {{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]} <small>{sessionId ? sessionId : '3:47 経過 / 残り 4:13'}</small></h2>
           <span className={styles.stat}>発言 <strong>{speechCount}</strong></span>
           <span className={styles.stat}>CO <strong>{coCount}</strong></span>
-          <span className={styles.stat}>投票確定 <strong>6/9</strong></span>
           <span className={styles.spacer} />
           <TopBarBtn>⇅ 新しい順</TopBarBtn>
           <TopBarBtn>🔍 検索</TopBarBtn>

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -1,8 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { FeedItem, LeftPane } from './SpectatorScreen.jsx';
+import { FeedItem, LeftPane, RightPane } from './SpectatorScreen.jsx';
+import SpectatorScreen from './SpectatorScreen.jsx';
 import styles from './SpectatorScreen.module.css';
+import * as replayLoader from '../lib/replayLoader.js';
+
+vi.mock('../lib/replayLoader.js', () => ({
+  fetchReplayLog: vi.fn(),
+  fetchReplayAgents: vi.fn(),
+  fetchReplayGame: vi.fn(),
+}));
 
 const roleAssignment = {
   Alice: 'Seer',
@@ -316,6 +324,130 @@ describe('FeedItem: system event icons', () => {
   });
 });
 
+const baseAgents = {
+  Alice: { role: 'Seer',     is_alive: true,  claimed_role: null },
+  Bob:   { role: 'Werewolf', is_alive: false, claimed_role: null },
+  Carol: { role: 'Knight',   is_alive: true,  claimed_role: null },
+};
+
+function renderRightPane(overrides = {}) {
+  const props = {
+    agents: baseAgents,
+    roleAssignment: { Alice: 'Seer', Bob: 'Werewolf', Carol: 'Knight' },
+    coStatus: {},
+    dayActions: {},
+    activeDay: 1,
+    viewerMode: 'spectator',
+    ...overrides,
+  };
+  return render(<RightPane {...props} />);
+}
+
+describe('RightPane: suspicion meter removed', () => {
+  it('does not render a suspicion meter', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: 容疑度メーターが右ペインに存在しないことを検証する。
+     */
+    const { container } = renderRightPane();
+    expect(container.querySelector('[class*="meter"]')).toBeNull();
+  });
+});
+
+describe('RightPane: role display in spectator mode', () => {
+  it('shows true role tag for alive agents', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: spectatorモードで生存エージェントに真の役職タグが表示されることを検証する。
+     */
+    renderRightPane({ viewerMode: 'spectator' });
+    // Alice is Seer (true role), Carol is Knight (true role)
+    expect(screen.getAllByText(/占い師/).length).toBeGreaterThan(0);
+  });
+
+  it('shows CO role badge when agent has claimed_role', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: COしたエージェントのCO役職バッジが表示されることを検証する。
+     */
+    renderRightPane({
+      coStatus: { Alice: 'Seer' },
+    });
+    expect(screen.getByText(/占い師.*CO|CO.*占い師|▶.*占い師/)).toBeTruthy();
+  });
+});
+
+describe('RightPane: CO board dynamic', () => {
+  it('shows CO agents with their claimed role', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: COボードに coStatus から動的生成されたエージェント名と役職が表示されることを検証する。
+     */
+    renderRightPane({
+      coStatus: { Alice: 'Seer', Carol: 'Knight' },
+    });
+    expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
+  });
+
+  it('shows 未CO placeholder when no one has CO for a role', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: COがない場合に「未CO」が表示されることを検証する。
+     */
+    renderRightPane({ coStatus: {} });
+    expect(screen.getAllByText('未CO').length).toBeGreaterThan(0);
+  });
+});
+
+describe('RightPane: night actions for activeDay', () => {
+  it('shows night action entries for the active day', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: activeDay の夜行動が右ペインに表示されることを検証する。
+     */
+    const dayActions = {
+      1: {
+        nightActions: [
+          { day: 1, event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf', is_public: false },
+        ],
+        execResult: { target: 'Bob', voteTable: [{ from: 'Alice', to: 'Bob' }] },
+      },
+    };
+    renderRightPane({ dayActions, activeDay: 1 });
+    expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Bob').length).toBeGreaterThan(0);
+  });
+
+  it('shows exec result for the active day', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: activeDay の処刑結果（ターゲット）が表示されることを検証する。
+     */
+    const dayActions = {
+      1: {
+        nightActions: [],
+        execResult: { target: 'Bob', voteTable: [{ from: 'Alice', to: 'Bob' }] },
+      },
+    };
+    renderRightPane({ dayActions, activeDay: 1 });
+    expect(screen.getAllByText('Bob').length).toBeGreaterThan(0);
+  });
+});
+
 describe('LeftPane phase interaction', () => {
   it.each([
     ['議論フェーズ', 'discuss'],
@@ -353,5 +485,91 @@ describe('LeftPane phase interaction', () => {
     expect(discussRow.className.split(' ')).not.toContain(styles.active);
     expect(voteRow.className.split(' ')).toContain(styles.active);
     expect(nightRow.className.split(' ')).not.toContain(styles.active);
+  });
+});
+
+const MINIMAL_JSONL = [
+  '{"id":"e1","day":1,"phase":"init","event_type":"phase_start","agent":null,"target":null,"content":"=== GAME START ===","is_public":true,"speech_id":null,"reply_to":null}',
+  '{"id":"e2","day":1,"phase":"day_discussion","event_type":"speech","agent":"Alice","target":null,"content":"こんにちは","is_public":true,"speech_id":1,"reply_to":null}',
+  '{"id":"e3","day":1,"phase":"day_vote","event_type":"vote","agent":"Alice","target":"Bob","content":"Alice votes for Bob","is_public":true,"speech_id":null,"reply_to":null}',
+  '{"id":"e4","day":1,"phase":"day_vote","event_type":"elimination","agent":"Bob","target":null,"content":"Bob was executed.","is_public":true,"speech_id":null,"reply_to":null}',
+  '{"id":"e5","day":1,"phase":"day_discussion","event_type":"co_announcement","agent":"Alice","target":null,"content":"Alice claims to be Seer","is_public":true,"speech_id":null,"reply_to":null,"claimed_role":"Seer"}',
+].join('\n');
+
+const MINIMAL_AGENT_JSON = {
+  Alice: { name: 'Alice', role: 'Seer', state: { is_alive: true }, profile: { name: 'Alice' } },
+};
+
+describe('SpectatorScreen: sessionId integration', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const CAST = [];
+
+  it('renders feed events from fetchReplayLog after load', async () => {
+    /*
+     * SUT: SpectatorScreen (default export)
+     * Mock: fetchReplayLog / fetchReplayAgents を vi.fn() でモック
+     * Level: integration
+     * Objective: sessionId が渡されると fetchReplayLog の結果がフィードに表示されることを検証する。
+     */
+    replayLoader.fetchReplayLog.mockResolvedValue(MINIMAL_JSONL);
+    replayLoader.fetchReplayAgents.mockResolvedValue(MINIMAL_AGENT_JSON);
+
+    render(<SpectatorScreen sessionId="test-session-001" cast={CAST} />);
+
+    await waitFor(() => expect(screen.getByText('こんにちは')).toBeTruthy(), { timeout: 3000 });
+  });
+
+  it('shows CO count from real log events', async () => {
+    /*
+     * SUT: SpectatorScreen (default export)
+     * Mock: fetchReplayLog / fetchReplayAgents を vi.fn() でモック
+     * Level: integration
+     * Objective: co_announcement イベントの数が TopBar の CO 表示に反映されることを検証する。
+     */
+    replayLoader.fetchReplayLog.mockResolvedValue(MINIMAL_JSONL);
+    replayLoader.fetchReplayAgents.mockResolvedValue(MINIMAL_AGENT_JSON);
+
+    render(<SpectatorScreen sessionId="test-session-001" cast={CAST} />);
+
+    await waitFor(() => {
+      const coSpan = [...document.querySelectorAll('span')].find(el => el.textContent.includes('CO'));
+      expect(coSpan?.querySelector('strong')?.textContent).toBe('1');
+    }, { timeout: 3000 });
+  });
+
+  it('shows load error when fetchReplayLog rejects', async () => {
+    /*
+     * SUT: SpectatorScreen (default export)
+     * Mock: fetchReplayLog を reject するモック
+     * Level: integration
+     * Objective: fetch 失敗時にエラーメッセージが表示されることを検証する。
+     */
+    replayLoader.fetchReplayLog.mockRejectedValue(new Error('network error'));
+    replayLoader.fetchReplayAgents.mockResolvedValue({});
+
+    render(<SpectatorScreen sessionId="bad-session" cast={CAST} />);
+
+    await waitFor(() => expect(screen.getByText(/network error/)).toBeTruthy(), { timeout: 3000 });
+  });
+
+  it('calls onBack when back button is clicked', async () => {
+    /*
+     * SUT: SpectatorScreen (default export)
+     * Mock: fetchReplayLog / fetchReplayAgents / onBack を vi.fn()
+     * Level: integration
+     * Objective: onBack prop が渡されていれば「← 一覧」ボタンが表示されクリックで呼ばれることを検証する。
+     */
+    replayLoader.fetchReplayLog.mockResolvedValue('');
+    replayLoader.fetchReplayAgents.mockResolvedValue({});
+    const onBack = vi.fn();
+
+    const user = userEvent.setup();
+    render(<SpectatorScreen sessionId="test-session-001" cast={CAST} onBack={onBack} />);
+
+    await user.click(screen.getByText('← 一覧'));
+    expect(onBack).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- Remove suspicion meter from `RightPane`
- Fix role display per `viewerMode`: spectator mode shows true role tag + CO badge; added `// TODO(#314)` comments for public mode toggle
- Add `aggregateCoStatus` / `aggregateDayActions` to `parseGameData.js` and connect `RightPane` night actions / exec results to real log data (stubs fully removed)
- Link left pane day click to right pane display via `activeDay` prop
- Fix `vi.mock` factory pattern and `cast=[]` prop stability to resolve integration test OOM / infinite loop

## Test plan
- [ ] `npx vitest run` passes (46 tests in SpectatorScreen.test.jsx, all green)
- [ ] Pre-commit hooks pass (ruff, pytest, frontend test, coverage)
- [ ] Playwright: right pane shows correct role tags and CO badges in spectator mode
- [ ] Playwright: clicking a day in left pane updates right pane night actions

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)