### PR TITLE
refactor(backend): adopt new LogEvent schema (#420)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,7 +19,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#420 | tech-debt | 🔴 | — | refactor(backend): adopt new LogEvent schema for mixed public/private fields | spectator_content 追加・思考の reasoning 化・guard_block 統合・CO の speech 統合（emit 側）。#344 の設計に基づく |
 | yukkie/AgentVillage#421 | tech-debt | 🔴 | — | refactor(cli): migrate renderer.py to new LogEvent schema | renderer.py を reasoning / spectator_content / claimed_role 参照に移行。旧ログフォールバック維持。依存: #420 |
 | yukkie/AgentVillage#422 | tech-debt | 🔴 | — | refactor(frontend): migrate parseGameData.js off [THINK]/co_announcement hacks | parseGameData の legacy-adapter 削除・文面択一・CO 別処理削除。旧ログフォールバック維持。依存: #420 |
 | yukkie/AgentVillage#417 | bug | ❌ | — | CO badge style ignores viewerMode; false-CO detection not implemented | CO バッジのスタイルが viewerMode を無視、偽CO判定未実装。両モードでスタイル統一し spectator モードのみ偽COマークを付ける|

--- a/src/domain/event.py
+++ b/src/domain/event.py
@@ -52,6 +52,7 @@ class LogEvent(BaseModel):
     inspection_role: RoleField = None
     reasoning: str = ""
     decision: str = ""
+    spectator_content: str = ""
 
     @classmethod
     def make(
@@ -69,6 +70,7 @@ class LogEvent(BaseModel):
         inspection_role: RoleField = None,
         reasoning: str = "",
         decision: str = "",
+        spectator_content: str = "",
     ) -> "LogEvent":
         return cls(
             day=day,
@@ -84,4 +86,5 @@ class LogEvent(BaseModel):
             inspection_role=inspection_role,
             reasoning=reasoning,
             decision=decision,
+            spectator_content=spectator_content,
         )

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -195,21 +195,11 @@ class GameEngine:
                 None,
             )
 
-        if isinstance(result, CoResult):
-            claim_role = result.claim_role
-            if actor.state.claimed_role != claim_role:
-                actor.state.claimed_role = claim_role
-                actor.state.intended_co = None
-                store.save(actor)
-                self._emit(LogEvent.make(
-                    day=self.day,
-                    phase=phase.value,
-                    event_type=EventType.CO_ANNOUNCEMENT,
-                    agent=actor.name,
-                    content=f"{actor.name} claims to be {claim_role.name}",
-                    is_public=True,
-                    claimed_role=claim_role,
-                ))
+        claim_role = result.claim_role if isinstance(result, CoResult) else None
+        if isinstance(result, CoResult) and actor.state.claimed_role != claim_role:
+            actor.state.claimed_role = claim_role
+            actor.state.intended_co = None
+            store.save(actor)
 
         speech_id = self._next_speech_id()
         entry = SpeechEntry(speech_id=speech_id, agent=actor.name, text=result.speech)
@@ -224,15 +214,8 @@ class GameEngine:
             is_public=True,
             speech_id=speech_id,
             reply_to=reply_to_entry.speech_id if reply_to_entry else None,
-        ))
-        self._emit(LogEvent.make(
-            day=self.day,
-            phase=phase.value,
-            event_type=EventType.SPEECH,
-            agent=actor.name,
-            content=f"[THINK] {result.thought}",
-            is_public=False,
-            speech_id=speech_id,
+            claimed_role=claim_role,
+            reasoning=result.thought,
         ))
 
         if result.suspicion_scores:

--- a/src/engine/phase_night.py
+++ b/src/engine/phase_night.py
@@ -123,14 +123,7 @@ def _run_wolf_chat(engine: GameEngine) -> str | None:
                 agent=wolf.name,
                 content=f"{wolf.name}: {output.speech}",
                 is_public=False,
-            ))
-            engine._emit(LogEvent.make(
-                day=engine.day,
-                phase=Phase.NIGHT_WOLF_CHAT.value,
-                event_type=EventType.WOLF_CHAT,
-                agent=wolf.name,
-                content=f"[THINK] {output.thought}",
-                is_public=False,
+                reasoning=output.thought,
             ))
 
     _apply_wolf_self_decisions(engine, wolves, last_wolf_outputs)
@@ -318,14 +311,8 @@ def _publish_night_results(engine: GameEngine, resolution: NightResolution) -> N
             phase=Phase.NIGHT.value,
             event_type=EventType.GUARD_BLOCK,
             target=resolution.attack.target,
