### PR TITLE
feat: show phase list only on hover, keep active day expanded

### DIFF
--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -246,7 +246,7 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
       <div className={styles.phaseNav}>
         <div className={styles.sectionLabel}>タイムライン</div>
         {days.map(d => (
-          <div key={d}>
+          <div key={d} className={`${styles.dayBlock} ${activeDay === d ? styles.dayBlockActive : ''}`}>
             <div className={styles.phaseDay}>
               <h3>第 {d} 日 <small>{d === 1 ? '初日' : d === 2 ? '荒れる' : '進行中'}</small></h3>
               {dayActions[d]?.nightActions?.find(a => a.event_type === 'night_attack') && (

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -46,6 +46,15 @@
 }
 .phaseDay .deathline { font-size: 10px; color: var(--danger); }
 
+.dayBlock .phaseList {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 200ms ease;
+}
+.dayBlock:hover .phaseList,
+.dayBlockActive .phaseList {
+  max-height: 120px;
+}
 .phaseList { display: flex; flex-direction: column; gap: 2px; padding: 0 4px; }
 .phaseItem {
   display: flex; align-items: center; gap: 8px;


### PR DESCRIPTION
## Summary
- 日付ブロックに `.dayBlock` / `.dayBlockActive` クラスを追加
- `.phaseList` をデフォルト `max-height: 0` で折りたたみ、`transition: max-height 200ms ease` でアニメーション付き展開
- ホバー時（`:hover`）またはアクティブ日（`.dayBlockActive`）のみ `max-height: 120px` に展開

## Test plan
- [x] `vitest run` 124 tests パス
- [x] Playwright でデフォルト状態（アクティブ日のみ展開）を確認
- [x] Playwright で第2日ホバー時に3行メニューが展開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)