### PR TITLE
fix(frontend): day-accurate alive/dead status in right pane (#382)

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -293,9 +293,9 @@ stateDiagram-v2
       == RightPane (360px)
       -- 参加エージェント  9/11生存 --
       生存 9
-      [Nox] Nox  占い師  容疑 ██░░ 45
-      [Mira] Mira 狩人   容疑 ███░ 62
-      [Kai]  Kai  人狼   容疑 ████ 88
+      [Nox] Nox  占い師
+      [Mira] Mira 狩人
+      [Kai]  Kai  人狼
       ...
       死亡 2
       [Sora] Sora 村人   Day1夜・襲撃
@@ -342,7 +342,7 @@ stateDiagram-v2
       [Sora]  Sora  村人   ✕
       [Toma]  Toma  村人   ✕
       --
-      [発言数↓] [容疑度↓] [役職別]
+      [発言数↓] [役職別]
     } |
     {+
       == Center (1fr)
@@ -481,7 +481,7 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 | `SystemRow` | GM通知・処刑・夜フェーズ移行など非発言イベント |
 | `FeedItem` | `event_type` でルーティングして各カードに振り分ける |
 | `LeftPane` | フェーズナビ（日 × フェーズ、クリックで中央フィードを切り替え） + エージェント/役職/表示フィルタ |
-| `RightPane` | ロスター（生存/死亡 + 容疑度メーター）/ COボード / 夜の行動タイムライン |
+| `RightPane` | ロスター（生存/死亡）/ COボード / 夜の行動タイムライン |
 
 #### フェーズクリックの仕様（#358）
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -12,7 +12,6 @@
 ## GitHub Issues（未実装タスク）
 
 並び順は Sprint Goal に沿って Milestone 2 優先 → ゲームロジック系 → 将来フェーズの順。
-| yukkie/AgentVillage#382 | bug | 🟡 | 2 | fix(frontend): show day-accurate alive/dead status in SpectatorScreen right pane | 右ペインの生存/死亡リストを activeDay 時点の状態に切り替える |
 同一区分内では優先度（🔴 → 🟡 → 🟢）で並べる。
 
 ### Milestone 2（実データ観戦）— 現 Sprint

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -262,6 +262,40 @@ export function aggregateDayActions(events) {
 }
 
 /**
+ * Build a cumulative dead-set per day from elimination events.
+ *
+ * Returns a map from day number → Set of agent names dead *at the end of that day*.
+ * Days with no elimination inherit the previous day's set so callers can simply
+ * do `deadByDay[activeDay]?.has(name)` without caring about history.
+ *
+ * @param {object[]} events
+ * @returns {Record<number, Set<string>>}
+ */
+export function computeDeadByDay(events) {
+  const dayNumbers = [...new Set(events.map(ev => ev.day).filter(Boolean))].sort((a, b) => a - b);
+  if (dayNumbers.length === 0) return {};
+
+  const eliminationsByDay = {};
+  for (const ev of events) {
+    if (ev.event_type === 'elimination' && ev.agent && ev.day) {
+      if (!eliminationsByDay[ev.day]) eliminationsByDay[ev.day] = [];
+      eliminationsByDay[ev.day].push(ev.agent);
+    }
+  }
+
+  const result = {};
+  let cumulative = new Set();
+  for (const day of dayNumbers) {
+    if (eliminationsByDay[day]) {
+      cumulative = new Set(cumulative);
+      for (const name of eliminationsByDay[day]) cumulative.add(name);
+    }
+    result[day] = cumulative;
+  }
+  return result;
+}
+
+/**
  * Parse archive JSONL and agent JSON into the GameData shape consumed by React.
  *
  * This function is intentionally synchronous and pure. I/O stays in

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseEventLine, parseGameData, normalizeEvents, aggregateDayResults, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, aggregateDayActions } from './parseGameData.js';
+import { parseEventLine, parseGameData, normalizeEvents, aggregateDayResults, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, aggregateDayActions, computeDeadByDay } from './parseGameData.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -434,6 +434,87 @@ describe('aggregateCoStatus', () => {
       { day: 3, event_type: 'co_announcement', agent: 'Ren', claimed_role: 'Villager', is_public: true },
     ];
     expect(aggregateCoStatus(events)).toEqual({ Ren: 'Villager' });
+  });
+});
+
+describe('computeDeadByDay', () => {
+  it('returns empty Sets for all days when there are no eliminations', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: elimination イベントがない場合、全日で空の Set が返ることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'speech', agent: 'Mira' },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[1]).toEqual(new Set());
+  });
+
+  it('includes only Day 1 victim in Day 1 dead set', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: Day 1 を選択したとき、Day 1 の処刑対象のみが死亡者として含まれることを検証する（AC1）。
+     */
+    const events = [
+      { day: 1, event_type: 'elimination', agent: 'Toma' },
+      { day: 2, event_type: 'elimination', agent: 'Nox' },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[1].has('Toma')).toBe(true);
+    expect(result[1].has('Nox')).toBe(false);
+  });
+
+  it('accumulates previous victims in later days (AC2)', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: Day 2 以降を選択したとき、それ以前の累積死亡者が Set に含まれることを検証する（AC2）。
+     */
+    const events = [
+      { day: 1, event_type: 'elimination', agent: 'Toma' },
+      { day: 2, event_type: 'elimination', agent: 'Nox' },
+      { day: 3, event_type: 'elimination', agent: 'Rei' },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[2].has('Toma')).toBe(true);
+    expect(result[2].has('Nox')).toBe(true);
+    expect(result[2].has('Rei')).toBe(false);
+  });
+
+  it('final day set matches total dead (AC3)', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: 最終日の Set が全死亡者を含むことを検証する（AC3）。
+     */
+    const events = [
+      { day: 1, event_type: 'elimination', agent: 'Toma' },
+      { day: 2, event_type: 'elimination', agent: 'Nox' },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[2]).toEqual(new Set(['Toma', 'Nox']));
+  });
+
+  it('handles days with no elimination by copying previous day dead set', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: elimination がない日（speech のみ）も前日の累積を引き継ぐことを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'speech', agent: 'Mira' },
+      { day: 1, event_type: 'elimination', agent: 'Toma' },
+      { day: 2, event_type: 'speech', agent: 'Mira' },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[2].has('Toma')).toBe(true);
   });
 });
 

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -5,7 +5,7 @@ import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
-import { parseGameData, aggregateCoStatus, aggregateDayActions } from '../lib/parseGameData.js';
+import { parseGameData, aggregateCoStatus, aggregateDayActions, computeDeadByDay } from '../lib/parseGameData.js';
 import { filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
 
@@ -286,10 +286,11 @@ const NIGHT_ACTION_LABEL = { inspection: '占い', guard: '護衛', night_attack
 
 // TODO(#314): public モードでは真の役職タグを非表示にし、CO役職のみ表示する
 // === 右ペイン ===
-export function RightPane({ agents, roleAssignment, coStatus = {}, dayActions = {}, activeDay, viewerMode = 'spectator' }) {
+export function RightPane({ agents, roleAssignment, coStatus = {}, dayActions = {}, activeDay, deadByDay = {}, viewerMode = 'spectator' }) {
   const order = Object.keys(agents);
-  const deadNames = order.filter(n => agents[n]?.is_alive === false);
-  const alive = order.filter(n => !deadNames.includes(n));
+  const activeDead = deadByDay[activeDay] ?? new Set();
+  const deadNames = order.filter(n => activeDead.has(n));
+  const alive = order.filter(n => !activeDead.has(n));
 
   const dayData = dayActions[activeDay];
   const nightActions = dayData?.nightActions ?? [];
@@ -415,6 +416,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   const [replayDaySummary, setReplayDaySummary] = useState(null);
   const [replayCoStatus, setReplayCoStatus] = useState({});
   const [replayDayActions, setReplayDayActions] = useState({});
+  const [replayDeadByDay, setReplayDeadByDay] = useState({});
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
   const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
   const [loadError, setLoadError] = useState(null);
@@ -430,6 +432,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     setReplayDaySummary(null);
     setReplayCoStatus({});
     setReplayDayActions({});
+    setReplayDeadByDay({});
     setLoadingEvents(true);
     setLoadingAgents(true);
     setLoadError(null);
@@ -454,6 +457,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         setReplayDaySummary(parsed.daySummary);
         setReplayCoStatus(aggregateCoStatus(parsed.events));
         setReplayDayActions(aggregateDayActions(parsed.events));
+        setReplayDeadByDay(computeDeadByDay(parsed.events));
         const firstDay = parsed.events.find(event => event.day)?.day;
         if (firstDay) { setActiveDay(firstDay); setActivePhase('discuss'); }
       })
@@ -501,7 +505,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         collapsibleLeft
         collapsibleRight
         left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} dayActions={replayDayActions} />}
