### PR TITLE
refactor: merge day aggregations

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -105,6 +105,20 @@ const [screen, setScreen] = useState('list');
 
 #312 で「❌ スタブ固定」とされた村名・ルール名・投票内訳・夜行動サマリ・ソーシャル系メトリクスは、#318 では fallback 表示のまま残す。
 
+### 4.2.2 `parseGameData.js` 集計関数
+
+`parseGameData.js` の aggregate 関数は JSONL 由来の `LogEvent[]` を UI 用の派生データへ変換する純粋関数として扱う。I/O・fetch・React state 更新は `replayLoader.js` / screen component 側に置き、aggregate 関数には持ち込まない。
+
+| 関数 | 目的 | 入力 | 出力 | `is_public` の扱い |
+|---|---|---|---|---|
+| `aggregateDaySummary` | 日別タイムライン・右ペイン表示に必要なサマリを単一ソースとして作る。旧 `aggregateDayResults` と `aggregateDayActions` の責務を統合する | raw `LogEvent[]` | `{ [day]: { speechCount, nightDone, nightActions, execResult } }` | private `night_attack` は `nightActions` に含める。public `night_attack` は夜明け結果の公知イベントなので `nightActions` には入れず、`nightDone` 判定だけに使う。public `elimination` は `execResult.target` に使う |
+| `aggregateCoStatus` | CO 状況を agent 名から claimed role へ引く map にする。日別表示では `upToDay` までを累積する | normalized `LogEvent[]`, optional `upToDay` | `{ [agentName]: claimed_role }` | `co_announcement` は公開発言として扱う。現状は `is_public` でフィルタせず、`event_type` / `agent` / `claimed_role` を正とする |
+| `aggregateNightResults` | private 夜襲ログから日別の襲撃先を取り出す。後方互換の派生データ | raw `LogEvent[]` | `{ [day]: { attacked } }` | private `night_attack` の `target` のみ使う。public `night_attack` はログ生成側の agent/target 揺れを避けるため無視する |
+| `computeDeadByDay` | 各日終了時点の累積死亡者 map を作る | raw または normalized `LogEvent[]` | `{ [day]: Map<agentName, { day, content }> }` | `elimination` は死亡として扱う。private `night_attack` は死亡候補として扱い、同日同 target の private `guard_block` があれば除外する。public `night_attack` は使わない |
+| `buildActionsTimeline` | 夜行動・処刑を横断的なアクション履歴に平坦化する | raw `LogEvent[]` | `[{ day, when, kind, who, target, label }]` | private `night_attack` は人狼視点の行動として含める。public `night_attack` は村への結果告知なので除外する。public `elimination` は処刑アクションとして含める |
+
+`daySummary` は `SpectatorScreen` の左右ペインで共有する日別データ名とする。`nightActions` や `execResult` のような行動系フィールドも `daySummary` 配下に置き、左ペインと右ペインが別々の集計結果を参照して表示ずれを起こさないようにする。
+
 ### 4.3 ルーティング方針（Milestone 2）
 
 react-router を導入し、URL ベースの遷移に移行する。

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -173,34 +173,62 @@ export function buildActionsTimeline(events) {
 }
 
 /**
- * Aggregate per-day execution target, vote count, and night completion from
- * elimination / vote / night_attack events. Days with only other event types
- * (speech, guard, etc.) have no entry in the returned map.
+ * Aggregate per-day night actions and execution results.
+ *
+ * nightActions: inspection / guard / private night_attack (is_public=false)
+ * execResult:   elimination target + vote breakdown
+ * speechCount:  public/private speech count for the day
+ * nightDone:    true when a public night_attack announcement exists
  *
  * @param {object[]} events
- * @returns {Record<number, { target: string|null, votes: number, nightDone: boolean }>}
+ * @returns {Record<number, { nightActions: object[], execResult: { target: string|null, votes: number, voteTable: {from:string,to:string}[] } | null, speechCount: number, nightDone: boolean }>}
  */
