### PR TITLE
docs: add dev-tool ideas to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -65,6 +65,8 @@
 | yukkie/AgentVillage#315 | enhancement | 🟢 | 8 | FastAPI + WebSocket backend | リアルタイムストリーミング（Milestone 2 完了後） |
 | yukkie/AgentVillage#316 | enhancement | 🟢 | 13 | Mobile app (React Native) | iOS/Android 対応（#315 完了後） |
 | yukkie/AgentVillage#30 | enhancement | 🟢 | 13 | State management DB migration | JSON → DB 移行 |
+| yukkie/AgentVillage#424 | enhancement | ❌ | — | Dev tool (1/2): AST-based relationship extraction for a central data type | 中心データ型を起点に producer/consumer/transform を AST で全列挙し隣接リスト出力。idd 事前調査から参照。汎用ツール（LogEvent は検証例） |
+| yukkie/AgentVillage#425 | enhancement | ❌ | — | Dev tool (2/2): smell evaluation over the extracted relationship graph | 抽出グラフ上で transform スメルを定義基準で分類・淀み度集計。依存: #424 |
 
 ---
 


### PR DESCRIPTION
## Summary
- 開発支援ツールの2段階アイデアを Ideas.md の将来フェーズに追記
  - 第一段階: 中心データ型を起点に AST で producer/consumer/transform を全列挙し隣接リスト出力
  - 第二段階: 抽出グラフ上で transform スメルを定義基準で分類・淀み度集計

## Background
横断的なスキーマ変更で producer/consumer を手作業 grep で追うと見落としが起きる（実例あり）。AST で関係を客観抽出し、その上でスメルを定義済み基準で評価する2段階ツールの構想。idd 事前調査ステップから参照する想定。汎用ツールとして任意の中心データ型に適用できる設計。

🤖 Generated with [Claude Code](https://claude.com/claude-code)