### PR TITLE
Refactor GameCard semantic markup

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -27,9 +27,7 @@
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
-| yukkie/AgentVillage#409 | tech-debt | 🔴 | 3 | Merge aggregateDayResults into aggregateDayActions and document all aggregate functions | 日別集計関数を統合し夜フェーズ被害者名バグの根因を解消。全 aggregate 関数を FrontendDesign.md に記載 |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
-| yukkie/AgentVillage#410 | tech-debt | 🟡 | 2 | Refactor GameCard to use semantic HTML for stable identification | GameCard を `<article>` に変更し Playwright から安定して特定できるようにする |
 | yukkie/AgentVillage#411 | tech-debt | 🟡 | 5 | Replace div soup with semantic HTML elements | div/span を意味のある要素に置き換え Playwright・アクセシビリティを改善。FrontendDesign.md に方針追記 |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |

--- a/frontend/src/screens/GameListScreen.jsx
+++ b/frontend/src/screens/GameListScreen.jsx
@@ -124,23 +124,19 @@ function winnerClass(winner) {
 
 function GameCard({ g, onOpen }) {
   return (
-    <div className={`${styles.gcard} ${g.hot ? styles.featured : ''}`}>
+    <article
+      className={`${styles.gcard} ${g.hot ? styles.featured : ''}`}
+      aria-label={g.id}
+    >
       <div className={styles.vote}>
         <button className={styles.up}>▲</button>
         <span className={styles.voteNum}>{g.votes}</span>
         <button>▼</button>
       </div>
-      <div
+      <button
+        type="button"
         className={styles.cardBody}
-        role="button"
-        tabIndex={0}
         onClick={() => onOpen(g)}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            onOpen(g);
-          }
-        }}
       >
         <div className={styles.gmeta}>
           {g.live
@@ -184,8 +180,8 @@ function GameCard({ g, onOpen }) {
           <span>★ 保存</span>
           <span>↗ 共有</span>
         </div>
-      </div>
-    </div>
+      </button>
+    </article>
   );
 }
 

--- a/frontend/src/screens/GameListScreen.module.css
+++ b/frontend/src/screens/GameListScreen.module.css
@@ -185,7 +185,23 @@
 }
 
 /* カード本体 */
-.cardBody { flex: 1; padding: 12px 14px; min-width: 0; }
+.cardBody {
+  flex: 1;
+  padding: 12px 14px;
+  min-width: 0;
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  font: inherit;
+  text-align: left;
+}
+.cardBody:focus-visible {
+  outline: 2px solid var(--acc);
+  outline-offset: -2px;
+}
 
 .gmeta {
   display: flex;

--- a/frontend/src/screens/GameListScreen.test.jsx
+++ b/frontend/src/screens/GameListScreen.test.jsx
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GameListScreen from './GameListScreen.jsx';
+import * as archiveLoader from '../lib/archiveLoader.js';
+
+vi.mock('../lib/archiveLoader.js', () => ({
+  fetchGameList: vi.fn(),
+}));
+
+const game = {
+  id: '20260510_102927',
+  title: '【第12回】「黎明の小径」— 狼勝利',
+  tag: '完了',
+  live: false,
+  hot: false,
+  day: 3,
+  winner: 'wolf',
+  winnerLabel: '狼陣営勝',
+  rule: '標準11人',
+  votes: 0,
+  comments: 0,
+  viewers: null,
+  cast: ['Kael', 'Kai', 'Mira'],
+  desc: '狂人 Kael の超積極投票で村が分断',
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function mockGameList(games = [game]) {
+  archiveLoader.fetchGameList.mockResolvedValue(games);
+}
+
+describe('GameListScreen GameCard semantics', () => {
+  it('exposes each game card as an article named by session id', async () => {
+    /**
+     * SUT: GameListScreen / GameCard
+     * Mock: fetchGameList（state_archive index の取得を固定）
+     * Level: component
+     * Objective: GameCard が article role と session_id 由来の accessible name で安定特定できることを検証する。
+     */
+    mockGameList();
+
+    render(<GameListScreen />);
+
+    const card = await screen.findByRole('article', { name: '20260510_102927' });
+
+    expect(card).toBeTruthy();
+    expect(screen.getByRole('heading', { level: 3, name: game.title })).toBeTruthy();
+  });
+
+  it('opens the selected game when the card body button is clicked', async () => {
+    /**
+     * SUT: GameListScreen / GameCard
+     * Mock: fetchGameList（state_archive index の取得を固定）
+     * Level: component
+     * Objective: semantic button 化後もカード選択で onOpenGame に選択 game が渡ることを検証する。
+     */
+    const onOpenGame = vi.fn();
+    const user = userEvent.setup();
+    mockGameList();
+
+    render(<GameListScreen onOpenGame={onOpenGame} />);
+
+    await user.click(await screen.findByRole('button', { name: new RegExp(game.title) }));
+
+    await waitFor(() => {
+      expect(onOpenGame).toHaveBeenCalledWith(game);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Wrap GameCard in an article named by session id
- Replace div role=button with a native button for card selection
- Add component coverage for article lookup and card opening

## Tests
- npm test -- GameListScreen.test.jsx
- npm test
- uv run ruff check .
- uv run pytest

Closes #410