-export function aggregateDayResults(events) {
+export function aggregateDaySummary(events) {
   const result = {};
   const voteCounts = {};
+
+  function ensureDay(d) {
+    if (!result[d]) {
+      result[d] = {
+        nightActions: [],
+        execResult: null,
+        speechCount: 0,
+        nightDone: false,
+      };
+    }
+  }
+
+  function ensureExecResult(d) {
+    ensureDay(d);
+    if (!result[d].execResult) {
+      result[d].execResult = { target: null, votes: 0, voteTable: [] };
+    }
+    return result[d].execResult;
+  }
 
   for (const ev of events) {
     const d = ev.day;
     if (!d) continue;
 
     if (ev.event_type === 'speech') {
-      if (!result[d]) result[d] = { target: null, votes: 0, nightDone: false, speechCount: 0 };
+      ensureDay(d);
       result[d].speechCount += 1;
-    } else if (ev.event_type === 'elimination' && ev.is_public) {
-      if (!result[d]) result[d] = { target: null, votes: 0, nightDone: false, speechCount: 0 };
-      result[d].target = ev.agent;
+    } else if (
+      (ev.event_type === 'inspection' || ev.event_type === 'guard') ||
+      (ev.event_type === 'night_attack' && !ev.is_public)
+    ) {
+      ensureDay(d);
+      result[d].nightActions.push(ev);
     } else if (ev.event_type === 'vote') {
-      if (!result[d]) result[d] = { target: null, votes: 0, nightDone: false, speechCount: 0 };
+      const execResult = ensureExecResult(d);
+      execResult.voteTable.push({ from: ev.agent, to: ev.target });
       if (!voteCounts[d]) voteCounts[d] = {};
       voteCounts[d][ev.target] = (voteCounts[d][ev.target] || 0) + 1;
-      result[d].votes = Math.max(...Object.values(voteCounts[d]));
+      execResult.votes = Math.max(...Object.values(voteCounts[d]));
+    } else if (ev.event_type === 'elimination' && ev.is_public) {
+      ensureExecResult(d).target = ev.agent;
     } else if (ev.event_type === 'night_attack' && ev.is_public) {
-      if (!result[d]) result[d] = { target: null, votes: 0, nightDone: false, speechCount: 0 };
+      ensureDay(d);
       result[d].nightDone = true;
     }
   }
@@ -222,46 +250,6 @@ export function aggregateCoStatus(events, upToDay) {
       result[ev.agent] = ev.claimed_role;
     }
   }
-  return result;
-}
-
-/**
- * Aggregate per-day night actions and execution results.
- *
- * nightActions: inspection / guard / private night_attack (is_public=false)
- * execResult:   elimination target + vote breakdown
- *
- * @param {object[]} events
- * @returns {Record<number, { nightActions: object[], execResult: { target: string, voteTable: {from:string,to:string}[] } | null }>}
- */
-export function aggregateDayActions(events) {
-  const result = {};
-
-  function ensureDay(d) {
-    if (!result[d]) result[d] = { nightActions: [], execResult: null };
-  }
-
-  for (const ev of events) {
-    const d = ev.day;
-    if (!d) continue;
-
-    if (
-      (ev.event_type === 'inspection' || ev.event_type === 'guard') ||
-      (ev.event_type === 'night_attack' && !ev.is_public)
-    ) {
-      ensureDay(d);
-      result[d].nightActions.push(ev);
-    } else if (ev.event_type === 'vote') {
-      ensureDay(d);
-      if (!result[d].execResult) result[d].execResult = { target: null, voteTable: [] };
-      result[d].execResult.voteTable.push({ from: ev.agent, to: ev.target });
-    } else if (ev.event_type === 'elimination') {
-      ensureDay(d);
-      if (!result[d].execResult) result[d].execResult = { target: null, voteTable: [] };
-      result[d].execResult.target = ev.agent;
-    }
-  }
-
   return result;
 }
 
