### PR TITLE
refactor: remove stub alias badge from speech header (#398)

### DIFF
--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -69,14 +69,13 @@ function SpeechCard({ ev, prevById, roleAssignment }) {
       <div>
         <div className={styles.spHead}>
           <span className={styles.name}>{ev.agent}</span>
-          <span className={styles.alias}>#{ev.agent.charCodeAt(0) % 99}</span>
+          <span className={styles.turn}>{fmtTurn(ev.day, ev.speech_id || 0)}</span>
           <RoleTag role={role} />
           {ev.claimed_role && (
             <span className={styles.coBadge}>
               ▶ {ROLES[ev.claimed_role]?.ja || ev.claimed_role} CO
             </span>
           )}
-          <span className={styles.turn}>{fmtTurn(ev.day, ev.speech_id || 0)}</span>
           <span className={styles.ts}>{fmtTime(ev.day, ev.speech_id || 0)}</span>
         </div>
         {replied && (
@@ -192,7 +191,6 @@ function WolfChatCard({ ev }) {
       <div>
         <div className={styles.spHead}>
           <span className={styles.name}>{ev.agent}</span>
-          <span className={styles.alias}>人狼</span>
         </div>
         <div className={styles.spBody}>{ev.content}</div>
         <ThoughtDetails reasoning={ev.reasoning} />

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -155,7 +155,6 @@
   margin-bottom: 6px;
 }
 .spHead .name   { font-family: var(--serif); font-weight: 600; font-size: 14px; color: var(--tx); }
-.spHead .alias  { color: var(--tx-3); font-size: 11px; }
 .spHead .turn   { font-family: var(--mono); font-size: 10px; color: var(--tx-4); }
 .spHead .ts     { font-size: 10px; color: var(--tx-3); margin-left: auto; font-family: var(--mono); }
 .spHead .coBadge {
@@ -417,7 +416,6 @@
 
 /* spHead child selectors (CSS Modules — using class names) */
 .name   { font-family: var(--serif); font-weight: 600; font-size: 14px; color: var(--tx); }
-.alias  { color: var(--tx-3); font-size: 11px; }
 .turn   { font-family: var(--mono); font-size: 10px; color: var(--tx-4); }
 .ts     { font-size: 10px; color: var(--tx-3); margin-left: auto; font-family: var(--mono); }
 .coBadge {


### PR DESCRIPTION
## Summary
- `span.alias`（`#{charCode % 99}` のスタブ容疑者メーター）を削除
- `span.turn` を `span.name` の直後に移動（`name → turn → RoleTag → coBadge → ts` の順）
- `.alias` CSS ルールを `SpectatorScreen.module.css` から削除

## Test plan
- [x] `frontend test` パス（pre-commit）
- [x] `frontend coverage` パス（pre-commit）
- [x] Playwright でスピーチヘッダーの DOM を確認: `name("Toma") → turn("D1-01") → RoleTag("村人") → ts("10:03")`
- [x] `.alias` 要素が 0件であることを確認

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)