-            content=f"{resolution.attack.target} was protected by the Knight! The attack was blocked.",
-            is_public=False,
-        ))
-        engine._emit(LogEvent.make(
-            day=engine.day,
-            phase=Phase.NIGHT.value,
-            event_type=EventType.GUARD_BLOCK,
             content="The village woke up to find everyone safe. The werewolves' attack seems to have failed.",
+            spectator_content=f"{resolution.attack.target} was protected by the Knight! The attack was blocked.",
             is_public=True,
         ))
         memory_mod.update_memory(

--- a/tests/contract/test_day_phase_contract.py
+++ b/tests/contract/test_day_phase_contract.py
@@ -337,3 +337,57 @@ class TestIntendedCoLifecycleContract:
         assert wolf.state.intended_co is None
         assert wolf.state.claimed_role is not None
         assert wolf.state.claimed_role.name == "Seer"
+
+
+class TestSpeechThinkHackContract:
+    def test_speech_thought_in_reasoning_field(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result()
+        Mock: call_discussion_parallel returns SpeakResult with a specific thought
+        Level: contract
+        Objective: speech の thought が SPEECH イベントの reasoning フィールドに格納され、
+                   speech ごとに1つの公開イベントのみ emit される契約を検証する（新スキーマ）。
+        """
+        actor = make_test_actor("Alice")
+        other = make_test_actor("Bob")
+        engine, emitted = make_test_engine([actor, other])
+
+        engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
+            (actor, SpeakResult(thought="inner monologue", speech="Hello everyone")),
+            (other, SilentResult(reasoning="quiet")),
+        ])
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        speech_events = [
+            e for e in emitted
+            if e.event_type == EventType.SPEECH and e.agent == "Alice" and e.is_public
+        ]
+        assert len(speech_events) >= 1
+        assert all(e.reasoning == "inner monologue" for e in speech_events)
+
+    def test_speech_does_not_emit_think_hack_events(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result()
+        Mock: call_discussion_parallel returns SpeakResult with a thought string
+        Level: contract
+        Objective: [THINK] プレフィックスの別 SPEECH イベントが emit されない契約を検証する（ハック廃止）。
+        """
+        actor = make_test_actor("Alice")
+        other = make_test_actor("Bob")
+        engine, emitted = make_test_engine([actor, other])
+
+        engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
+            (actor, SpeakResult(thought="inner monologue", speech="Hello everyone")),
+            (other, SilentResult(reasoning="quiet")),
+        ])
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        think_events = [
+            e for e in emitted
+            if e.event_type == EventType.SPEECH and "[THINK]" in e.content
+        ]
+        assert len(think_events) == 0

--- a/tests/contract/test_night_phase_contract.py
+++ b/tests/contract/test_night_phase_contract.py
@@ -257,12 +257,13 @@ class TestWolfChatContract:
         assert wolf1.state.intended_co.name == "Seer"
         assert wolf2.state.intended_co is None
 
-    def test_wolf_chat_emits_thought_as_non_public_event(self, make_test_actor, make_test_engine):
+    def test_wolf_chat_thought_in_reasoning_field(self, make_test_actor, make_test_engine):
         """
         SUT: _run_wolf_chat()
         Mock: call_wolf_chat returns WolfChatOutput with a specific thought string
         Level: contract
-        Objective: wolf chat の thought が is_public=False の WOLF_CHAT イベントとして emit される契約を検証する。
+        Objective: wolf chat の thought が WOLF_CHAT イベントの reasoning フィールドに格納され、
+                   speech ごとに1イベントのみ emit される契約を検証する（新スキーマ）。
         """
         from src.domain.schema import WolfChatOutput
         from src.engine.phase_night import _run_wolf_chat
@@ -282,9 +283,37 @@ class TestWolfChatContract:
         with patch("src.engine.phase_night.store.save"):
             _run_wolf_chat(engine)
 
