### PR TITLE
fix(frontend): compute CO status up to selected day instead of final day

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,7 +21,6 @@
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |
-| yukkie/AgentVillage#390 | bug | 🟡 | 1 | fix(frontend): compute CO status up to selected day instead of final day | 他コンポーネントと同様、選択日時点のCO状況を表示する |
 | yukkie/AgentVillage#344 | tech-debt | 🟡 | 3 | Design: LogEvent cannot express mixed public/private fields in a single speech event | speech イベントの公開/非公開混在問題の設計を定め Architecture.md に記載、[THINK] ハックを廃止する設計Issueを作る |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -211,9 +211,10 @@ export function aggregateDayResults(events) {
  * @param {object[]} events
  * @returns {Record<string, string>} agent name → claimed_role
  */
-export function aggregateCoStatus(events) {
+export function aggregateCoStatus(events, upToDay) {
   const result = {};
   for (const ev of events) {
+    if (upToDay !== undefined && ev.day > upToDay) continue;
     if (ev.event_type === 'co_announcement' && ev.agent && ev.claimed_role) {
       result[ev.agent] = ev.claimed_role;
     }

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -435,6 +435,50 @@ describe('aggregateCoStatus', () => {
     ];
     expect(aggregateCoStatus(events)).toEqual({ Ren: 'Villager' });
   });
+
+  it('filters out co_announcement events after upToDay', () => {
+    /*
+     * SUT: aggregateCoStatus
+     * Mock: なし
+     * Level: unit
+     * Objective: upToDay を指定した場合、その日以降の CO イベントが除外されることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'co_announcement', agent: 'Jonas', claimed_role: 'Seer',   is_public: true },
+      { day: 2, event_type: 'co_announcement', agent: 'SQ',    claimed_role: 'Medium', is_public: true },
+      { day: 3, event_type: 'co_announcement', agent: 'Ren',   claimed_role: 'Hunter', is_public: true },
+    ];
+    expect(aggregateCoStatus(events, 2)).toEqual({ Jonas: 'Seer', SQ: 'Medium' });
+  });
+
+  it('returns only CO up to upToDay=1 when later days exist', () => {
+    /*
+     * SUT: aggregateCoStatus
+     * Mock: なし
+     * Level: unit
+     * Objective: Day 1 のみ選択時に Day 1 の CO だけが返されることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'co_announcement', agent: 'Jonas', claimed_role: 'Seer',   is_public: true },
+      { day: 2, event_type: 'co_announcement', agent: 'SQ',    claimed_role: 'Medium', is_public: true },
+    ];
+    expect(aggregateCoStatus(events, 1)).toEqual({ Jonas: 'Seer' });
+  });
+
+  it('accumulates CO correctly when upToDay matches later days', () => {
+    /*
+     * SUT: aggregateCoStatus
+     * Mock: なし
+     * Level: unit
+     * Objective: upToDay を後の日に設定すると、その日までの CO が累積されることを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'co_announcement', agent: 'Jonas', claimed_role: 'Seer',   is_public: true },
+      { day: 2, event_type: 'co_announcement', agent: 'SQ',    claimed_role: 'Medium', is_public: true },
+      { day: 3, event_type: 'co_announcement', agent: 'Ren',   claimed_role: 'Hunter', is_public: true },
+    ];
+    expect(aggregateCoStatus(events, 3)).toEqual({ Jonas: 'Seer', SQ: 'Medium', Ren: 'Hunter' });
+  });
 });
 
 describe('computeDeadByDay', () => {

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -421,7 +421,6 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   const [replayEvents, setReplayEvents] = useState(null);
   const [replayAgents, setReplayAgents] = useState({});
   const [replayDaySummary, setReplayDaySummary] = useState(null);
-  const [replayCoStatus, setReplayCoStatus] = useState({});
   const [replayDayActions, setReplayDayActions] = useState({});
   const [replayDeadByDay, setReplayDeadByDay] = useState({});
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
@@ -437,7 +436,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     setReplayEvents(null);
     setReplayAgents({});
     setReplayDaySummary(null);
-    setReplayCoStatus({});
+
     setReplayDayActions({});
     setReplayDeadByDay({});
     setLoadingEvents(true);
@@ -462,7 +461,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         const parsed = parseGameData(jsonlText);
         setReplayEvents(parsed.events);
         setReplayDaySummary(parsed.daySummary);
-        setReplayCoStatus(aggregateCoStatus(parsed.events));
+
         setReplayDayActions(aggregateDayActions(parsed.events));
         setReplayDeadByDay(computeDeadByDay(parsed.events));
         const firstDay = parsed.events.find(event => event.day)?.day;
@@ -486,6 +485,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   const roleAssignment = useMemo(() => Object.fromEntries(
     Object.entries(agents).map(([name, agent]) => [name, agent.role])
   ), [agents]);
+  const replayCoStatus = useMemo(() => aggregateCoStatus(events, activeDay), [events, activeDay]);
   const agentNames = Object.keys(agents);
   const visibleDays = [...new Set(events.map(event => event.day).filter(Boolean))].sort((a, b) => a - b);
 


### PR DESCRIPTION
## Summary
- `aggregateCoStatus` に `upToDay` 引数を追加し、選択日以降の CO イベントを除外するように修正
- `SpectatorScreen` の `replayCoStatus` を `useState`（ロード時固定）から `useMemo([events, activeDay])` に変更し、日付選択のたびに正しい CO 状況を導出するように修正

## Test plan
- [ ] `aggregateCoStatus` の新規テスト 3 件（upToDay フィルタ）GREEN 確認済み
- [ ] 既存テスト 124 件すべて GREEN 確認済み
- [ ] Playwright でブラウザ動作確認済み: Day 1 選択 → 未CO表示、Day 2 選択 → CO名表示、Day 1 に戻す → 未CO表示

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)