### PR TITLE
refactor(frontend): replace stub fallbacks with real log data in SpectatorScreen

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,10 +21,10 @@
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |
+| yukkie/AgentVillage#383 | bug | 🟡 | 2 | night_attack public event has agent/target fields swapped | is_public:true の night_attack で agent/target が逆転しているバグ。バックエンド修正後、SpectatorScreen.jsx:219 の `?? ev.agent` workaround を除去する |
 | yukkie/AgentVillage#344 | tech-debt | 🟡 | 3 | Design: LogEvent cannot express mixed public/private fields in a single speech event | speech イベントの公開/非公開混在問題の設計を定め Architecture.md に記載、[THINK] ハックを廃止する設計Issueを作る |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |
-| yukkie/AgentVillage#357 | tech-debt | 🔴 | 2 | Remove remaining stub fallbacks in SpectatorScreen (NIGHT_RESULTS, VOTE_TABLE_D1, ACTIONS_TIMELINE, ROLE_ASSIGNMENT) | #346 で未対応のスタブ依存4件を実ログ由来データに差し替え、stub/spectator.js の import を完全除去 |
 | yukkie/AgentVillage#350 | enhancement | 🟡 | 3 | Rework SpectatorScreen right pane — role display, real log actions, day-linked view | 容疑度メーター削除・役職表示改善・夜行動実ログ接続・左ペイン日付クリック連動。#314/#346 依存 |
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -123,6 +123,56 @@ function parseAgent(agentJson) {
 }
 
 /**
+ * Index public night_attack events by day to get the attacked agent name.
+ *
+ * @param {object[]} events
+ * @returns {Record<number, { attacked: string }>}
+ */
+export function aggregateNightResults(events) {
+  const result = {};
+  for (const ev of events) {
+    if (ev.event_type === 'night_attack' && !ev.is_public && ev.target) {
+      result[ev.day] = { attacked: ev.target };
+    }
+  }
+  return result;
+}
+
+const ACTION_KIND = {
+  inspection: 'divine',
+  guard: 'guard',
+  night_attack: 'attack',
+  elimination: 'exec',
+};
+
+/**
+ * Build a flat timeline of night/day actions for the right-pane action list.
+ * Includes inspection, guard, private night_attack (wolf POV), and elimination.
+ * Public night_attack (village result announcement) is excluded — use aggregateNightResults for that.
+ *
+ * @param {object[]} events
+ * @returns {Array<{ day: number, when: 'N'|'D', kind: string, who: string, target: string, label: string }>}
+ */
+export function buildActionsTimeline(events) {
+  const nightEntries = [];
+  const dayEntries = [];
+
+  for (const ev of events) {
+    if (ev.event_type === 'inspection') {
+      nightEntries.push({ day: ev.day, when: 'N', kind: 'divine', who: ev.agent, target: ev.target, label: '占い' });
+    } else if (ev.event_type === 'guard') {
+      nightEntries.push({ day: ev.day, when: 'N', kind: 'guard', who: ev.agent, target: ev.target, label: '護衛' });
+    } else if (ev.event_type === 'night_attack' && !ev.is_public) {
+      nightEntries.push({ day: ev.day, when: 'N', kind: 'attack', who: ev.agent, target: ev.target, label: '襲撃' });
+    } else if (ev.event_type === 'elimination' && ev.is_public) {
+      dayEntries.push({ day: ev.day, when: 'D', kind: 'exec', who: '村', target: ev.agent, label: '処刑' });
+    }
+  }
+
+  return [...nightEntries, ...dayEntries];
+}
+
+/**
  * Aggregate per-day execution target, vote count, and night completion from
  * elimination / vote / night_attack events. Days with only other event types
  * (speech, guard, etc.) have no entry in the returned map.
@@ -183,5 +233,7 @@ export function parseGameData(jsonlText, agentJsonByName = {}) {
     events,
     agents,
     daySummary: aggregateDayResults(rawEvents),
+    nightResults: aggregateNightResults(rawEvents),
+    actionsTimeline: buildActionsTimeline(rawEvents),
   };
 }

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseEventLine, parseGameData, normalizeEvents, aggregateDayResults } from './parseGameData.js';
+import { parseEventLine, parseGameData, normalizeEvents, aggregateDayResults, aggregateNightResults, buildActionsTimeline } from './parseGameData.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -182,6 +182,165 @@ describe('parseGameData', () => {
     expect(day1.target).toBeTruthy();
     expect(typeof day1.votes).toBe('number');
     expect(typeof day1.nightDone).toBe('boolean');
+  });
+});
+
+describe('aggregateNightResults', () => {
+  it('returns attacked name from private night_attack per day', () => {
+    /*
+     * SUT: aggregateNightResults
+     * Mock: なし
+     * Level: unit
+     * Objective: is_public=false の night_attack の target（被害者）を day ごとにインデックスし、
+     *            { attacked: string } を返すことを検証する。
+     *            is_public=true の night_attack は agent/target が逆転しているバグがあるため使わない。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', agent: 'Kai', target: 'Sora', is_public: false },
+      { day: 2, event_type: 'night_attack', agent: 'Kai', target: 'Rei',  is_public: false },
+      { day: 2, event_type: 'night_attack', agent: 'Rei', target: null,   is_public: true },
+    ];
+    const result = aggregateNightResults(events);
+    expect(result[1]).toEqual({ attacked: 'Sora' });
+    expect(result[2]).toEqual({ attacked: 'Rei' });
+  });
+
+  it('ignores public night_attack events', () => {
+    /*
+     * SUT: aggregateNightResults
+     * Mock: なし
+     * Level: unit
+     * Objective: is_public=true の night_attack は agent/target が逆転しているバグがあるため無視することを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', agent: 'Sora', target: null, is_public: true },
+    ];
+    const result = aggregateNightResults(events);
+    expect(result[1]).toBeUndefined();
+  });
+
+  it('returns empty object when no night_attack events', () => {
+    /*
+     * SUT: aggregateNightResults
+     * Mock: なし
+     * Level: unit
+     * Objective: night_attack がないイベント列では空オブジェクトを返すことを検証する。
+     */
+    const result = aggregateNightResults([
+      { day: 1, event_type: 'speech', agent: 'Mira' },
+    ]);
+    expect(result).toEqual({});
+  });
+});
+
+describe('buildActionsTimeline', () => {
+  it('maps inspection event to divine kind entry', () => {
+    /*
+     * SUT: buildActionsTimeline
+     * Mock: なし
+     * Level: unit
+     * Objective: inspection イベントが kind="divine" のタイムラインエントリに変換されることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'inspection', agent: 'Nox', target: 'Kai', content: 'Nox inspects Kai: Werewolf', is_public: false },
+    ];
+    const timeline = buildActionsTimeline(events);
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]).toMatchObject({ day: 1, when: 'N', kind: 'divine', who: 'Nox', target: 'Kai' });
+  });
+
+  it('maps guard event to guard kind entry', () => {
+    /*
+     * SUT: buildActionsTimeline
+     * Mock: なし
+     * Level: unit
+     * Objective: guard イベントが kind="guard" のタイムラインエントリに変換されることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'guard', agent: 'Rei', target: 'Nox', content: 'Rei guards Nox', is_public: false },
+    ];
+    const timeline = buildActionsTimeline(events);
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]).toMatchObject({ day: 1, when: 'N', kind: 'guard', who: 'Rei', target: 'Nox' });
+  });
+
+  it('maps private night_attack to attack kind entry', () => {
+    /*
+     * SUT: buildActionsTimeline
+     * Mock: なし
+     * Level: unit
+     * Objective: is_public=false の night_attack が kind="attack" に変換されることを検証する
+     *            （狼視点の行動を表す）。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', agent: 'Kai', target: 'Sora', content: 'Kai attacks Sora', is_public: false },
+    ];
+    const timeline = buildActionsTimeline(events);
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]).toMatchObject({ day: 1, when: 'N', kind: 'attack', who: 'Kai', target: 'Sora' });
+  });
+
+  it('maps elimination to exec kind entry with when="D"', () => {
+    /*
+     * SUT: buildActionsTimeline
+     * Mock: なし
+     * Level: unit
+     * Objective: elimination イベントが kind="exec", when="D" のタイムラインエントリに変換されることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'elimination', agent: 'Toma', target: null, content: 'Toma was eliminated.', is_public: true },
+    ];
+    const timeline = buildActionsTimeline(events);
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]).toMatchObject({ day: 1, when: 'D', kind: 'exec', who: '村', target: 'Toma' });
+  });
+
+  it('ignores public night_attack (result announcement) in timeline', () => {
+    /*
+     * SUT: buildActionsTimeline
+     * Mock: なし
+     * Level: unit
+     * Objective: is_public=true の night_attack（村への結果通知）はタイムラインに含まれないことを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', target: 'Sora', is_public: true },
+    ];
+    const timeline = buildActionsTimeline(events);
+    expect(timeline).toHaveLength(0);
+  });
+
+  it('orders entries: night actions before day actions', () => {
+    /*
+     * SUT: buildActionsTimeline
+     * Mock: なし
+     * Level: unit
+     * Objective: 同日内で夜行動（when="N"）が昼行動（when="D"）より先に並ぶことを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'elimination', agent: 'Toma', is_public: true },
+      { day: 1, event_type: 'inspection',  agent: 'Nox',  target: 'Kai', is_public: false },
+    ];
+    const timeline = buildActionsTimeline(events);
+    expect(timeline[0].when).toBe('N');
+    expect(timeline[1].when).toBe('D');
+  });
+
+  it('parseGameData returns nightResults and actionsTimeline', () => {
+    /*
+     * SUT: parseGameData
+     * Mock: なし
+     * Level: unit
+     * Objective: parseGameData の戻り値に nightResults と actionsTimeline が含まれることを検証する。
+     */
+    const jsonl = [
+      JSON.stringify({ day: 1, event_type: 'night_attack', agent: 'Kai', target: 'Sora', is_public: false }),
+      JSON.stringify({ day: 1, event_type: 'inspection', agent: 'Nox', target: 'Kai', is_public: false }),
+    ].join('\n');
+    const result = parseGameData(jsonl);
+    expect(result.nightResults).toBeDefined();
+    expect(result.nightResults[1]).toEqual({ attacked: 'Sora' });
+    expect(result.actionsTimeline).toBeDefined();
+    expect(result.actionsTimeline.length).toBeGreaterThan(0);
   });
 });
 

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -4,10 +4,6 @@ import RoleTag from '../components/RoleTag.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
-import {
-  ROLE_ASSIGNMENT, NIGHT_RESULTS,
-  VOTE_TABLE_D1, ACTIONS_TIMELINE,
-} from '../../stub/spectator.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
 import { parseGameData } from '../lib/parseGameData.js';
 import { filterFeedEvents } from '../lib/feedFilter.js';