-        right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} dayActions={replayDayActions} activeDay={activeDay} viewerMode={viewerMode} />}
+        right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} dayActions={replayDayActions} activeDay={activeDay} deadByDay={replayDeadByDay} viewerMode={viewerMode} />}
       >
         <div className={styles.feedHead}>
           <h2>Day {activeDay} {{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]} <small>{sessionId ? sessionId : '3:47 経過 / 残り 4:13'}</small></h2>

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -367,6 +367,9 @@ const baseAgents = {
   Carol: { role: 'Knight',   is_alive: true,  claimed_role: null },
 };
 
+// Bob is dead at day 1
+const baseDeadByDay = { 1: new Set(['Bob']) };
+
 function renderRightPane(overrides = {}) {
   const props = {
     agents: baseAgents,
@@ -374,6 +377,7 @@ function renderRightPane(overrides = {}) {
     coStatus: {},
     dayActions: {},
     activeDay: 1,
+    deadByDay: baseDeadByDay,
     viewerMode: 'spectator',
     ...overrides,
   };


### PR DESCRIPTION
## Summary
- Add `computeDeadByDay(events)` to `parseGameData.js` — builds cumulative dead-Set per day from `elimination` events
- `RightPane` now accepts `deadByDay` prop; dead/alive split uses `deadByDay[activeDay]` instead of agent JSON's final `is_alive`
- `SpectatorScreen` computes and passes `replayDeadByDay` state to `RightPane`
- Remove suspicion meter references from `FrontendDesign.md` (feature dropped)

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `computeDeadByDay` 5テスト追加（TDD: RED → GREEN 確認済み）
- [ ] 既存 RightPane テストを `deadByDay` prop 対応に更新
- [ ] Playwright でDay 1/2/最終日の生死表示が正しく切り替わることを確認済み

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)