### PR TITLE
docs: add issues #390 and #391 to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,6 +21,8 @@
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |
+| yukkie/AgentVillage#390 | bug | 🟡 | 1 | fix(frontend): compute CO status up to selected day instead of final day | 他コンポーネントと同様、選択日時点のCO状況を表示する |
+| yukkie/AgentVillage#391 | enhancement | 🟡 | 2 | feat(frontend): show death reason (day + content) in right pane roster | computeDeadByDay の戻り値に day+content を付加し、右ペイン死亡行に死因と日付を表示 |
 | yukkie/AgentVillage#344 | tech-debt | 🟡 | 3 | Design: LogEvent cannot express mixed public/private fields in a single speech event | speech イベントの公開/非公開混在問題の設計を定め Architecture.md に記載、[THINK] ハックを廃止する設計Issueを作る |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |


### PR DESCRIPTION
## Summary
- #390: fix(frontend): compute CO status up to selected day instead of final day
- #391: feat(frontend): show death reason (day + content) in right pane roster

🤖 Generated with [Claude Code](https://claude.com/claude-code)