@@ -129,10 +125,13 @@ function SystemRow({ kind, icon, label, children, reasoning, ts, leftName, right
 }
 
 // --- 投票内訳カード ---
-function VoteDetail({ day, daySummary }) {
-  if (day !== 1) return null;
-  const exec = daySummary[1];
+function VoteDetail({ day, daySummary, events }) {
+  const exec = daySummary[day];
   if (!exec) return null;
+  const votes = events
+    .filter(ev => ev.event_type === 'vote' && ev.day === day)
+    .map(ev => ({ from: ev.agent, to: ev.target }));
+  if (!votes.length) return null;
   return (
     <div className={styles.voteDetail}>
       <h4>
@@ -140,7 +139,7 @@ function VoteDetail({ day, daySummary }) {
         <span className={styles.pill}>処刑: {exec.target}（{exec.votes}票）</span>
       </h4>
       <div className={styles.voteGrid}>
-        {VOTE_TABLE_D1.map((v, i) => (
+        {votes.map((v, i) => (
           <div className={styles.voteCell} key={i}>
             <Avatar name={v.from} size="xs" />
             <span className={styles.voteFrom}>{v.from}</span>
@@ -239,7 +238,7 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
 }
 
 // === 左ペイン ===
-export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary }) {
+export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary, nightResults = {} }) {
   const handlePhase = (d, phase) => {
     setDay(d);
     setPhase(phase);
@@ -253,7 +252,7 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
           <div key={d}>
             <div className={styles.phaseDay}>
               <h3>第 {d} 日 <small>{d === 1 ? '初日' : d === 2 ? '荒れる' : '進行中'}</small></h3>
-              {NIGHT_RESULTS[d] && <div className={styles.deathline}>⚰ {NIGHT_RESULTS[d].attacked}</div>}
+              {nightResults[d] && <div className={styles.deathline}>⚰ {nightResults[d].attacked}</div>}
             </div>
             <div className={styles.phaseList}>
               <div
@@ -309,7 +308,7 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
 }
 
 // === 右ペイン ===
-function RightPane({ agents, roleAssignment }) {
+function RightPane({ agents, roleAssignment, actionsTimeline = [] }) {
   const order = Object.keys(agents).length
     ? Object.keys(agents)
     : ['Nox','Mira','Ren','Kai','Toma','Shiki','Rei','Sable','Sera','Kael','Sora'];
@@ -390,14 +389,14 @@ function RightPane({ agents, roleAssignment }) {
 
       <div className={styles.sectionLabel}>夜の行動・推測</div>
       <div className={styles.actionList}>
-        {ACTIONS_TIMELINE.map((a, i) => (
+        {actionsTimeline.map((a, i) => (
           <div key={i} className={`${styles.action} ${styles[a.kind] || ''}`}>
             <div className={styles.when}>D{a.day}{a.when}</div>
             <div className={styles.actionIco}>
               {a.kind === 'divine' ? '◉' : a.kind === 'guard' ? '盾' : a.kind === 'attack' ? '✕' : a.kind === 'exec' ? '⚑' : '・'}
             </div>
             <div className={styles.what}>
-              <strong>{a.who}</strong> → <em style={{ '--r-color': ROLES[ROLE_ASSIGNMENT[a.target]]?.color }}>{a.target}</em>
+              <strong>{a.who}</strong> → <em style={{ '--r-color': ROLES[roleAssignment[a.target]]?.color }}>{a.target}</em>
               <span style={{ color: 'var(--tx-4)', marginLeft: 6 }}>{a.label}</span>
             </div>
             {a.result && <div className={`${styles.res} ${styles[a.result]}`}>{a.result === 'black' ? '黒' : '白'}</div>}
@@ -416,6 +415,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   const [replayEvents, setReplayEvents] = useState(null);
   const [replayAgents, setReplayAgents] = useState({});
   const [replayDaySummary, setReplayDaySummary] = useState(null);
+  const [replayNightResults, setReplayNightResults] = useState({});
+  const [replayActionsTimeline, setReplayActionsTimeline] = useState([]);
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
   const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
   const [loadError, setLoadError] = useState(null);
@@ -427,6 +428,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     setReplayEvents(null);
     setReplayAgents({});
     setReplayDaySummary(null);
+    setReplayNightResults({});
+    setReplayActionsTimeline([]);
     setLoadingEvents(true);
     setLoadingAgents(true);
     setLoadError(null);
@@ -449,6 +452,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         const parsed = parseGameData(jsonlText);
         setReplayEvents(parsed.events);
         setReplayDaySummary(parsed.daySummary);
+        setReplayNightResults(parsed.nightResults);
+        setReplayActionsTimeline(parsed.actionsTimeline);
         const firstDay = parsed.events.find(event => event.day)?.day;
         if (firstDay) { setActiveDay(firstDay); setActivePhase('discuss'); }
       })
@@ -467,6 +472,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   const events = replayEvents ?? [];
   const agents = replayAgents;
   const daySummary = replayDaySummary ?? {};
+  const nightResults = replayNightResults;
+  const actionsTimeline = replayActionsTimeline;
   const roleAssignment = useMemo(() => Object.fromEntries(
     Object.entries(agents).map(([name, agent]) => [name, agent.role])
   ), [agents]);
@@ -495,8 +502,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
       <ThreePaneLayout
         collapsibleLeft
         collapsibleRight
-        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} />}
-        right={<RightPane agents={agents} roleAssignment={roleAssignment} />}
+        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} nightResults={nightResults} />}
+        right={<RightPane agents={agents} roleAssignment={roleAssignment} actionsTimeline={actionsTimeline} />}
       >
         <div className={styles.feedHead}>
           <h2>Day {activeDay} {{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]} <small>{sessionId ? sessionId : '3:47 経過 / 残り 4:13'}</small></h2>

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -316,6 +316,38 @@ describe('FeedItem: system event icons', () => {
   });
 });
 
+describe('LeftPane night death display', () => {
+  it('shows attacked agent name from nightResults when available', () => {
+    /**
+     * SUT: LeftPane
+     * Mock: なし（nightResults plain object を入力）
+     * Level: unit
+     * Objective: nightResults[day].attacked が渡されると ⚰ マークと共に左ペインに表示されることを検証する。
+     */
+    renderLeftPane({
+      days: [1],
+      nightResults: { 1: { attacked: 'Alice' } },
+    });
+
+    expect(screen.getByText(/⚰.*Alice|Alice.*⚰/)).toBeTruthy();
+  });
+
+  it('shows nothing when nightResults has no entry for the day', () => {
+    /**
+     * SUT: LeftPane
+     * Mock: なし
+     * Level: unit
+     * Objective: nightResults に当該 day のエントリがない場合は ⚰ が表示されないことを検証する。
+     */
+    const { container } = renderLeftPane({
+      days: [1],
+      nightResults: {},
+    });
+
+    expect(container.querySelector('[class*="deathline"]')).toBeNull();
+  });
+});
+
 describe('LeftPane phase interaction', () => {
   it.each([
     ['議論フェーズ', 'discuss'],


### PR DESCRIPTION
## Summary

- `parseGameData.js` に `aggregateNightResults()` / `buildActionsTimeline()` を追加し、`parseGameData` の戻り値に `nightResults` / `actionsTimeline` を追加
- 左ペインの ⚰ 死亡者表示を `NIGHT_RESULTS` スタブから実ログの private `night_attack.target` に差し替え（public イベントは agent/target が逆転しているバグ #383 があるため private を使用）
- VoteDetail の投票内訳を `VOTE_TABLE_D1` スタブから実ログの `vote` イベントに差し替え（全 day 対応）
- 右ペインの夜の行動タイムラインを `ACTIONS_TIMELINE` / `ROLE_ASSIGNMENT` スタブから実ログ由来データに差し替え
- `stub/spectator.js` の import を `SpectatorScreen.jsx` から完全除去

## Test plan

- [ ] `npm test` パス（88テスト全GREEN）
- [ ] `aggregateNightResults` — public night_attack を無視し private の target を使うことを検証
- [ ] `buildActionsTimeline` — inspection/guard/night_attack/elimination の各マッピングを検証
- [ ] `LeftPane night death display` — nightResults prop から ⚰ 表示を検証
- [ ] Playwright で ⚰ 表示・夜の行動タイムライン・フィード表示を目視確認済み

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)