### PR TITLE
feat(frontend): spectator/public mode toggle

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -497,6 +497,17 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 | `LeftPane` | フェーズナビ（日 × フェーズ、クリックで中央フィードを切り替え） + エージェント/役職/表示フィルタ |
 | `RightPane` | ロスター（生存/死亡）/ COボード / 夜の行動タイムライン |
 
+#### viewerMode トグル（#314）
+
+ヘッダーの「観戦者モード / 参加者視点」トグルで `viewerMode: 'spectator' | 'public'` を切り替える。
+
+| 要素 | spectator | public |
+|---|---|---|
+| `SpeechCard` 役職タグ・Avatar 役職刻印 | 真の役職を表示 | 非表示 |
+| `ThoughtDetails` / `WolfChatCard` 思考ログ | `<details>` で展開可 | `🔒 思考ログ` ロックバッジ（クリック不可） |
+| `RightPane` 生存ロスター役職タグ・Avatar 役職刻印 | 真の役職を表示 | 非表示 |
+| spectator 限定システムログ（`wolf_chat` / `inspection` / `guard` / `medium_result` および `is_public=false` のイベント） | 表示 | **完全非表示**（カード自体をマウントしない） |
+
 #### フェーズクリックの仕様（#358）
 
 左ペインの各フェーズ行をクリックすると、中央フィードがそのフェーズのイベントに絞り込まれる。

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -22,7 +22,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#314 | enhancement | 🔴 | 2 | spectator / public mode toggle | viewerMode prop による表示切替。#350 のブロッカー |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |
 | yukkie/AgentVillage#344 | tech-debt | 🔴 | 3 | Design: LogEvent cannot express mixed public/private fields in a single speech event | speech イベントの公開/非公開混在問題の設計を定め Architecture.md に記載、[THINK] ハックを廃止する設計Issueを作る |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -27,8 +27,12 @@ function Mentioned({ text }) {
   );
 }
 
