### PR TITLE
refactor: reduce SpectatorScreen system event duplication

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -28,7 +28,6 @@
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | — | — | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
-| yukkie/AgentVillage#371 | tech-debt | — | — | reduce duplication in SpectatorScreen system event rendering | system event 表示の重複 JSX を設定テーブル化し、content そのまま表示と左右アバター配置を維持する |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -98,6 +98,65 @@ function logContent(ev) {
   return ev.content || MISSING_CONTENT;
 }
 
+const SYSTEM_EVENT_VIEWS = {
+  vote: {
+    kind: 'exec',
+    label: '投票',
+    leftName: ev => ev.agent,
+    rightName: ev => ev.target,
+    reasoning: ev => ev.reasoning,
+  },
+  elimination: {
+    kind: 'death',
+    icon: '💀',
+    label: '処刑',
+    rightName: ev => ev.agent,
+  },
+  medium_result: {
+    kind: 'gm',
+    icon: '👁',
+    label: '霊媒結果',
+    leftName: ev => ev.agent,
+    rightName: ev => ev.target,
+    reasoning: ev => ev.reasoning,
+  },
+  inspection: {
+    kind: 'gm',
+    icon: '🔮',
+    label: '占い結果',
+    leftName: ev => ev.agent,
+    rightName: ev => ev.target,
+    reasoning: ev => ev.reasoning,
+  },
+  guard: {
+    kind: 'gm',
+    icon: '🛡',
+    label: '護衛',
+    leftName: ev => ev.agent,
+    rightName: ev => ev.target,
+    reasoning: ev => ev.reasoning,
+  },
+};
+
+function renderConfiguredSystemEvent(ev, roleAssignment) {
+  const view = SYSTEM_EVENT_VIEWS[ev.event_type];
+  if (!view) return null;
+
+  return (
+    <SystemRow
+      kind={view.kind}
+      icon={view.icon}
+      label={view.label}
+      reasoning={view.reasoning?.(ev)}
+      leftName={view.leftName?.(ev)}
+      rightName={view.rightName?.(ev)}
+      roleAssignment={roleAssignment}
+    >
+      {logContent(ev)}
+    </SystemRow>
+  );
+}
+
 // --- システム行 ---
 function SystemRow({ kind, icon, label, children, reasoning, ts, leftName, rightName, roleAssignment = {} }) {
   const defaultIcon = { gm: '👁', death: '💀', exec: '⚑', phase: '☾' }[kind] || '⌘';
@@ -147,41 +206,9 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
   if (ev.event_type === 'speech') return <SpeechCard ev={ev} prevById={prevById} roleAssignment={roleAssignment} />;
   if (ev.event_type === 'wolf_chat') return <WolfChatCard ev={ev} />;
 
-  if (ev.event_type === 'vote') {
-    return (
-      <SystemRow kind="exec" label="投票" reasoning={ev.reasoning} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
-        {logContent(ev)}
-      </SystemRow>
-    );
-  }
-  if (ev.event_type === 'elimination') {
-    return (
-      <SystemRow kind="death" icon="💀" label="処刑" rightName={ev.agent} roleAssignment={roleAssignment}>
-        {logContent(ev)}
-      </SystemRow>
-    );
-  }
-  if (ev.event_type === 'medium_result') {
-    return (
-      <SystemRow kind="gm" icon="👁" label="霊媒結果" reasoning={ev.reasoning} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
-        {logContent(ev)}
-      </SystemRow>
-    );
-  }
-  if (ev.event_type === 'inspection') {
-    return (
-      <SystemRow kind="gm" icon="🔮" label="占い結果" reasoning={ev.reasoning} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
-        {logContent(ev)}
-      </SystemRow>
-    );
-  }
-  if (ev.event_type === 'guard') {
-    return (
-      <SystemRow kind="gm" icon="🛡" label="護衛" reasoning={ev.reasoning} leftName={ev.agent} rightName={ev.target} roleAssignment={roleAssignment}>
-        {logContent(ev)}
-      </SystemRow>
-    );
-  }
+  const configuredSystemEvent = renderConfiguredSystemEvent(ev, roleAssignment);
+  if (configuredSystemEvent) return configuredSystemEvent;
+
   if (ev.event_type === 'guard_block') {
     return ev.is_public
       ? <SystemRow kind="gm" icon="🛡" label="護衛">{logContent(ev)}</SystemRow>


### PR DESCRIPTION
## Summary
- Add a compact system event view configuration for simple SpectatorScreen feed events.
- Keep guard_block and night_attack as explicit branches for their public/private handling.
- Remove completed issue #371 from Ideas.md.

## Test plan
- [x] `.\node_modules\.bin\vitest.cmd run SpectatorScreen.test.jsx`
- [x] `.\node_modules\.bin\vitest.cmd run SpectatorScreen.test.jsx --coverage`
- [x] `.\node_modules\.bin\vitest.cmd run`
- [x] `uv run ruff check .`
- [x] `uv run pytest`

Closes #371

🤖 Generated with [Codex](https://Codex.com/Codex)