### PR TITLE
docs: design new LogEvent schema for mixed public/private fields (#344)

### DIFF
--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -106,6 +106,52 @@ spectator.py がログを書き出す  →  state_archive/{session}/
 `src/ui/api.py` を追加して WebSocket でイベントをリアルタイム配信する。
 `src/ui/cli.py` / `src/ui/renderer.py` には触れない。
 
+### 2.4 LogEvent — イベントスキーマと表示制御の3軸
+
+`LogEvent`（`src/domain/event.py`）は `GameEngine`（producer）と
+`Renderer` / `ReplayPager` / `LogWriter` / JS `parseGameData`（consumers）の間で
+やり取りされる唯一の契約型である。`spectator_log.jsonl` に1行1イベントで記録される。
+
+#### EventType 一覧
+
+| event_type | 概要 | is_public 既定 | reasoning | spectator_content |
+|---|---|---|---|---|
+| `speech` | 昼の発言。`claimed_role` 付きなら CO を兼ねる | true | ✅ 思考 | — |
+| `wolf_chat` | 夜の狼チーム会話 | false | ✅ 思考 | — |
+| `vote` | 投票 | true | ✅ 理由 | — |
+| `judgment` | 占い師の判定 | true | ✅ 理由 | — |
+| `inspection` | 占い結果 | false | ✅ 理由 | — |
+| `guard` | 騎士の護衛 | false | ✅ 理由 | — |
+| `guard_block` | 護衛成功の通知（観戦者は守護者を明示、公開版は伏せる） | — | — | ✅ 文面択一 |
+| `night_attack` | 狼の襲撃 | 通知=true / 実行=false | ✅ 理由 | — |
+| `pre_night_decision` | 夜前の判断 | false | ✅ 理由 | — |
+| `elimination` | 処刑・死亡 | true | — | — |
+| `medium_result` | 霊媒結果 | false | — | — |
+| `co_announcement` | （廃止予定）CO 告知。`speech` の `claimed_role` に統合する | true | — | — |
+| `suspicion_update` | 疑念スコア更新 | false | — | — |
+| `threat_update` | 脅威スコア更新 | false | — | — |
+| `game_over` | 決着 | true | — | — |
+| `phase_start` | フェーズ開始マーカー | true | — | — |
+
+#### 表示制御の3軸
+
+`LogEvent` の公開/非公開・viewerMode 制御は**直交する3つの軸**で表現する。
+これらを混同しないことが設計の要点である。
+
+| 軸 | フィールド | 意味 |
+|---|---|---|
+| **イベント全体の公開可否** | `is_public` | `false` のイベントは public モードで非表示。イベント単位の on/off（vote 内訳・wolf_chat・inspection 等） |
+| **viewerMode 別の文面択一** | `content` / `spectator_content` | 同一イベントを viewerMode で**文面切替**する。「非表示」ではなく「択一」。`spectator_content` が空なら両モードとも `content` を使う（guard_block 等） |
+| **思考の付帯情報** | `reasoning` | `content` とは独立した、**常に spectator 限定**の思考・理由。`is_public` とは無関係に spectator のみ表示 |
+
+加えて `claimed_role`（CO 情報）は `speech` イベントに付随させ、別イベント化しない。
+CO の告知文は consumer 側が `claimed_role` から生成する。
+
+> **後方互換**: 旧ログには CO が `co_announcement` 別行、思考が `[THINK]` プレフィックス付きの
+> 非公開行として記録されている。emit 側は新スキーマのみを出力するが、read 側（CLI renderer /
+> JS parser）は旧形式を解釈できる**読み取りフォールバック**を残し、過去ログの replay を壊さない。
+> 旧 `[THINK]` 行の reasoning は新コードでも復元されるが、復元できなくても許容する方針。
+
 ### 2.3 LLM出力は構造化して受け取る
 
 LLMの出力は自然文のパースに頼らず、常にPydanticモデルで検証する。
@@ -370,3 +416,41 @@ Contract test: `tests/contract/test_day_phase_contract.py`
 
 **結果・トレードオフ**
 発言順が実行ごとに変わる（非決定論的だが意図的）。全員silentのケースに備えてフォールバックが必要。
+
+---
+
+### ADR-005: LogEvent で公開/非公開の混在と viewerMode 別文面を表現する
+
+**状況**
+`LogEvent` は `is_public` で行単位の公開/非公開を制御するため、1イベント内に
+公開フィールドと非公開フィールドを混在させられなかった。この制約を回避するため、
+3つのハックが分散して存在していた:
+
+1. **思考の混在**: `speech` / `wolf_chat` の思考を `content="[THINK] ..."` の
+   非公開別イベントとして emit し、CLI renderer・JS parser が文字列パースで結合していた。
+2. **viewerMode 別文面**: `guard_block` を spectator 版・public 版の2イベントとして
+   別々に emit し、`is_public` フィルタで出し分けていた（本来は「択一」であり「非表示」ではない）。
+3. **CO の二重化**: `co_announcement` を `speech` と別イベントとして emit し、
+   同一の発言行動が2イベントに分裂していた。
+
+**決定**
+表示制御を直交する3軸（`is_public` / `content`+`spectator_content` / `reasoning`）に整理し、
+上記ハックを廃止する（§2.4 参照）。
+
+- 思考は `reasoning` フィールドに載せる（`[THINK]` 別イベント廃止）
+- viewerMode 別文面は `spectator_content` フィールドで表現する（`guard_block` の2イベント emit 廃止）
+- CO は `speech` の `claimed_role` に統合する（`co_announcement` 廃止、告知文は consumer 生成）
+
+**実装方法**
+スキーマ＋emit 側（Issue A）→ CLI renderer 移行（Issue B）∥ JS parser 移行（Issue C）の
+順で分割実装する。read 側に旧形式の読み取りフォールバックを残すため、A 単独マージでも
+旧 consumer はクラッシュせず劣化表示に留まり、各段階で壊れない。
+
+**理由**
+- 3軸の意味論が直交し、新イベント追加時に「どの軸で制御するか」が一意に決まる
+- consumer から `[THINK]` 文字列パース・co_announcement 別処理・guard_block の2イベント前提が消える
+- CO バッジ表示（#417）が `speech.claimed_role` を直接参照でき、別イベント追跡が不要になる
+
+**結果・トレードオフ**
+過去ログ（旧形式）の replay は読み取りフォールバックで維持するが、フォールバックコードが
+read 側に残る。旧 `[THINK]` の reasoning は復元を試みるが、復元失敗は許容する。

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -465,9 +465,13 @@ parseGameData(jsonlText, agentJsonByName)
 現在は `spectator_log.jsonl` 全体を一括 fetch して行単位に JSON parse する。
 ログ量が増えた場合の変更ポイントは `replayLoader.js` に閉じ、day chunk、cursor pagination、ReadableStream JSONL parser、または FastAPI endpoint に置き換える。
 
-`spectator_log.jsonl` の非公開 `[THINK]` 行は、`parseGameData.js` の Legacy-adapter で表示イベントの `thought` に結合する。
-speech は同じ `day` / `agent` / `speech_id` を持つ公開 speech に結合する。
-wolf_chat は現行ログに `speech_id` がないため、同じ `day` / `agent` の直近 wolf_chat に結合する暫定互換処理とする。
+`speech` / `wolf_chat` の思考は、イベント自身の `reasoning` フィールドに格納する
+（Architecture.md §2.4 の3軸を参照）。`parseGameData.js` は `event.reasoning` を直接読むだけでよい。
+
+旧ログ（思考を `content="[THINK] ..."` の非公開別イベントとして記録した形式）に対しては、
+read 側に**読み取りフォールバック**を残す: `content` が `[THINK]` で始まる非公開 speech/wolf_chat 行を、
+同じ `day` / `agent` / `speech_id`（wolf_chat は `speech_id` がないため `day` / `agent` の直近行）の
+表示イベントの `reasoning` に結合する。新規 emit ではこの形式を一切出力しない。
 
 ### viewerMode — spectator / public
 
@@ -478,8 +482,18 @@ wolf_chat は現行ログに `speech_id` がないため、同じ `day` / `agent
 | 役職タグ | 真の役職を常時表示 | 未CO は「役職不明」 |
 | 偽CO バッジ | 赤＋「偽」マーク | 中立色 |
 | 思考ログピル | 展開可 | ロックバッジ（存在のみ示す） |
+| 文面択一（`spectator_content`） | `spectator_content` を表示 | `content` を表示 |
 
-`spectator_log.jsonl` を読み込み、public モードでは `is_public=true` のイベントのみを表示し、spectator モードでは全イベントを表示することで対応する。
+イベントの公開範囲は3軸で制御する（Architecture.md §2.4）:
+
+- **`is_public=false` のイベント**: public モードで非表示、spectator モードで表示
+- **`spectator_content` を持つイベント**（`guard_block` 等）: spectator は `spectator_content`、
+  public は `content` を表示する（イベントは1つ、文面を択一）
+- **`reasoning`**: viewerMode が spectator のときのみ思考ログとして表示
+
+CO 表示は `speech` イベントの `claimed_role` から consumer 側で生成する
+（`co_announcement` 別イベントには依存しない）。旧ログの `co_announcement` 別行に対しては
+read 側フォールバックで従来表示を維持する。
 
 ### replay.py — クラス構成
 

--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -112,7 +112,7 @@ const [screen, setScreen] = useState('list');
 | 関数 | 目的 | 入力 | 出力 | `is_public` の扱い |
 |---|---|---|---|---|
 | `aggregateDaySummary` | 日別タイムライン・右ペイン表示に必要なサマリを単一ソースとして作る。旧 `aggregateDayResults` と `aggregateDayActions` の責務を統合する | raw `LogEvent[]` | `{ [day]: { speechCount, nightDone, nightActions, execResult } }` | private `night_attack` は `nightActions` に含める。public `night_attack` は夜明け結果の公知イベントなので `nightActions` には入れず、`nightDone` 判定だけに使う。public `elimination` は `execResult.target` に使う |
-| `aggregateCoStatus` | CO 状況を agent 名から claimed role へ引く map にする。日別表示では `upToDay` までを累積する | normalized `LogEvent[]`, optional `upToDay` | `{ [agentName]: claimed_role }` | `co_announcement` は公開発言として扱う。現状は `is_public` でフィルタせず、`event_type` / `agent` / `claimed_role` を正とする |
+| `aggregateCoStatus` | CO 状況を agent 名から claimed role へ引く map にする。日別表示では `upToDay` までを累積する | normalized `LogEvent[]`, optional `upToDay` | `{ [agentName]: claimed_role }` | `speech` イベントの `claimed_role` を正とする（CO は speech に統合）。旧ログの `co_announcement` 別行は read 側フォールバックで同様に扱う。`is_public` でフィルタしない |
 | `aggregateNightResults` | private 夜襲ログから日別の襲撃先を取り出す。後方互換の派生データ | raw `LogEvent[]` | `{ [day]: { attacked } }` | private `night_attack` の `target` のみ使う。public `night_attack` はログ生成側の agent/target 揺れを避けるため無視する |
 | `computeDeadByDay` | 各日終了時点の累積死亡者 map を作る | raw または normalized `LogEvent[]` | `{ [day]: Map<agentName, { day, content }> }` | `elimination` は死亡として扱う。private `night_attack` は死亡候補として扱い、同日同 target の private `guard_block` があれば除外する。public `night_attack` は使わない |
 | `buildActionsTimeline` | 夜行動・処刑を横断的なアクション履歴に平坦化する | raw `LogEvent[]` | `[{ day, when, kind, who, target, label }]` | private `night_attack` は人狼視点の行動として含める。public `night_attack` は村への結果告知なので除外する。public `elimination` は処刑アクションとして含める |
@@ -518,7 +518,7 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 
 | activePhase | 表示するイベント種別 |
 |---|---|
-| `'discuss'` | `speech`（public）, `phase_start`（TURN系）, `co_announcement` |
+| `'discuss'` | `speech`（public、`claimed_role` 付きは CO を兼ねる）, `phase_start`（TURN系）。旧ログの `co_announcement` 別行はフォールバックで表示 |
 | `'vote'` | `vote`, `elimination`, `medium_result`, `phase_start`（VOTE系） |
 | `'night'` | `wolf_chat`, `inspection`, `guard`, `guard_block`, `night_attack`, `phase_start`（NIGHT / NIGHT_WOLF_CHAT 系） |
 

--- a/doc/GameData.md
+++ b/doc/GameData.md
@@ -77,8 +77,8 @@ Milestone 3（FastAPI / DB 導入後）に改めて対応方針を検討する�
 
 | フィールド | 用途 | 現状 | 対応方針 |
 |---|---|---|---|
-| `thought` | 発言前の思考ログ（spectator限定表示） | ✅ `spectator_log.jsonl` に `is_public=false` + `content: "[THINK] ..."` の speech 行として存在。`parseGameData.js` が同じ `day/agent/speech_id` の公開 speech に結合して `thought` プロパティを生成 | ✅ 実装済み（スタブ不要） |
-| `claimed_role` | CO（カミングアウト）フラグ | ✅ `spectator_log.jsonl` の speech 行・co_announcement 行に存在 | ✅ 実装済み（スタブ不要） |
+| `reasoning` | 発言前の思考ログ（spectator限定表示） | ✅ `spectator_log.jsonl` の speech / wolf_chat 行の `reasoning` フィールドに格納（Architecture.md §2.4）。`parseGameData.js` は `event.reasoning` を直接読む。旧ログの `[THINK]` 別行は read 側フォールバックで結合 | ✅ 実装済み（スタブ不要） |
+| `claimed_role` | CO（カミングアウト）フラグ | ✅ `spectator_log.jsonl` の speech 行に存在（CO は speech に統合。`co_announcement` 別イベントは廃止予定、旧ログのみフォールバックで対応） | ✅ 実装済み（スタブ不要） |
 | `reply_to` | 返信先 speech_id | ✅ `spectator_log.jsonl` の speech 行に存在（返信なし時は `null`） | ✅ 実装済み（スタブ不要） |
 | `speech_id` | 発言の連番ID（日内） | ✅ `spectator_log.jsonl` の speech 行に存在 | ✅ 実装済み（スタブ不要） |
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,11 +19,13 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
+| yukkie/AgentVillage#420 | tech-debt | 🔴 | — | refactor(backend): adopt new LogEvent schema for mixed public/private fields | spectator_content 追加・思考の reasoning 化・guard_block 統合・CO の speech 統合（emit 側）。#344 の設計に基づく |
+| yukkie/AgentVillage#421 | tech-debt | 🔴 | — | refactor(cli): migrate renderer.py to new LogEvent schema | renderer.py を reasoning / spectator_content / claimed_role 参照に移行。旧ログフォールバック維持。依存: #420 |
+| yukkie/AgentVillage#422 | tech-debt | 🔴 | — | refactor(frontend): migrate parseGameData.js off [THINK]/co_announcement hacks | parseGameData の legacy-adapter 削除・文面択一・CO 別処理削除。旧ログフォールバック維持。依存: #420 |
 | yukkie/AgentVillage#417 | bug | ❌ | — | CO badge style ignores viewerMode; false-CO detection not implemented | CO バッジのスタイルが viewerMode を無視、偽CO判定未実装。両モードでスタイル統一し spectator モードのみ偽COマークを付ける|
 | yukkie/AgentVillage#415 | tech-debt | ❌ | — | docs: introduce DataSpec.md | UI非依存のデータ定義（EventType・可視性ルール・ログスキーマ）を DataSpec.md に集約し、Spec.md §5・DetailDesign.md・flow-js.md から参照する。依存: #344|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |
-| yukkie/AgentVillage#344 | tech-debt | 🔴 | 3 | Design: LogEvent cannot express mixed public/private fields in a single speech event | speech イベントの公開/非公開混在問題の設計を定め Architecture.md に記載、[THINK] ハックを廃止する設計Issueを作る |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |


### PR DESCRIPTION
## Summary
- LogEvent の公開/非公開混在問題の設計を定義（#344）
- 表示制御を直交3軸（is_public / content+spectator_content / reasoning）に整理し、Architecture.md §2.4（EventType 一覧）+ ADR-005 として記載
- `[THINK]` ハック・co_announcement 二重化・guard_block 2イベントを廃止する設計に更新（DetailDesign.md / GameData.md / FrontendDesign.md）
- 実装を3分割した Issue を作成: #420 backend / #421 CLI renderer / #422 frontend（CLI renderer の見落としを踏まえ backend/frontend の2分割から3分割に）

## Implementation notes
- 後方互換: emit は新スキーマのみ、read 側に旧 `[THINK]`/co_announcement の読み取りフォールバックを残す方針を設計に明記
- CO（claimed_role）は speech に統合。CO バッジ見た目・偽CO判定は #417 の担当として分離

## Test plan
- [x] `ruff check .` パス（docs のみ変更、コード変更なし）
- [x] 設計内容が Architecture.md / DetailDesign.md に記載されている（AC 1, 2）
- [x] backend / frontend 実装 Issue が作成されている（AC 3, 4）

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)