### PR TITLE
test: remove [THINK] regression tests

### DIFF
--- a/tests/contract/test_day_phase_contract.py
+++ b/tests/contract/test_day_phase_contract.py
@@ -366,28 +366,3 @@ class TestSpeechThinkHackContract:
         ]
         assert len(speech_events) >= 1
         assert all(e.reasoning == "inner monologue" for e in speech_events)
-
-    def test_speech_does_not_emit_think_hack_events(self, make_test_actor, make_test_engine):
-        """
-        SUT: GameEngine._apply_discussion_result()
-        Mock: call_discussion_parallel returns SpeakResult with a thought string
-        Level: contract
-        Objective: [THINK] プレフィックスの別 SPEECH イベントが emit されない契約を検証する（ハック廃止）。
-        """
-        actor = make_test_actor("Alice")
-        other = make_test_actor("Bob")
-        engine, emitted = make_test_engine([actor, other])
-
-        engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
-            (actor, SpeakResult(thought="inner monologue", speech="Hello everyone")),
-            (other, SilentResult(reasoning="quiet")),
-        ])
-
-        with patch("src.agent.store.save"):
-            engine._run_day()
-
-        think_events = [
-            e for e in emitted
-            if e.event_type == EventType.SPEECH and "[THINK]" in e.content
-        ]
-        assert len(think_events) == 0

--- a/tests/contract/test_night_phase_contract.py
+++ b/tests/contract/test_night_phase_contract.py
@@ -286,34 +286,3 @@ class TestWolfChatContract:
         wolf_chat_events = [e for e in emitted if e.event_type == EventType.WOLF_CHAT]
         assert len(wolf_chat_events) == 2  # one per wolf, no extra [THINK] events
         assert all(e.reasoning == "secret plan" for e in wolf_chat_events)
-
-    def test_wolf_chat_does_not_emit_think_hack_events(self, make_test_actor, make_test_engine):
-        """
-        SUT: _run_wolf_chat()
-        Mock: call_wolf_chat returns WolfChatOutput with a thought string
-        Level: contract
-        Objective: [THINK] プレフィックスの別 WOLF_CHAT イベントが emit されない契約を検証する（ハック廃止）。
-        """
-        from src.domain.schema import WolfChatOutput
-        from src.engine.phase_night import _run_wolf_chat
-
-        wolf1 = make_test_actor("Wolf1", "Werewolf")
-        wolf2 = make_test_actor("Wolf2", "Werewolf")
-        villager = make_test_actor("Alice")
-        engine, emitted = make_test_engine([wolf1, wolf2, villager])
-        engine._wolf_chat_rounds = 1
-
-        engine._llm_client.call_wolf_chat.return_value = WolfChatOutput(
-            thought="secret plan",
-            speech="let's attack Alice",
-            attack_candidates={"Alice": 0.9},
-        )
-
-        with patch("src.engine.phase_night.store.save"):
-            _run_wolf_chat(engine)
-
-        think_events = [
-            e for e in emitted
-            if e.event_type == EventType.WOLF_CHAT and "[THINK]" in e.content
-        ]
-        assert len(think_events) == 0


### PR DESCRIPTION
## Summary
- `test_wolf_chat_does_not_emit_think_hack_events` を削除
- `test_speech_does_not_emit_think_hack_events` を削除

退行テストは一度通れば役目を終える。`[THINK]` ハックのコードは PR #427 で削除済みのため、テストを残し続ける意味がない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)