### PR TITLE
fix(frontend): include night_attack victims in computeDeadByDay

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,7 +21,6 @@
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |
-| yukkie/AgentVillage#386 | bug | 🟡 | 2 | include night_attack victims in computeDeadByDay | 夜の襲撃死が右ペインの死亡者リストに反映されていない。#383（バックエンド）完了後に private night_attack.target + guard_block で判定 |
 | yukkie/AgentVillage#344 | tech-debt | 🟡 | 3 | Design: LogEvent cannot express mixed public/private fields in a single speech event | speech イベントの公開/非公開混在問題の設計を定め Architecture.md に記載、[THINK] ハックを廃止する設計Issueを作る |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -275,20 +275,36 @@ export function computeDeadByDay(events) {
   const dayNumbers = [...new Set(events.map(ev => ev.day).filter(Boolean))].sort((a, b) => a - b);
   if (dayNumbers.length === 0) return {};
 
-  const eliminationsByDay = {};
+  const deathsByDay = {};
+  const guardBlocksByDay = {};
   for (const ev of events) {
-    if (ev.event_type === 'elimination' && ev.agent && ev.day) {
-      if (!eliminationsByDay[ev.day]) eliminationsByDay[ev.day] = [];
-      eliminationsByDay[ev.day].push(ev.agent);
+    if (!ev.day) continue;
+    if (ev.event_type === 'elimination' && ev.agent) {
+      if (!deathsByDay[ev.day]) deathsByDay[ev.day] = [];
+      deathsByDay[ev.day].push(ev.agent);
+    } else if (ev.event_type === 'night_attack' && !ev.is_public && ev.target) {
+      if (!deathsByDay[ev.day]) deathsByDay[ev.day] = [];
+      deathsByDay[ev.day].push({ nightAttackTarget: ev.target });
+    } else if (ev.event_type === 'guard_block' && !ev.is_public && ev.target) {
+      if (!guardBlocksByDay[ev.day]) guardBlocksByDay[ev.day] = new Set();
+      guardBlocksByDay[ev.day].add(ev.target);
     }
   }
 
   const result = {};
   let cumulative = new Set();
   for (const day of dayNumbers) {
-    if (eliminationsByDay[day]) {
+    const blocked = guardBlocksByDay[day] ?? new Set();
+    const entries = deathsByDay[day] ?? [];
+    if (entries.length > 0) {
       cumulative = new Set(cumulative);
-      for (const name of eliminationsByDay[day]) cumulative.add(name);
+      for (const entry of entries) {
+        if (typeof entry === 'string') {
+          cumulative.add(entry);
+        } else if (!blocked.has(entry.nightAttackTarget)) {
+          cumulative.add(entry.nightAttackTarget);
+        }
+      }
     }
     result[day] = cumulative;
   }

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -516,6 +516,65 @@ describe('computeDeadByDay', () => {
     const result = computeDeadByDay(events);
     expect(result[2].has('Toma')).toBe(true);
   });
+
+  it('includes night_attack victim in dead set (AC1)', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: private night_attack の target が死亡者 Set に含まれることを検証する（AC1）。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', target: 'Rei', is_public: false },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[1].has('Rei')).toBe(true);
+  });
+
+  it('does not include night_attack victim when guard_block exists for same target (AC2)', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: 同日同 target の private guard_block がある場合、night_attack の target が死亡者 Set に含まれないことを検証する（AC2）。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', target: 'Toma', is_public: false },
+      { day: 1, event_type: 'guard_block',  target: 'Toma', is_public: false },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[1].has('Toma')).toBe(false);
+  });
+
+  it('night_attack victim appears in later days if killed on earlier day', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: 夜襲犠牲者は翌日以降の累積 Set にも引き継がれることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', target: 'Rei', is_public: false },
+      { day: 2, event_type: 'speech', agent: 'Mira' },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[2].has('Rei')).toBe(true);
+  });
+
+  it('guard_block on different day does not protect night_attack victim', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: guard_block が別の日のものであれば、night_attack の target は死亡者 Set に含まれることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', target: 'Rei', is_public: false },
+      { day: 2, event_type: 'guard_block',  target: 'Rei', is_public: false },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[1].has('Rei')).toBe(true);
+  });
 });
 
 describe('aggregateDayActions', () => {


### PR DESCRIPTION
## Summary
- `computeDeadByDay()` が `elimination`（昼処刑）しか追跡していなかった問題を修正
- private `night_attack.target` を死亡者に追加し、同日同 target の private `guard_block` がある場合は除外する
- 既存の elimination テスト 5 件はすべてパス

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス
- [x] `computeDeadByDay` — night_attack victim が dead set に含まれる（AC1）
- [x] `computeDeadByDay` — guard_block がある場合は dead set に含まれない（AC2）
- [x] `computeDeadByDay` — 翌日以降の累積 set にも引き継がれる
- [x] `computeDeadByDay` — 別の日の guard_block は保護にならない
- [x] Playwright でブラウザ動作確認済み（Day 2 議論フェーズで夜襲犠牲者が右ペインに死亡表示）

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)