-function ThoughtDetails({ reasoning }) {
+function ThoughtDetails({ reasoning, viewerMode = 'spectator' }) {
   if (!reasoning) return null;
+
+  if (viewerMode === 'public') {
+    return <span className={styles.lockBadge}>🔒 思考ログ</span>;
+  }
 
   return (
     <details className={styles.spThink}>
@@ -53,24 +57,25 @@ function ThoughtDetails({ reasoning }) {
 }
 
 // --- 発言カード ---
-function SpeechCard({ ev, prevById, roleAssignment }) {
+function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) {
   const role = roleAssignment[ev.agent];
   const r = ROLES[role];
   const replied = ev.reply_to ? prevById[`${ev.day}-${ev.reply_to}`] : null;
   const isWolf = role === 'Werewolf';
+  const isPublic = viewerMode === 'public';
 
   return (
     <div
       className={`${styles.speech} ${isWolf ? styles.speechWolf : ''}`}
       style={{ '--r-color': r?.color }}
     >
-      <Avatar name={ev.agent} role={role} />
+      <Avatar name={ev.agent} role={isPublic ? undefined : role} />
       <div className={styles.vert} />
       <div>
         <div className={styles.spHead}>
           <span className={styles.name}>{ev.agent}</span>
           <span className={styles.turn}>{fmtTurn(ev.day, ev.speech_id || 0)}</span>
-          <RoleTag role={role} />
+          {!isPublic && <RoleTag role={role} />}
           {ev.claimed_role && (
             <span className={styles.coBadge}>
               ▶ {ROLES[ev.claimed_role]?.ja || ev.claimed_role} CO
@@ -87,7 +92,7 @@ function SpeechCard({ ev, prevById, roleAssignment }) {
         <div className={styles.spBody}>
           <Mentioned text={ev.content} />
         </div>
-        <ThoughtDetails reasoning={ev.reasoning} />
+        <ThoughtDetails reasoning={ev.reasoning} viewerMode={viewerMode} />
       </div>
     </div>
   );
@@ -137,7 +142,7 @@ const SYSTEM_EVENT_VIEWS = {
   },
 };
 
-function renderConfiguredSystemEvent(ev, roleAssignment) {
+function renderConfiguredSystemEvent(ev, roleAssignment, viewerMode) {
   const view = SYSTEM_EVENT_VIEWS[ev.event_type];
   if (!view) return null;
 
@@ -150,6 +155,7 @@ function renderConfiguredSystemEvent(ev, roleAssignment) {
       leftName={view.leftName?.(ev)}
       rightName={view.rightName?.(ev)}
       roleAssignment={roleAssignment}
+      viewerMode={viewerMode}
     >
       {logContent(ev)}
     </SystemRow>
@@ -157,7 +163,7 @@ function renderConfiguredSystemEvent(ev, roleAssignment) {
 }
 
 // --- システム行 ---
-function SystemRow({ kind, icon, label, children, reasoning, ts, leftName, rightName, roleAssignment = {} }) {
+function SystemRow({ kind, icon, label, children, reasoning, ts, leftName, rightName, roleAssignment = {}, viewerMode = 'spectator' }) {
   const defaultIcon = { gm: '👁', death: '💀', exec: '⚑', phase: '☾' }[kind] || '⌘';
   return (
     <div className={`${styles.sysrow} ${styles[kind] || ''}`}>
@@ -176,14 +182,14 @@ function SystemRow({ kind, icon, label, children, reasoning, ts, leftName, right
             <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
           )}
         </div>
-        <ThoughtDetails reasoning={reasoning} />
+        <ThoughtDetails reasoning={reasoning} viewerMode={viewerMode} />
       </div>
     </div>
   );
 }
 
 // --- 人狼会話カード ---
-function WolfChatCard({ ev }) {
+function WolfChatCard({ ev, viewerMode = 'spectator' }) {
   return (
     <div className={`${styles.speech} ${styles.wolfChat}`}>
       <Avatar name={ev.agent} />
@@ -193,30 +199,40 @@ function WolfChatCard({ ev }) {
           <span className={styles.name}>{ev.agent}</span>
         </div>
         <div className={styles.spBody}>{ev.content}</div>
-        <ThoughtDetails reasoning={ev.reasoning} />
+        <ThoughtDetails reasoning={ev.reasoning} viewerMode={viewerMode} />
       </div>
     </div>
   );
 }
 
-// --- フィードアイテム ---
-export function FeedItem({ ev, prevById, roleAssignment, title }) {
-  if (ev.event_type === 'speech') return <SpeechCard ev={ev} prevById={prevById} roleAssignment={roleAssignment} />;
-  if (ev.event_type === 'wolf_chat') return <WolfChatCard ev={ev} />;
+// public モードで非表示にする非公開イベント種別
+const SPECTATOR_ONLY_EVENTS = new Set(['wolf_chat', 'inspection', 'guard', 'medium_result']);
 
-  const configuredSystemEvent = renderConfiguredSystemEvent(ev, roleAssignment);
+// --- フィードアイテム ---
+export function FeedItem({ ev, prevById, roleAssignment, title, viewerMode = 'spectator' }) {
+  const isPublic = viewerMode === 'public';
+
+  if (ev.event_type === 'speech') return <SpeechCard ev={ev} prevById={prevById} roleAssignment={roleAssignment} viewerMode={viewerMode} />;
+
+  // public モードでは spectator 限定イベントを完全非表示
+  if (isPublic && SPECTATOR_ONLY_EVENTS.has(ev.event_type)) return null;
+  if (isPublic && !ev.is_public) return null;
+
+  if (ev.event_type === 'wolf_chat') return <WolfChatCard ev={ev} viewerMode={viewerMode} />;
+
+  const configuredSystemEvent = renderConfiguredSystemEvent(ev, roleAssignment, viewerMode);
   if (configuredSystemEvent) return configuredSystemEvent;
 
   if (ev.event_type === 'guard_block') {
     return ev.is_public
-      ? <SystemRow kind="gm" icon="🛡" label="護衛">{logContent(ev)}</SystemRow>
-      : <SystemRow kind="gm" icon="🛡" label="護衛成功" rightName={ev.target} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>;
+      ? <SystemRow kind="gm" icon="🛡" label="護衛" viewerMode={viewerMode}>{logContent(ev)}</SystemRow>
+      : <SystemRow kind="gm" icon="🛡" label="護衛成功" rightName={ev.target} roleAssignment={roleAssignment} viewerMode={viewerMode}>{logContent(ev)}</SystemRow>;
   }
   if (ev.event_type === 'night_attack') {
     const victim = ev.target;
     return ev.is_public
-      ? <SystemRow kind="death" icon="💀" label="襲撃結果" rightName={victim} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>
-      : <SystemRow kind="exec" icon="🐺" label="人狼の襲撃" rightName={ev.target} roleAssignment={roleAssignment}>{logContent(ev)}</SystemRow>;
+      ? <SystemRow kind="death" icon="💀" label="襲撃結果" rightName={victim} roleAssignment={roleAssignment} viewerMode={viewerMode}>{logContent(ev)}</SystemRow>
+      : <SystemRow kind="exec" icon="🐺" label="人狼の襲撃" rightName={ev.target} roleAssignment={roleAssignment} viewerMode={viewerMode}>{logContent(ev)}</SystemRow>;
   }
 
   if (ev.event_type === 'phase_start') {
@@ -309,7 +325,6 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
 const NIGHT_ACTION_ICON = { inspection: '🔮', guard: '🛡', night_attack: '🐺' };
 const NIGHT_ACTION_LABEL = { inspection: '占い', guard: '護衛', night_attack: '襲撃' };
 
-// TODO(#314): public モードでは真の役職タグを非表示にし、CO役職のみ表示する
 // === 右ペイン ===
 export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = {}, activeDay, deadByDay = {}, viewerMode = 'spectator' }) {
   const order = Object.keys(agents);
@@ -394,11 +409,10 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
           const coRole = coStatus[n];
           return (
             <div key={n} className={styles.rosterRow} style={{ '--r-color': r?.color }}>
-              <Avatar name={n} role={role} size="sm" />
+              <Avatar name={n} role={viewerMode === 'spectator' ? role : undefined} size="sm" />
               <div className={styles.who}>
                 <span className={styles.rosterName}>
                   {n}
-                  {/* spectator mode: true role tag always shown; TODO(#314): hide in public mode */}
                   {viewerMode === 'spectator' && <RoleTag role={role} />}
                   {coRole && (
                     <span className={styles.coBadge}>▶ {ROLES[coRole]?.ja || coRole} CO</span>
@@ -450,8 +464,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
   const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
   const [loadError, setLoadError] = useState(null);
-  // TODO(#314): public モード切り替えUIを追加したらここで toggle する
-  const viewerMode = 'spectator';
+  const [viewerMode, setViewerMode] = useState('spectator');
 
   useEffect(() => {
     if (!sessionId) return undefined;
@@ -525,6 +538,9 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         {onBack && <TopBarBtn onClick={onBack}>← 一覧</TopBarBtn>}
         <TopBarBtn><span className={topBarStyles.liveDot} /> REPLAY</TopBarBtn>
         <TopBarBtn>同時観戦 142</TopBarBtn>
+        <TopBarBtn onClick={() => setViewerMode(v => v === 'spectator' ? 'public' : 'spectator')}>
+          {viewerMode === 'spectator' ? '🔍 観戦者モード' : '👤 参加者視点'}
+        </TopBarBtn>
         <TopBarBtn>⤓ 全ログDL</TopBarBtn>
         <TopBarBtn primary>★ 応援</TopBarBtn>
       </TopBar>
@@ -562,6 +578,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
               prevById={prevById}
               roleAssignment={roleAssignment}
               title={title || sessionId}
+              viewerMode={viewerMode}
             />
           ))}
         </div>

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -504,3 +504,6 @@
 
 /* filter chip swatch */
 .swatch { width: 8px; height: 8px; border-radius: 2px; }
+
+/* viewerMode: public */
+.lockBadge { font-size: 11px; color: var(--tx-4); padding: 2px 6px; cursor: default; user-select: none; }

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -477,6 +477,23 @@ describe('RightPane: role display in spectator mode', () => {
     expect(screen.getAllByText(/占い師/).length).toBeGreaterThan(0);
   });
 
+  it('hides true role tag for alive agents in public mode (AC2)', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: publicモードで生存エージェントの真の役職タグが非表示になることを検証する（AC2 / #314）。
+     *            死亡者行（Bob）は常時役職公開のため対象外。
+     */
+    const { container } = renderRightPane({ viewerMode: 'public', coStatus: {} });
+    // Find the alive section (first rosterSection) and check no roleTag inside it
+    const aliveSections = container.querySelectorAll('[class*="rosterSection"]');
+    // aliveSections[0] = 生存, aliveSections[1] = 死亡者
+    const aliveSection = aliveSections[0];
+    const roleTagsInAlive = aliveSection.querySelectorAll('[class*="roleTag"]');
+    expect(roleTagsInAlive.length).toBe(0);
+  });
+
   it('shows CO role badge when agent has claimed_role', () => {
     /*
      * SUT: RightPane
@@ -696,5 +713,199 @@ describe('SpectatorScreen: sessionId integration', () => {
     await waitForReplayLoadToSettle();
     await user.click(screen.getByText('← 一覧'));
     expect(onBack).toHaveBeenCalledOnce();
+  });
+});
+
+describe('FeedItem: public mode hides spectator-only events (AC3 / #314)', () => {
+  it.each([
+    ['inspection', { event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf', is_public: false }],
+    ['guard', { event_type: 'guard', agent: 'Carol', target: 'Alice', content: 'Carol guards Alice', is_public: false }],
+    ['medium_result', { event_type: 'medium_result', agent: 'Alice', target: 'Bob', content: 'Alice senses: Bob was Werewolf', is_public: false }],
+    ['wolf_chat', { event_type: 'wolf_chat', agent: 'Bob', content: 'Attack Alice tonight.', is_public: false }],
+  ])('hides %s entirely in public mode', (_type, event) => {
+    /*
+     * SUT: FeedItem
+     * Mock: なし
+     * Level: unit
+     * Objective: public モードで spectator 限定イベント（inspection/guard/medium_result/wolf_chat）が完全非表示になることを検証する（AC3 / #314）。
+     */
+    const { container } = render(
+      <FeedItem ev={event} prevById={{}} roleAssignment={roleAssignment} title="Test" viewerMode="public" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows inspection in spectator mode', () => {
+    /*
+     * SUT: FeedItem
+     * Mock: なし
+     * Level: unit
+     * Objective: spectator モードでは inspection が表示されることを検証する（対比用）。
+     */
+    render(
+      <FeedItem
+        ev={{ event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf', is_public: false }}
+        prevById={{}} roleAssignment={roleAssignment} title="Test" viewerMode="spectator"
+      />
+    );
+    expect(screen.getByText(/Alice inspects Bob: Werewolf/)).toBeTruthy();
+  });
+});
+
+describe('SpeechCard: viewerMode public (AC2 / #314)', () => {
+  function renderSpeechCard(viewerMode = 'spectator') {
+    const ev = {
+      day: 1,
+      event_type: 'speech',
+      agent: 'Alice',
+      target: null,
+      content: 'こんにちは',
+      speech_id: 1,
+      reply_to: null,
+      claimed_role: null,
+      reasoning: null,
+      is_public: true,
+    };
+    return render(
+      <FeedItem
+        ev={ev}
+        prevById={{}}
+        roleAssignment={roleAssignment}
+        title="Test Village"
+        viewerMode={viewerMode}
+      />
+    );
+  }
+
+  it('shows role tag in spectator mode', () => {
+    /*
+     * SUT: FeedItem → SpeechCard
+     * Mock: なし
+     * Level: unit
+     * Objective: spectator モードで発言カードに真の役職タグが表示されることを検証する（#314）。
+     */
+    renderSpeechCard('spectator');
+    expect(document.querySelectorAll('[class*="roleTag"]').length).toBeGreaterThan(0);
+  });
+
+  it('hides role tag in public mode (AC2)', () => {
+    /*
+     * SUT: FeedItem → SpeechCard
+     * Mock: なし
+     * Level: unit
+     * Objective: public モードで発言カードの役職タグが非表示になることを検証する（AC2 / #314）。
+     */
+    renderSpeechCard('public');
+    expect(document.querySelectorAll('[class*="roleTag"]').length).toBe(0);
+  });
+
+  it.each(['spectator', 'public'])('shows CO badge with coBadge class in %s mode', (mode) => {
+    /*
+     * SUT: FeedItem → SpeechCard
+     * Mock: なし
+     * Level: unit
+     * Objective: spectator / public 両モードで CO バッジが coBadge クラスで表示されることを検証する（#314 / #417）。
+     */
+    const ev = {
+      day: 1,
+      event_type: 'speech',
+      agent: 'Alice',
+      content: 'こんにちは',
+      speech_id: 1,
+      reply_to: null,
+      claimed_role: 'Seer',
+      reasoning: null,
+      is_public: true,
+    };
+    const { container } = render(
+      <FeedItem ev={ev} prevById={{}} roleAssignment={roleAssignment} title="Test" viewerMode={mode} />
+    );
+    const badge = container.querySelector('[class*="coBadge"]');
+    expect(badge).toBeTruthy();
+    expect(badge.className).toMatch(/coBadge/);
+  });
+});
+
+describe('ThoughtDetails: viewerMode public (AC4 / #314)', () => {
+  function renderWithReasoning(viewerMode = 'spectator') {
+    const ev = {
+      day: 1,
+      event_type: 'speech',
+      agent: 'Alice',
+      content: 'こんにちは',
+      speech_id: 1,
+      reply_to: null,
+      claimed_role: null,
+      reasoning: '村人として最適な行動を選ぶ。',
+      is_public: true,
+    };
+    return render(
+      <FeedItem
+        ev={ev}
+        prevById={{}}
+        roleAssignment={roleAssignment}
+        title="Test Village"
+        viewerMode={viewerMode}
+      />
+    );
+  }
+
+  it('shows expandable thought details in spectator mode', () => {
+    /*
+     * SUT: FeedItem → SpeechCard → ThoughtDetails
+     * Mock: なし
+     * Level: unit
+     * Objective: spectator モードで思考ログが <details> として展開可能であることを検証する（#314）。
+     */
+    const { container } = renderWithReasoning('spectator');
+    expect(container.querySelector('details')).toBeTruthy();
+    expect(screen.getByText(/思考ログを読む/)).toBeTruthy();
+  });
+
+  it('shows lock badge instead of expandable details in public mode (AC4)', () => {
+    /*
+     * SUT: FeedItem → SpeechCard → ThoughtDetails
+     * Mock: なし
+     * Level: unit
+     * Objective: public モードで思考ログが <details> でなくロックバッジに切り替わることを検証する（AC4 / #314）。
+     */
+    const { container } = renderWithReasoning('public');
+    expect(container.querySelector('details')).toBeNull();
+    expect(screen.getByText(/🔒/)).toBeTruthy();
+  });
+});
+
+describe('SpectatorScreen: viewerMode toggle (AC1 / #314)', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('toggles between spectator and public mode on header button click (AC1)', async () => {
+    /*
+     * SUT: SpectatorScreen (default export)
+     * Mock: fetchReplayLog / fetchReplayAgents を vi.fn()
+     * Level: integration
+     * Objective: ヘッダーのトグルボタンクリックで spectator / public が切り替わることを検証する（AC1 / #314）。
+     */
+    replayLoader.fetchReplayLog.mockResolvedValue('');
+    replayLoader.fetchReplayAgents.mockResolvedValue({});
+    const user = userEvent.setup();
+
+    render(<SpectatorScreen sessionId="test-session-001" cast={[]} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/読み込み中/)).toBeNull();
+    }, { timeout: 3000 });
+
+    // Initially in spectator mode
+    expect(screen.getByText(/観戦者モード/)).toBeTruthy();
+
+    // Click to switch to public mode
+    await user.click(screen.getByText(/観戦者モード/));
+    expect(screen.getByText(/参加者視点/)).toBeTruthy();
+
+    // Click again to switch back
+    await user.click(screen.getByText(/参加者視点/));
+    expect(screen.getByText(/観戦者モード/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- SpectatorScreen ヘッダーに観戦者モード/参加者視点トグルボタンを追加
- public モードでは真の役職タグ・Avatar 役職刻印を非表示にする（FeedItem・RightPane）
- public モードでは思考ログを 🔒 ロックバッジに差し替え（ThoughtDetails・WolfChatCard・SystemRow）
- public モードでは spectator 限定イベント（wolf_chat/inspection/guard/medium_result）と is_public=false イベントを完全非表示
- 不要になった coBadgeNeutral CSS クラスを削除し、CO バッジは coBadge に統一
- FrontendDesign.md に viewerMode モード別表示仕様テーブルを追記

## Implementation notes
- `SPECTATOR_ONLY_EVENTS` Set を定数として定義し FeedItem 先頭でフィルタ
- viewerMode は SpectatorScreen → FeedItem → SpeechCard/WolfChatCard/SystemRow/ThoughtDetails へ prop drilling
- renderConfiguredSystemEvent にも viewerMode を追加し SystemRow へ伝播
- co_announcement イベントが FeedItem で表示されない問題（#417）は別 Issue として分離

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス
- [x] Vitest: 139 テスト GREEN（AC1〜AC4 対応テスト追加済み）
- [x] Playwright ブラウザ動作確認済み（トグル前後の役職タグ・思考ログ・spectator 限定イベント）

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)