-        thought_events = [
+        wolf_chat_events = [e for e in emitted if e.event_type == EventType.WOLF_CHAT]
+        assert len(wolf_chat_events) == 2  # one per wolf, no extra [THINK] events
+        assert all(e.reasoning == "secret plan" for e in wolf_chat_events)
+
+    def test_wolf_chat_does_not_emit_think_hack_events(self, make_test_actor, make_test_engine):
+        """
+        SUT: _run_wolf_chat()
+        Mock: call_wolf_chat returns WolfChatOutput with a thought string
+        Level: contract
+        Objective: [THINK] プレフィックスの別 WOLF_CHAT イベントが emit されない契約を検証する（ハック廃止）。
+        """
+        from src.domain.schema import WolfChatOutput
+        from src.engine.phase_night import _run_wolf_chat
+
+        wolf1 = make_test_actor("Wolf1", "Werewolf")
+        wolf2 = make_test_actor("Wolf2", "Werewolf")
+        villager = make_test_actor("Alice")
+        engine, emitted = make_test_engine([wolf1, wolf2, villager])
+        engine._wolf_chat_rounds = 1
+
+        engine._llm_client.call_wolf_chat.return_value = WolfChatOutput(
+            thought="secret plan",
+            speech="let's attack Alice",
+            attack_candidates={"Alice": 0.9},
+        )
+
+        with patch("src.engine.phase_night.store.save"):
+            _run_wolf_chat(engine)
+
+        think_events = [
             e for e in emitted
-            if not e.is_public and "[THINK]" in e.content and e.event_type == EventType.WOLF_CHAT
+            if e.event_type == EventType.WOLF_CHAT and "[THINK]" in e.content
         ]
-        assert len(thought_events) == 2  # one per wolf
-        assert all("secret plan" in e.content for e in thought_events)
+        assert len(think_events) == 0

--- a/tests/unit/test_phase_night.py
+++ b/tests/unit/test_phase_night.py
@@ -61,7 +61,7 @@ class TestRunWolfChat:
 
         assert result == "Alice"
         wolf_chat_events = [e for e in events if e.event_type == EventType.WOLF_CHAT]
-        assert len(wolf_chat_events) == 4  # speech + thought per wolf per round
+        assert len(wolf_chat_events) == 2  # one per wolf per round
 
     def test_multi_wolf_chat_empty_candidates_returns_none(self, make_test_actor, make_test_engine):
         """
@@ -201,12 +201,13 @@ class TestResolveNightOutcomes:
 
 
 class TestPublishNightResults:
-    def test_guard_block_emits_private_and_public_events(self, make_test_actor, make_test_engine):
+    def test_guard_block_emits_single_public_event_with_spectator_content(self, make_test_actor, make_test_engine):
         """
         SUT: _publish_night_results
         Mock: memory_mod.update_memory — メモリ更新のファイルI/Oを回避
         Level: unit
-        Objective: ガードブロック成功時に非公開と公開の GUARD_BLOCK イベントが各1件 emit されること。
+        Objective: ガードブロック成功時に is_public=True の GUARD_BLOCK イベントが1件 emit され、
+                   spectator_content に観戦者向け詳細が含まれること（新スキーマ）。
         """
         wolf = make_test_actor("Wolf1", "Werewolf")
         knight = make_test_actor("Knight1", "Knight")
@@ -221,11 +222,11 @@ class TestPublishNightResults:
             _publish_night_results(engine, resolution)
 
         guard_block_events = [e for e in events if e.event_type == EventType.GUARD_BLOCK]
-        assert len(guard_block_events) == 2
-        private_events = [e for e in guard_block_events if not e.is_public]
-        public_events = [e for e in guard_block_events if e.is_public]
-        assert len(private_events) == 1
-        assert len(public_events) == 1
+        assert len(guard_block_events) == 1
+        ev = guard_block_events[0]
+        assert ev.is_public is True
+        assert "Alice" in ev.spectator_content
+        assert "Knight" in ev.spectator_content
 
     def test_guard_block_updates_knight_memory(self, make_test_actor, make_test_engine):
         """
@@ -344,7 +345,7 @@ class TestPublishNightResults:
         SUT: _publish_night_results
         Mock: memory_mod.update_memory — メモリ更新のファイルI/Oを回避
         Level: unit
-        Objective: 護衛成功時は private attack → private guard_block → public guard_block の順で emit されること。
+        Objective: 護衛成功時は private attack → public guard_block（1イベント）の順で emit されること（新スキーマ）。
         """
         wolf = make_test_actor("Wolf1", "Werewolf")
         knight = make_test_actor("Knight1", "Knight")
@@ -365,7 +366,6 @@ class TestPublishNightResults:
         ]
         assert night_events == [
             (EventType.NIGHT_ATTACK, False),
-            (EventType.GUARD_BLOCK, False),
             (EventType.GUARD_BLOCK, True),
         ]
 


### PR DESCRIPTION
## Summary
- `LogEvent` に `spectator_content` フィールドを追加
- `speech` / `wolf_chat` の `[THINK]` 別イベントを廃止し、`reasoning` フィールドに統合
- `guard_block` の2イベント emit を1イベント（`is_public=True` + `spectator_content`）に統合
- `co_announcement` 別イベントの emit を廃止し、`speech.claimed_role` で表現

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（367 passed）
- [ ] `[THINK]` ハック廃止の contract テスト（wolf_chat / speech 各2件）追加

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)