### PR TITLE
feat(frontend): show death reason (day + content) in right pane roster

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -22,7 +22,6 @@
 | yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |
 | yukkie/AgentVillage#390 | bug | 🟡 | 1 | fix(frontend): compute CO status up to selected day instead of final day | 他コンポーネントと同様、選択日時点のCO状況を表示する |
-| yukkie/AgentVillage#391 | enhancement | 🟡 | 2 | feat(frontend): show death reason (day + content) in right pane roster | computeDeadByDay の戻り値に day+content を付加し、右ペイン死亡行に死因と日付を表示 |
 | yukkie/AgentVillage#344 | tech-debt | 🟡 | 3 | Design: LogEvent cannot express mixed public/private fields in a single speech event | speech イベントの公開/非公開混在問題の設計を定め Architecture.md に記載、[THINK] ハックを廃止する設計Issueを作る |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -262,14 +262,14 @@ export function aggregateDayActions(events) {
 }
 
 /**
- * Build a cumulative dead-set per day from elimination events.
+ * Build a cumulative dead-map per day from elimination and night_attack events.
  *
- * Returns a map from day number → Set of agent names dead *at the end of that day*.
- * Days with no elimination inherit the previous day's set so callers can simply
- * do `deadByDay[activeDay]?.has(name)` without caring about history.
+ * Returns a map from day number → Map<agentName, { day: number, content: string }>.
+ * Days with no new deaths inherit the previous day's map so callers can simply
+ * do `deadByDay[activeDay]?.has(name)` or `.get(name)` without caring about history.
  *
  * @param {object[]} events
- * @returns {Record<number, Set<string>>}
+ * @returns {Record<number, Map<string, { day: number, content: string }>>}
  */
 export function computeDeadByDay(events) {
   const dayNumbers = [...new Set(events.map(ev => ev.day).filter(Boolean))].sort((a, b) => a - b);
@@ -281,10 +281,10 @@ export function computeDeadByDay(events) {
     if (!ev.day) continue;
     if (ev.event_type === 'elimination' && ev.agent) {
       if (!deathsByDay[ev.day]) deathsByDay[ev.day] = [];
-      deathsByDay[ev.day].push(ev.agent);
+      deathsByDay[ev.day].push({ name: ev.agent, day: ev.day, content: ev.content ?? '' });
     } else if (ev.event_type === 'night_attack' && !ev.is_public && ev.target) {
       if (!deathsByDay[ev.day]) deathsByDay[ev.day] = [];
-      deathsByDay[ev.day].push({ nightAttackTarget: ev.target });
+      deathsByDay[ev.day].push({ name: ev.target, day: ev.day, content: ev.content ?? '', isNightAttack: true });
     } else if (ev.event_type === 'guard_block' && !ev.is_public && ev.target) {
       if (!guardBlocksByDay[ev.day]) guardBlocksByDay[ev.day] = new Set();
       guardBlocksByDay[ev.day].add(ev.target);
@@ -292,17 +292,19 @@ export function computeDeadByDay(events) {
   }
 
   const result = {};
-  let cumulative = new Set();
+  let cumulative = new Map();
   for (const day of dayNumbers) {
     const blocked = guardBlocksByDay[day] ?? new Set();
     const entries = deathsByDay[day] ?? [];
     if (entries.length > 0) {
-      cumulative = new Set(cumulative);
+      cumulative = new Map(cumulative);
       for (const entry of entries) {
-        if (typeof entry === 'string') {
-          cumulative.add(entry);
-        } else if (!blocked.has(entry.nightAttackTarget)) {
-          cumulative.add(entry.nightAttackTarget);
+        if (entry.isNightAttack) {
+          if (!blocked.has(entry.name)) {
+            cumulative.set(entry.name, { day: entry.day, content: entry.content });
+          }
+        } else {
+          cumulative.set(entry.name, { day: entry.day, content: entry.content });
         }
       }
     }

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -438,21 +438,21 @@ describe('aggregateCoStatus', () => {
 });
 
 describe('computeDeadByDay', () => {
-  it('returns empty Sets for all days when there are no eliminations', () => {
+  it('returns empty Maps for all days when there are no eliminations', () => {
     /*
      * SUT: computeDeadByDay
      * Mock: なし
      * Level: unit
-     * Objective: elimination イベントがない場合、全日で空の Set が返ることを検証する。
+     * Objective: elimination イベントがない場合、全日で空の Map が返ることを検証する。
      */
     const events = [
       { day: 1, event_type: 'speech', agent: 'Mira' },
     ];
     const result = computeDeadByDay(events);
-    expect(result[1]).toEqual(new Set());
+    expect(result[1]).toEqual(new Map());
   });
 
-  it('includes only Day 1 victim in Day 1 dead set', () => {
+  it('includes only Day 1 victim in Day 1 dead map', () => {
     /*
      * SUT: computeDeadByDay
      * Mock: なし
@@ -473,7 +473,7 @@ describe('computeDeadByDay', () => {
      * SUT: computeDeadByDay
      * Mock: なし
      * Level: unit
-     * Objective: Day 2 以降を選択したとき、それ以前の累積死亡者が Set に含まれることを検証する（AC2）。
+     * Objective: Day 2 以降を選択したとき、それ以前の累積死亡者が Map に含まれることを検証する（AC2）。
      */
     const events = [
       { day: 1, event_type: 'elimination', agent: 'Toma' },
@@ -486,22 +486,24 @@ describe('computeDeadByDay', () => {
     expect(result[2].has('Rei')).toBe(false);
   });
 
-  it('final day set matches total dead (AC3)', () => {
+  it('final day map contains all dead agents (AC3)', () => {
     /*
      * SUT: computeDeadByDay
      * Mock: なし
      * Level: unit
-     * Objective: 最終日の Set が全死亡者を含むことを検証する（AC3）。
+     * Objective: 最終日の Map が全死亡者を含むことを検証する（AC3）。
      */
     const events = [
       { day: 1, event_type: 'elimination', agent: 'Toma' },
       { day: 2, event_type: 'elimination', agent: 'Nox' },
     ];
     const result = computeDeadByDay(events);
-    expect(result[2]).toEqual(new Set(['Toma', 'Nox']));
+    expect(result[2].has('Toma')).toBe(true);
+    expect(result[2].has('Nox')).toBe(true);
+    expect(result[2].size).toBe(2);
   });
 
-  it('handles days with no elimination by copying previous day dead set', () => {
+  it('handles days with no elimination by copying previous day dead map', () => {
     /*
      * SUT: computeDeadByDay
      * Mock: なし
@@ -517,12 +519,12 @@ describe('computeDeadByDay', () => {
     expect(result[2].has('Toma')).toBe(true);
   });
 
-  it('includes night_attack victim in dead set (AC1)', () => {
+  it('includes night_attack victim in dead map (AC1)', () => {
     /*
      * SUT: computeDeadByDay
      * Mock: なし
      * Level: unit
-     * Objective: private night_attack の target が死亡者 Set に含まれることを検証する（AC1）。
+     * Objective: private night_attack の target が死亡者 Map に含まれることを検証する（AC1）。
      */
     const events = [
       { day: 1, event_type: 'night_attack', target: 'Rei', is_public: false },
@@ -536,7 +538,7 @@ describe('computeDeadByDay', () => {
      * SUT: computeDeadByDay
      * Mock: なし
      * Level: unit
-     * Objective: 同日同 target の private guard_block がある場合、night_attack の target が死亡者 Set に含まれないことを検証する（AC2）。
+     * Objective: 同日同 target の private guard_block がある場合、night_attack の target が死亡者 Map に含まれないことを検証する（AC2）。
      */
     const events = [
       { day: 1, event_type: 'night_attack', target: 'Toma', is_public: false },
@@ -551,7 +553,7 @@ describe('computeDeadByDay', () => {
      * SUT: computeDeadByDay
      * Mock: なし
      * Level: unit
-     * Objective: 夜襲犠牲者は翌日以降の累積 Set にも引き継がれることを検証する。
+     * Objective: 夜襲犠牲者は翌日以降の累積 Map にも引き継がれることを検証する。
      */
     const events = [
       { day: 1, event_type: 'night_attack', target: 'Rei', is_public: false },
@@ -566,7 +568,7 @@ describe('computeDeadByDay', () => {
      * SUT: computeDeadByDay
      * Mock: なし
      * Level: unit
-     * Objective: guard_block が別の日のものであれば、night_attack の target は死亡者 Set に含まれることを検証する。
+     * Objective: guard_block が別の日のものであれば、night_attack の target は死亡者 Map に含まれることを検証する。
      */
     const events = [
       { day: 1, event_type: 'night_attack', target: 'Rei', is_public: false },
@@ -574,6 +576,49 @@ describe('computeDeadByDay', () => {
     ];
     const result = computeDeadByDay(events);
     expect(result[1].has('Rei')).toBe(true);
+  });
+
+  it('stores day and content metadata for elimination victim (contract)', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: elimination 死亡者のメタデータ（day, content）が Map の value として取得できることを検証する（#391 contract）。
+     */
+    const events = [
+      { day: 2, event_type: 'elimination', agent: 'Toma', content: 'Toma was executed.', is_public: true },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[2].get('Toma')).toEqual({ day: 2, content: 'Toma was executed.' });
+  });
+
+  it('stores day and content metadata for night_attack victim (contract)', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: night_attack 死亡者のメタデータ（day, content）が Map の value として取得できることを検証する（#391 contract）。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', target: 'Rei', content: 'Werewolves attacked Rei.', is_public: false },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[1].get('Rei')).toEqual({ day: 1, content: 'Werewolves attacked Rei.' });
+  });
+
+  it('metadata is preserved when victim carries over to later days', () => {
+    /*
+     * SUT: computeDeadByDay
+     * Mock: なし
+     * Level: unit
+     * Objective: 死亡者のメタデータが翌日以降の Map にも引き継がれることを検証する（#391 contract）。
+     */
+    const events = [
+      { day: 1, event_type: 'elimination', agent: 'Toma', content: 'Toma was executed.', is_public: true },
+      { day: 2, event_type: 'speech', agent: 'Mira' },
+    ];
+    const result = computeDeadByDay(events);
+    expect(result[2].get('Toma')).toEqual({ day: 1, content: 'Toma was executed.' });
   });
 });
 

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -337,11 +337,13 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, dayActions = 
           return (
             <div key={n} className={`${styles.rosterRow} ${styles.dead}`} style={{ '--r-color': r?.color }}>
               <Avatar name={n} role={role} size="sm" dead />
-              <div className={styles.who}>
-                <span className={styles.rosterName}>{n}</span>
-                <span className={styles.sub}>
-                  <RoleTag role={role} />
-                </span>
+              <div className={styles.whoMeta}>
+                <div className={styles.whoBlock}>
+                  <span className={styles.rosterName}>{n}</span>
+                  <span className={styles.sub}>
+                    <RoleTag role={role} />
+                  </span>
+                </div>
                 {meta && (
                   <span className={styles.deathReason}>Day {meta.day} · {meta.content}</span>
                 )}

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -288,8 +288,9 @@ const NIGHT_ACTION_LABEL = { inspection: '占い', guard: '護衛', night_attack
 // === 右ペイン ===
 export function RightPane({ agents, roleAssignment, coStatus = {}, dayActions = {}, activeDay, deadByDay = {}, viewerMode = 'spectator' }) {
   const order = Object.keys(agents);
-  const activeDead = deadByDay[activeDay] ?? new Set();
-  const deadNames = order.filter(n => activeDead.has(n));
+  const activeDead = deadByDay[activeDay] ?? new Map();
+  const deadNames = order.filter(n => activeDead.has(n))
+    .sort((a, b) => (activeDead.get(a)?.day ?? 0) - (activeDead.get(b)?.day ?? 0));
   const alive = order.filter(n => !activeDead.has(n));
 
   const dayData = dayActions[activeDay];
@@ -332,6 +333,7 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, dayActions = 
         {deadNames.map(n => {
           const role = roleAssignment[n];
           const r = ROLES[role];
+          const meta = activeDead.get(n);
           return (
             <div key={n} className={`${styles.rosterRow} ${styles.dead}`} style={{ '--r-color': r?.color }}>
               <Avatar name={n} role={role} size="sm" dead />
@@ -340,6 +342,9 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, dayActions = 
                 <span className={styles.sub}>
                   <RoleTag role={role} />
                 </span>
+                {meta && (
+                  <span className={styles.deathReason}>Day {meta.day} · {meta.content}</span>
+                )}
               </div>
             </div>
           );

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -342,7 +342,7 @@
 
 .rosterRow {
   display: grid;
-  grid-template-columns: 32px 1fr auto;
+  grid-template-columns: 32px 1fr;
   gap: 10px;
   align-items: center;
   padding: 7px 8px;
@@ -460,7 +460,9 @@
 .who       { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .rosterName { font-family: var(--serif); font-size: 13px; font-weight: 600; color: var(--tx); display: flex; align-items: center; gap: 4px; }
 .sub       { font-size: 10px; color: var(--tx-3); display: flex; gap: 6px; }
-.deathReason { font-size: 10px; color: var(--tx); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.whoMeta { display: flex; flex-direction: row; align-items: baseline; gap: 8px; min-width: 0; }
+.whoBlock { display: flex; flex-direction: column; gap: 1px; flex-shrink: 0; }
+.deathReason { font-size: 12px; color: var(--tx); word-break: break-word; flex: 1; min-width: 0; }
 .meter     { width: 64px; height: 22px; display: flex; flex-direction: column; gap: 2px; }
 .bar       { height: 4px; border-radius: 2px; background: var(--bg-3); overflow: hidden; }
 .bar i     { display: block; height: 100%; background: var(--danger); }

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -460,6 +460,7 @@
 .who       { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .rosterName { font-family: var(--serif); font-size: 13px; font-weight: 600; color: var(--tx); display: flex; align-items: center; gap: 4px; }
 .sub       { font-size: 10px; color: var(--tx-3); display: flex; gap: 6px; }
+.deathReason { font-size: 10px; color: var(--tx); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .meter     { width: 64px; height: 22px; display: flex; flex-direction: column; gap: 2px; }
 .bar       { height: 4px; border-radius: 2px; background: var(--bg-3); overflow: hidden; }
 .bar i     { display: block; height: 100%; background: var(--danger); }

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -387,7 +387,7 @@ const baseAgents = {
 };
 
 // Bob is dead at day 1
-const baseDeadByDay = { 1: new Set(['Bob']) };
+const baseDeadByDay = { 1: new Map([['Bob', { day: 1, content: 'Bob was executed.' }]]) };
 
 function renderRightPane(overrides = {}) {
   const props = {
@@ -402,6 +402,50 @@ function renderRightPane(overrides = {}) {
   };
   return render(<RightPane {...props} />);
 }
+
+describe('RightPane: death reason display (#391)', () => {
+  it('shows day and content for dead agent in roster', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: 死亡者行に死亡日（Day N）と死因テキスト（content）が表示されることを検証する（AC1 / #391）。
+     */
+    renderRightPane({
+      deadByDay: { 1: new Map([['Bob', { day: 1, content: 'Bob was executed.' }]]) },
+      activeDay: 1,
+    });
+    expect(screen.getByText(/Day 1 · Bob was executed\./)).toBeTruthy();
+  });
+
+  it('shows night_attack content for dead agent', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: 夜襲死亡者行に night_attack の content テキストが表示されることを検証する（AC2 / #391）。
+     */
+    renderRightPane({
+      deadByDay: { 1: new Map([['Bob', { day: 1, content: 'Werewolves attacked Bob.' }]]) },
+      activeDay: 1,
+    });
+    expect(screen.getByText(/Werewolves attacked Bob\./)).toBeTruthy();
+  });
+
+  it('shows no deathReason when deadByDay entry has no metadata', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: メタデータなし（Map.get が undefined）の死亡者行には死亡理由が表示されないことを検証する。
+     */
+    const { container } = renderRightPane({
+      deadByDay: { 1: new Map([['Bob', undefined]]) },
+      activeDay: 1,
+    });
+    expect(container.querySelector('[class*="deathReason"]')).toBeNull();
+  });
+});
 
 describe('RightPane: suspicion meter removed', () => {
   it('does not render a suspicion meter', () => {


### PR DESCRIPTION
## Summary
- `computeDeadByDay` の戻り値を `Set<string>` から `Map<string, { day, content }>` に変更し、死因メタデータを保持するようにした
- `RightPane` の死亡者行に死亡日（Day N）と死因テキスト（`elimination.content` または private `night_attack.content`）を表示
- 死亡者を day 昇順でソート
- `deathReason` テキストの文字色を `--tx`（最明輝度）に設定

## Test plan
- [x] `computeDeadByDay` の contract テスト（elimination / night_attack のメタデータ、累積引き継ぎ）を追加
- [x] `RightPane` の死亡者表示テストを追加（day+content 表示、night_attack content、メタデータなし時）
- [x] `npm test` パス
- [x] `npm run test:coverage` パス
- [x] Playwright でブラウザ動作確認済み（処刑・夜襲の両方で正しく表示）

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)