### PR TITLE
fix: pin filter to bottom of left pane, scroll date list (#404)

### DIFF
--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -242,7 +242,7 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
   };
 
   return (
-    <>
+    <div className={styles.leftPaneInner}>
       <div className={styles.phaseNav}>
         <div className={styles.sectionLabel}>タイムライン</div>
         {days.map(d => (
@@ -302,7 +302,7 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
           <button className={styles.chip}>思考ログ</button>
         </div>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -410,9 +410,10 @@
 .action .res.black { color: var(--r-werewolf); background: rgba(226,107,107,0.12); }
 .action .res.white { color: var(--r-seer);     background: rgba(110,168,255,0.12); }
 
-/* phaseNav / filt scroll */
-.phaseNav { padding: 8px 12px 16px; overflow-y: auto; }
-.filt { padding: 4px 14px 16px; overflow-y: auto; flex: 1; }
+/* Left pane inner layout: date list scrolls, filter pinned at bottom */
+.leftPaneInner { display: flex; flex-direction: column; height: 100%; min-height: 0; overflow: hidden; }
+.phaseNav { padding: 8px 12px 16px; overflow-y: auto; flex: 1; min-height: 0; }
+.filt { padding: 4px 14px 16px; overflow-y: auto; flex: 0 0 auto; border-top: 1px solid var(--bd); }
 
 /* spHead child selectors (CSS Modules — using class names) */
 .name   { font-family: var(--serif); font-weight: 600; font-size: 14px; color: var(--tx); }


### PR DESCRIPTION
## Summary
- LeftPane を flex コンテナ(.leftPaneInner)でラップし、日付リストが伸び縮みするようにした
- `.phaseNav`: `flex: 1; overflow-y: auto` → 日付リストがスクロール対象
- `.filt`: `flex: 0 0 auto; border-top` → フィルターが左下に固定

## Test plan
- [x] `vitest run` 124 tests パス
- [x] Playwright で 4日分の日付リストがスクロールし、フィルターが下部固定で見えることを確認

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)