@@ -326,7 +314,7 @@ export function computeDeadByDay(events) {
  *
  * @param {string} jsonlText
  * @param {Record<string, object>} agentJsonByName
- * @returns {{ events: object[], agents: Record<string, object>, daySummary: object }}
+ * @returns {{ events: object[], agents: Record<string, object>, daySummary: object, nightResults: object, actionsTimeline: object[] }}
  */
 export function parseGameData(jsonlText, agentJsonByName = {}) {
   const rawEvents = jsonlText
@@ -344,7 +332,7 @@ export function parseGameData(jsonlText, agentJsonByName = {}) {
   return {
     events,
     agents,
-    daySummary: aggregateDayResults(rawEvents),
+    daySummary: aggregateDaySummary(rawEvents),
     nightResults: aggregateNightResults(rawEvents),
     actionsTimeline: buildActionsTimeline(rawEvents),
   };

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseEventLine, parseGameData, normalizeEvents, aggregateDayResults, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, aggregateDayActions, computeDeadByDay } from './parseGameData.js';
+import { parseEventLine, parseGameData, normalizeEvents, aggregateDaySummary, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, computeDeadByDay } from './parseGameData.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -179,8 +179,8 @@ describe('parseGameData', () => {
     const gameData = parseGameData(readFixture('spectator_log.jsonl'));
     expect(gameData.daySummary).toBeDefined();
     const day1 = gameData.daySummary[1];
-    expect(day1.target).toBeTruthy();
-    expect(typeof day1.votes).toBe('number');
+    expect(day1.execResult.target).toBeTruthy();
+    expect(typeof day1.execResult.votes).toBe('number');
     expect(typeof day1.nightDone).toBe('boolean');
   });
 });
@@ -344,10 +344,10 @@ describe('buildActionsTimeline', () => {
   });
 });
 
-describe('aggregateDayResults', () => {
+describe('aggregateDaySummary', () => {
   it('extracts elimination target and top vote count', () => {
     /*
-     * SUT: aggregateDayResults
+     * SUT: aggregateDaySummary
      * Mock: なし
      * Level: unit
      * Objective: elimination イベントの agent フィールドが daySummary の target に反映され、vote 集計で最多票数が votes に入ることを検証する。
@@ -358,14 +358,14 @@ describe('aggregateDayResults', () => {
       { day: 1, event_type: 'vote', agent: 'Mira', target: 'Kael' },
       { day: 1, event_type: 'vote', agent: 'Ren',  target: 'Sora' },
     ];
-    const summary = aggregateDayResults(events);
-    expect(summary[1].target).toBe('Kael');
-    expect(summary[1].votes).toBe(2);
+    const summary = aggregateDaySummary(events);
+    expect(summary[1].execResult.target).toBe('Kael');
+    expect(summary[1].execResult.votes).toBe(2);
   });
 
   it('sets nightDone true when public night_attack exists', () => {
     /*
-     * SUT: aggregateDayResults
+     * SUT: aggregateDaySummary
      * Mock: なし
      * Level: unit
      * Objective: is_public な night_attack イベントがある日は nightDone が true、ない日は false になることを検証する。
@@ -374,14 +374,14 @@ describe('aggregateDayResults', () => {
       { day: 1, event_type: 'night_attack', agent: 'Rei',  is_public: true },
       { day: 2, event_type: 'night_attack', agent: 'Sora', is_public: false },
     ];
-    const summary = aggregateDayResults(events);
+    const summary = aggregateDaySummary(events);
     expect(summary[1].nightDone).toBe(true);
-    expect(summary[2]).toBeUndefined();
+    expect(summary[2].nightDone).toBe(false);
   });
 
   it('counts speech events per day', () => {
     /*
-     * SUT: aggregateDayResults
+     * SUT: aggregateDaySummary
      * Mock: なし
      * Level: unit
      * Objective: speech イベントが speechCount に集計され、複数日が独立して集計されることを検証する。
@@ -391,7 +391,7 @@ describe('aggregateDayResults', () => {
       { day: 1, event_type: 'speech', agent: 'Kael', speech_id: 2 },
       { day: 2, event_type: 'speech', agent: 'Nox',  speech_id: 1 },
     ];
-    const summary = aggregateDayResults(events);
+    const summary = aggregateDaySummary(events);
     expect(summary[1].speechCount).toBe(2);
     expect(summary[2].speechCount).toBe(1);
   });
@@ -669,10 +669,10 @@ describe('computeDeadByDay', () => {
   });
 });
 
-describe('aggregateDayActions', () => {
+describe('aggregateDaySummary action fields', () => {
   it('collects night actions and exec result per day', () => {
     /*
-     * SUT: aggregateDayActions
+     * SUT: aggregateDaySummary
      * Mock: なし
      * Level: unit
      * Objective: inspection / guard / night_attack(private) / elimination / vote から日別サマリを生成することを検証する。
@@ -686,7 +686,7 @@ describe('aggregateDayActions', () => {
       { day: 1, event_type: 'vote',         agent: 'Kai',  target: 'Nox',  content: 'Kai votes for Nox',         is_public: true },
       { day: 1, event_type: 'elimination',  agent: 'Toma', target: null,   content: 'Toma was executed.',        is_public: true },
     ];
-    const result = aggregateDayActions(events);
+    const result = aggregateDaySummary(events);
     const d1 = result[1];
 
     expect(d1.nightActions).toHaveLength(3);
@@ -695,6 +695,7 @@ describe('aggregateDayActions', () => {
     expect(d1.nightActions.find(a => a.event_type === 'night_attack' && !a.is_public)).toBeTruthy();
 
     expect(d1.execResult.target).toBe('Toma');
+    expect(d1.execResult.votes).toBe(2);
     expect(d1.execResult.voteTable).toEqual([
       { from: 'Nox',  to: 'Toma' },
       { from: 'Mira', to: 'Toma' },
@@ -704,7 +705,7 @@ describe('aggregateDayActions', () => {
 
   it('excludes public night_attack from nightActions (already shown in feed)', () => {
     /*
-     * SUT: aggregateDayActions
+     * SUT: aggregateDaySummary
      * Mock: なし
      * Level: unit
      * Objective: is_public な night_attack（夜明け公知イベント）は nightActions に含まれないことを検証する。
@@ -713,22 +714,22 @@ describe('aggregateDayActions', () => {
       { day: 1, event_type: 'night_attack', agent: 'Kai',  target: 'Sora', is_public: false },
       { day: 1, event_type: 'night_attack', agent: 'Sora', target: null,   is_public: true },
     ];
-    const result = aggregateDayActions(events);
+    const result = aggregateDaySummary(events);
     expect(result[1].nightActions).toHaveLength(1);
     expect(result[1].nightActions[0].is_public).toBe(false);
   });
 
-  it('returns empty nightActions and null execResult for days with no relevant events', () => {
+  it('returns no summary entry for days with no summary-relevant events', () => {
     /*
-     * SUT: aggregateDayActions
+     * SUT: aggregateDaySummary
      * Mock: なし
      * Level: unit
-     * Objective: 該当イベントがない日はデフォルト値を返すことを検証する。
+     * Objective: 該当イベントがない日は daySummary エントリを作らないことを検証する。
      */
     const events = [
-      { day: 1, event_type: 'speech', agent: 'Mira', speech_id: 1 },
+      { day: 1, event_type: 'phase_start', phase: 'day_discussion' },
     ];
-    const result = aggregateDayActions(events);
+    const result = aggregateDaySummary(events);
     expect(result[1]).toBeUndefined();
   });
 });

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -5,7 +5,7 @@ import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
-import { parseGameData, aggregateCoStatus, aggregateDayActions, computeDeadByDay } from '../lib/parseGameData.js';
+import { parseGameData, aggregateCoStatus, computeDeadByDay } from '../lib/parseGameData.js';
 import { filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
 
@@ -235,7 +235,7 @@ export function FeedItem({ ev, prevById, roleAssignment, title }) {
 }
 
 // === 左ペイン ===
-export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary, dayActions = {} }) {
+export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary = {} }) {
   const handlePhase = (d, phase) => {
     setDay(d);
     setPhase(phase);
@@ -249,8 +249,8 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
           <div key={d} className={`${styles.dayBlock} ${activeDay === d ? styles.dayBlockActive : ''}`}>
             <div className={styles.phaseDay}>
               <h3>第 {d} 日</h3>
-              {dayActions[d]?.nightActions?.find(a => a.event_type === 'night_attack') && (
-                <div className={styles.deathline}>⚰ {dayActions[d].nightActions.find(a => a.event_type === 'night_attack').target}</div>
+              {daySummary[d]?.nightActions?.find(a => a.event_type === 'night_attack') && (
+                <div className={styles.deathline}>⚰ {daySummary[d].nightActions.find(a => a.event_type === 'night_attack').target}</div>
               )}
             </div>
             <div className={styles.phaseList}>
@@ -264,13 +264,13 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
                 className={`${styles.phaseItem} ${styles.phaseExec} ${activeDay === d && activePhase === 'vote' ? styles.active : ''}`}
                 onClick={() => handlePhase(d, 'vote')}
               >
-                <span className={styles.dot} /> 投票・処刑 <span className={styles.phaseTurn}>{daySummary[d]?.target || '—'}</span>
+                <span className={styles.dot} /> 投票・処刑 <span className={styles.phaseTurn}>{daySummary[d]?.execResult?.target || '—'}</span>
               </div>
               <div
                 className={`${styles.phaseItem} ${styles.phaseNight} ${activeDay === d && activePhase === 'night' ? styles.active : ''}`}
                 onClick={() => handlePhase(d, 'night')}
               >
-                <span className={styles.dot} /> 夜フェーズ <span className={styles.phaseTurn}>{dayActions[d]?.nightActions?.find(a => a.event_type === 'night_attack')?.target ?? ''}</span>
+                <span className={styles.dot} /> 夜フェーズ <span className={styles.phaseTurn}>{daySummary[d]?.nightActions?.find(a => a.event_type === 'night_attack')?.target ?? ''}</span>
               </div>
             </div>
           </div>
@@ -311,14 +311,14 @@ const NIGHT_ACTION_LABEL = { inspection: '占い', guard: '護衛', night_attack
 
 // TODO(#314): public モードでは真の役職タグを非表示にし、CO役職のみ表示する
 // === 右ペイン ===
-export function RightPane({ agents, roleAssignment, coStatus = {}, dayActions = {}, activeDay, deadByDay = {}, viewerMode = 'spectator' }) {
+export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = {}, activeDay, deadByDay = {}, viewerMode = 'spectator' }) {
   const order = Object.keys(agents);
   const activeDead = deadByDay[activeDay] ?? new Map();
   const deadNames = order.filter(n => activeDead.has(n))
     .sort((a, b) => (activeDead.get(a)?.day ?? 0) - (activeDead.get(b)?.day ?? 0));
   const alive = order.filter(n => !activeDead.has(n));
 
-  const dayData = dayActions[activeDay];
+  const dayData = daySummary[activeDay];
   const nightActions = dayData?.nightActions ?? [];
   const execResult = dayData?.execResult ?? null;
 
@@ -445,8 +445,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   const [activePhase, setActivePhase] = useState('discuss');
   const [replayEvents, setReplayEvents] = useState(null);
   const [replayAgents, setReplayAgents] = useState({});
-  const [replayDaySummary, setReplayDaySummary] = useState(null);
-  const [replayDayActions, setReplayDayActions] = useState({});
+  const [replayDaySummary, setReplayDaySummary] = useState({});
   const [replayDeadByDay, setReplayDeadByDay] = useState({});
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
   const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
@@ -460,9 +459,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     let cancelled = false;
     setReplayEvents(null);
     setReplayAgents({});
-    setReplayDaySummary(null);
-
-    setReplayDayActions({});
+    setReplayDaySummary({});
     setReplayDeadByDay({});
     setLoadingEvents(true);
     setLoadingAgents(true);
@@ -487,7 +484,6 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         setReplayEvents(parsed.events);
         setReplayDaySummary(parsed.daySummary);
 
-        setReplayDayActions(aggregateDayActions(parsed.events));
         setReplayDeadByDay(computeDeadByDay(parsed.events));
         const firstDay = parsed.events.find(event => event.day)?.day;
         if (firstDay) { setActiveDay(firstDay); setActivePhase('discuss'); }
@@ -506,7 +502,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
 
   const events = replayEvents ?? [];
   const agents = replayAgents;
-  const daySummary = replayDaySummary ?? {};
+  const daySummary = replayDaySummary;
   const roleAssignment = useMemo(() => Object.fromEntries(
     Object.entries(agents).map(([name, agent]) => [name, agent.role])
   ), [agents]);
@@ -536,8 +532,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
       <ThreePaneLayout
         collapsibleLeft
         collapsibleRight
-        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} dayActions={replayDayActions} />}
-        right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} dayActions={replayDayActions} activeDay={activeDay} deadByDay={replayDeadByDay} viewerMode={viewerMode} />}
+        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} />}
+        right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} daySummary={daySummary} activeDay={activeDay} deadByDay={replayDeadByDay} viewerMode={viewerMode} />}
       >
         <div className={styles.feedHead}>
           <h2>Day {activeDay} {{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]} <small>{sessionId ? sessionId : '3:47 経過 / 残り 4:13'}</small></h2>

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -53,8 +53,10 @@ function renderLeftPane(overrides = {}) {
     agentNames: ['Alice', 'Bob', 'Carol'],
     daySummary: {
       1: {
-        target: 'Bob',
+        execResult: { target: 'Bob', votes: 1, voteTable: [] },
         nightDone: true,
+        nightActions: [],
+        speechCount: 0,
       },
     },
     ...overrides,
@@ -344,19 +346,21 @@ describe('FeedItem: system event icons', () => {
 });
 
 describe('LeftPane night death display', () => {
-  it('shows attacked agent name from dayActions when available', () => {
+  it('shows attacked agent name from daySummary when available', () => {
     /**
      * SUT: LeftPane
-     * Mock: なし（dayActions plain object を入力）
+     * Mock: なし（daySummary plain object を入力）
      * Level: unit
-     * Objective: dayActions[day].nightActions に night_attack がある場合 ⚰ マークと共に左ペインに表示されることを検証する。
+     * Objective: daySummary[day].nightActions に night_attack がある場合 ⚰ マークと共に左ペインに表示されることを検証する。
      */
     renderLeftPane({
       days: [1],
-      dayActions: {
+      daySummary: {
         1: {
           nightActions: [{ event_type: 'night_attack', agent: 'Kai', target: 'Alice', is_public: false }],
           execResult: null,
+          speechCount: 0,
+          nightDone: false,
         },
       },
     });
@@ -364,16 +368,16 @@ describe('LeftPane night death display', () => {
     expect(screen.getByText(/⚰.*Alice|Alice.*⚰/)).toBeTruthy();
   });
 
-  it('shows nothing when dayActions has no night_attack for the day', () => {
+  it('shows nothing when daySummary has no night_attack for the day', () => {
     /**
      * SUT: LeftPane
      * Mock: なし
      * Level: unit
-     * Objective: dayActions に night_attack がない場合は ⚰ が表示されないことを検証する。
+     * Objective: daySummary に night_attack がない場合は ⚰ が表示されないことを検証する。
      */
     const { container } = renderLeftPane({
       days: [1],
-      dayActions: {},
+      daySummary: {},
     });
 
     expect(container.querySelector('[class*="deathline"]')).toBeNull();
@@ -394,7 +398,7 @@ function renderRightPane(overrides = {}) {
     agents: baseAgents,
     roleAssignment: { Alice: 'Seer', Bob: 'Werewolf', Carol: 'Knight' },
     coStatus: {},
-    dayActions: {},
+    daySummary: {},
     activeDay: 1,
     deadByDay: baseDeadByDay,
     viewerMode: 'spectator',
@@ -521,15 +525,17 @@ describe('RightPane: night actions for activeDay', () => {
      * Level: unit
      * Objective: activeDay の夜行動が右ペインに表示されることを検証する。
      */
-    const dayActions = {
+    const daySummary = {
       1: {
         nightActions: [
           { day: 1, event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf', is_public: false },
         ],
-        execResult: { target: 'Bob', voteTable: [{ from: 'Alice', to: 'Bob' }] },
+        execResult: { target: 'Bob', votes: 1, voteTable: [{ from: 'Alice', to: 'Bob' }] },
+        speechCount: 0,
+        nightDone: false,
       },
     };
-    renderRightPane({ dayActions, activeDay: 1 });
+    renderRightPane({ daySummary, activeDay: 1 });
     expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Bob').length).toBeGreaterThan(0);
   });
@@ -541,13 +547,15 @@ describe('RightPane: night actions for activeDay', () => {
      * Level: unit
      * Objective: activeDay の処刑結果（ターゲット）が表示されることを検証する。
      */
-    const dayActions = {
+    const daySummary = {
       1: {
         nightActions: [],
-        execResult: { target: 'Bob', voteTable: [{ from: 'Alice', to: 'Bob' }] },
+        execResult: { target: 'Bob', votes: 1, voteTable: [{ from: 'Alice', to: 'Bob' }] },
+        speechCount: 0,
+        nightDone: false,
       },
     };
-    renderRightPane({ dayActions, activeDay: 1 });
+    renderRightPane({ daySummary, activeDay: 1 });
     expect(screen.getAllByText('Bob').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- Replace separate day result/action aggregators with aggregateDaySummary
- Keep daySummary as the UI-facing single source for speech counts, night state, night actions, and execution results
- Document aggregate function contracts and is_public handling in FrontendDesign.md

Closes #409

## Tests
- npm test -- src/lib/parseGameData.test.js src/screens/SpectatorScreen.test.jsx
- npm test
- npm run build
- uv run ruff check .
- uv run pytest