### PR TITLE
refactor: migrate CLI renderer schema

### DIFF
--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -354,10 +354,10 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 | `INSPECTION` | False | 占い師の占い結果（観戦者のみ）。`reasoning` フィールドに占い対象を選んだ理由 |
 | `MEDIUM_RESULT` | False | 霊媒師が受け取った処刑者の役職（観戦者のみ・黄色表示） |
 | `GUARD` | False | 騎士の護衛行動（観戦者のみ）。`reasoning` フィールドに護衛対象を選んだ理由 |
-| `GUARD_BLOCK` | False / True | 護衛成功の詳細（観戦者）/ 全体通知（村人全員） |
+| `GUARD_BLOCK` | True | 護衛成功通知。`content` に公開文面、`spectator_content` に観戦者向け詳細文面を格納 |
 | `WOLF_CHAT` | False | 狼チャット（観戦者のみ） |
 | `PRE_NIGHT_DECISION` | False | 旧アーカイブ replay 互換のためだけに残る前夜CO判断イベント |
-| `CO_ANNOUNCEMENT` | True | 役職公言。`claimed_role` フィールドに公言した役職名を格納 |
+| `CO_ANNOUNCEMENT` | True | 旧アーカイブ replay 互換のためだけに残る役職公言イベント。新規 emit は `SPEECH.claimed_role` を使う |
 | `VOTE_CANDIDATES` | False | 発言フェーズ（DISCUSSION）での vote_candidates スナップショット（観戦者のみ）。発言後に emit される |
 | `SUSPICION_UPDATE` | False | 発言フェーズで村人視点の疑惑スコアが更新されたとき（観戦者のみ・dim cyan） |
 | `THREAT_UPDATE` | False | 発言フェーズで人狼視点の脅威スコアが更新されたとき（観戦者のみ・dim red） |
@@ -366,15 +366,15 @@ LLMの提案をゲームエンジンに渡す橋渡し役。
 
 #### event.py — LogEvent フィールド
 
-`CO_ANNOUNCEMENT` イベントには `claimed_role: str | None` フィールドを使う。
-`content` の文字列フォーマット（`"{name} claims to be {role}"`）に依存せず、型安全に公言役職名を参照できる。
-既存アーカイブとの後方互換は `default=None` で対応する。
+CO 表示は `SPEECH` イベントの `claimed_role: str | None` フィールドから consumer 側で生成する。
+`content` の文字列フォーマット（`"{name} claims to be {role}"`）や `CO_ANNOUNCEMENT` 別イベントには依存しない。
+既存アーカイブとの後方互換のため、旧 `CO_ANNOUNCEMENT` イベントも `claimed_role` を読んで従来表示を維持する。
 
 `INSPECTION` イベントには `inspection_role: str | None` フィールドを使う。
 占い師が確認した役職名（`"Werewolf"` または `"Villager"`）を格納し、レンダラーが文字列パースなしに役職情報を参照できる。
 既存アーカイブとの後方互換は `default=None` で対応し、`None` の場合は `content` フォールバックで表示する。
 
-`VOTE` / `GUARD` / `INSPECTION` / `JUDGMENT` イベントには `reasoning: str` フィールドを使う。
+`SPEECH` / `WOLF_CHAT` / `VOTE` / `GUARD` / `INSPECTION` / `JUDGMENT` イベントには `reasoning: str` フィールドを使う。
 エージェントが行動を選んだ理由を格納し、観戦者モードで表示する。他エージェントのゲーム状態には含めない（`is_public=False` または表示フィルタで制御）。
 既存アーカイブとの後方互換は `default=""` で対応する。
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,7 +19,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#421 | tech-debt | 🔴 | — | refactor(cli): migrate renderer.py to new LogEvent schema | renderer.py を reasoning / spectator_content / claimed_role 参照に移行。旧ログフォールバック維持。依存: #420 |
 | yukkie/AgentVillage#422 | tech-debt | 🔴 | — | refactor(frontend): migrate parseGameData.js off [THINK]/co_announcement hacks | parseGameData の legacy-adapter 削除・文面択一・CO 別処理削除。旧ログフォールバック維持。依存: #420 |
 | yukkie/AgentVillage#417 | bug | ❌ | — | CO badge style ignores viewerMode; false-CO detection not implemented | CO バッジのスタイルが viewerMode を無視、偽CO判定未実装。両モードでスタイル統一し spectator モードのみ偽COマークを付ける|
 | yukkie/AgentVillage#415 | tech-debt | ❌ | — | docs: introduce DataSpec.md | UI非依存のデータ定義（EventType・可視性ルール・ログスキーマ）を DataSpec.md に集約し、Spec.md §5・DetailDesign.md・flow-js.md から参照する。依存: #344|

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -19,7 +19,7 @@ from src.domain.actor import Actor
 class Renderer:
     """Convert ``LogEvent`` instances into Rich ``Text`` for console output."""
 
-    # Simple events where the output is ``[PREFIX] {content}`` in a fixed style.
+    # Simple events where the output is ``[PREFIX] {display_content}`` in a fixed style.
     # Events needing dynamic style or extra fields (SPEECH, VOTE, JUDGMENT, PHASE_START,
     # PRE_NIGHT_DECISION, INSPECTION, GUARD, GAME_OVER) are handled separately in ``on_event``.
     _SIMPLE_EVENT_STYLES: dict[EventType, tuple[str, str]] = {
@@ -42,16 +42,17 @@ class Renderer:
             return None
 
         text = Text()
+        content = self._display_content(event)
 
         if event.event_type == EventType.PHASE_START:
-            text.append(f"\n{event.content}\n", style="bold yellow")
+            text.append(f"\n{content}\n", style="bold yellow")
 
         elif event.event_type == EventType.SPEECH:
             self._render_speech(event, text)
 
         elif event.event_type == EventType.REASONING:
             text.append(f"[REASON] {event.agent}: ", style="bold magenta")
-            text.append(event.content, style="magenta")
+            text.append(content, style="magenta")
 
         elif event.event_type == EventType.VOTE:
             text.append(f"[VOTE] {event.agent} → {event.target}", style="white")
@@ -66,13 +67,17 @@ class Renderer:
                 text.append(f"\n{event.reasoning}", style="dim")
 
         elif event.event_type == EventType.ELIMINATION:
-            text.append(f"\n{event.content}\n", style="bold red")
+            text.append(f"\n{content}\n", style="bold red")
 
         elif event.event_type == EventType.WOLF_CHAT:
-            if event.content.startswith("[THINK]"):
-                text.append(f"[WOLF] {event.content}", style="dim red")
+            legacy_think = self._legacy_think_content(event)
+            if legacy_think is not None:
+                text.append(f"[WOLF] {content}", style="dim red")
             else:
-                text.append(f"[WOLF] {event.content}", style="red")
+                text.append(f"[WOLF] {content}", style="red")
+                if self.spectator_mode and event.reasoning:
+                    text.append("\n  [THINK] ", style="dim red")
+                    text.append(event.reasoning, style="dim red")
 
         elif event.event_type == EventType.NIGHT_ATTACK:
             # Spectator only — render attacker/target explicitly when available.
@@ -82,12 +87,12 @@ class Renderer:
                     style="red",
                 )
             else:
-                text.append(f"[NIGHT] {event.content}", style="red")
+                text.append(f"[NIGHT] {content}", style="red")
             if self.spectator_mode and event.reasoning:
                 text.append(f" — {event.reasoning}", style="dim")
 
         elif event.event_type == EventType.GUARD:
-            text.append(f"[GUARD] {event.content}", style="bright_green")
+            text.append(f"[GUARD] {content}", style="bright_green")
             if self.spectator_mode and event.reasoning:
                 text.append(f" — {event.reasoning}", style="dim")
 
@@ -95,29 +100,29 @@ class Renderer:
             self._render_inspection(event, text)
 
         elif event.event_type == EventType.SUSPICION_UPDATE:
-            text.append(f"[SUSPICION] {event.content}", style="dim cyan")
+            text.append(f"[SUSPICION] {content}", style="dim cyan")
 
         elif event.event_type == EventType.THREAT_UPDATE:
-            text.append(f"[THREAT] {event.content}", style="dim red")
+            text.append(f"[THREAT] {content}", style="dim red")
 
         # Search marker: Legacy-Adapter
         # Legacy-Adapter: render archived PRE_NIGHT replay events only.
         elif event.event_type == EventType.PRE_NIGHT_DECISION:
             actor = self._get_agent(event.agent)
             style = actor.role.color if actor else "cyan"
-            text.append(f"[PRE-NIGHT] {event.content}", style=style)
+            text.append(f"[PRE-NIGHT] {content}", style=style)
 
         elif event.event_type == EventType.GAME_OVER:
             text.append(f"\n{'=' * 50}\n", style="bold yellow")
-            text.append(event.content, style="bold green")
+            text.append(content, style="bold green")
             text.append(f"\n{'=' * 50}\n", style="bold yellow")
 
         elif event.event_type in self._SIMPLE_EVENT_STYLES:
             prefix, style = self._SIMPLE_EVENT_STYLES[event.event_type]
-            text.append(f"{prefix}{event.content}", style=style)
+            text.append(f"{prefix}{content}", style=style)
 
         else:
-            text.append(event.content)
+            text.append(content)
 
         return text if len(text) > 0 else None
 
@@ -126,31 +131,50 @@ class Renderer:
             result_str = "Werewolf" if event.inspection_role.name == "Werewolf" else "Not Werewolf"
             display = f"{event.agent} inspects {event.target}: {result_str}"
         else:
-            display = event.content
+            display = self._display_content(event)
         text.append(f"[INSPECT] {display}", style="cyan")
         if self.spectator_mode and event.reasoning:
             text.append(f" — {event.reasoning}", style="dim")
 
     def _render_speech(self, event: LogEvent, text: Text) -> None:
-        if event.content.startswith("[THINK]"):
+        legacy_think = self._legacy_think_content(event)
+        if legacy_think is not None:
             # Thought log — spectator only (already filtered in on_event).
-            thought_content = event.content[len("[THINK] "):]
             text.append(f"  [THINK] {event.agent}: ", style="dim white")
-            text.append(thought_content, style="dim white")
+            text.append(legacy_think, style="dim white")
             return
 
-        style = self._speech_style(event.agent)
+        style = self._speech_style(event.agent, event.claimed_role)
         prefix = f"[{event.speech_id}] " if event.speech_id is not None else ""
         reply = f" (→[{event.reply_to}])" if event.reply_to is not None else ""
+        if event.claimed_role is not None:
+            text.append(
+                f"[CO] {event.agent} claims to be {event.claimed_role.name}\n",
+                style="bold white",
+            )
         text.append(f"{prefix}{event.agent}{reply}: ", style=f"bold {style}")
-        text.append(event.content, style=style)
+        text.append(self._display_content(event), style=style)
+        if self.spectator_mode and event.reasoning:
+            text.append(f"\n  [THINK] {event.agent}: ", style="dim white")
+            text.append(event.reasoning, style="dim white")
+
+    def _display_content(self, event: LogEvent) -> str:
+        if self.spectator_mode and event.spectator_content:
+            return event.spectator_content
+        return event.content
+
+    @staticmethod
+    def _legacy_think_content(event: LogEvent) -> str | None:
+        if event.content.startswith("[THINK]"):
+            return event.content[len("[THINK]"):].lstrip()
+        return None
 
     def _get_agent(self, agent_name: str | None) -> Actor | None:
         if agent_name is None:
             return None
         return next((a for a in self.agents if a.name == agent_name), None)
 
-    def _speech_style(self, agent_name: str | None) -> str:
+    def _speech_style(self, agent_name: str | None, claimed_role_override=None) -> str:
         """Return Rich color style for a speech event.
 
         Spectator mode: color by true role.
@@ -161,6 +185,8 @@ class Renderer:
             return "white"
         if self.spectator_mode:
             return actor.role.color
+        if claimed_role_override:
+            return claimed_role_override.color
         if actor.state.claimed_role:
             return actor.state.claimed_role.color
         return "white"

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -14,6 +14,7 @@ from rich.text import Text
 
 from src.domain.event import LogEvent, EventType
 from src.domain.actor import Actor
+from src.domain.roles import Role
 
 
 class Renderer:
@@ -70,8 +71,7 @@ class Renderer:
             text.append(f"\n{content}\n", style="bold red")
 
         elif event.event_type == EventType.WOLF_CHAT:
-            legacy_think = self._legacy_think_content(event)
-            if legacy_think is not None:
+            if event.content.startswith("[THINK]"):
                 text.append(f"[WOLF] {content}", style="dim red")
             else:
                 text.append(f"[WOLF] {content}", style="red")
@@ -174,7 +174,11 @@ class Renderer:
             return None
         return next((a for a in self.agents if a.name == agent_name), None)
 
-    def _speech_style(self, agent_name: str | None, claimed_role_override=None) -> str:
+    def _speech_style(
+        self,
+        agent_name: str | None,
+        claimed_role_override: Role | None = None,
+    ) -> str:
         """Return Rich color style for a speech event.
 
         Spectator mode: color by true role.

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -150,7 +150,11 @@ class ReplayPager:
 
         for event in events:
             # Use event.claimed_role (structured field) rather than parsing content text.
-            if event.event_type == EventType.CO_ANNOUNCEMENT and event.agent and event.claimed_role:
+            if (
+                event.event_type in (EventType.SPEECH, EventType.CO_ANNOUNCEMENT)
+                and event.agent
+                and event.claimed_role
+            ):
                 if event.agent in dynamic_actors:
                     dynamic_actors[event.agent].state.claimed_role = event.claimed_role
 

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -609,6 +609,7 @@ def test_wolf_chat_legacy_think_prefix_renders_dim_red(make_test_actor) -> None:
     result = renderer.on_event(event)
 
     assert result is not None
+    assert "[WOLF] [THINK] secret plan" in result.plain
     assert "secret plan" in result.plain
     spans = [s for s in result._spans if s.style == "dim red"]
     assert len(spans) > 0

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -70,6 +70,12 @@ def test_speech_uses_true_role_color_in_spectator_mode(make_test_actor) -> None:
 
 
 def test_think_prefix_renders_as_dim_spectator_line(make_test_actor) -> None:
+    """
+    SUT: Renderer._render_speech
+    Mock: なし
+    Level: unit
+    Objective: 旧ログの [THINK] speech 行が従来どおり spectator 思考行として描画されること。
+    """
     actor = make_test_actor("Alice", "Villager")
     renderer = Renderer([actor], spectator_mode=True)
     event = _make_event(
@@ -80,6 +86,78 @@ def test_think_prefix_renders_as_dim_spectator_line(make_test_actor) -> None:
 
     assert result is not None
     assert "[THINK] Alice: they look nervous" in result.plain
+
+
+def test_speech_reasoning_renders_as_think_line_in_spectator_mode(make_test_actor) -> None:
+    """
+    SUT: Renderer._render_speech
+    Mock: なし
+    Level: unit
+    Objective: 新ログの SPEECH.reasoning が spectator の思考行として描画され、content に [THINK] が出ないこと。
+    """
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=True)
+    event = _make_event(
+        EventType.SPEECH,
+        agent="Alice",
+        content="I think Bob is suspicious.",
+        reasoning="Bob avoided voting.",
+        speech_id=3,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "[3] Alice: I think Bob is suspicious." in result.plain
+    assert "[THINK] Alice: Bob avoided voting." in result.plain
+    assert "[THINK] I think Bob is suspicious." not in result.plain
+
+
+def test_speech_reasoning_hidden_in_public_mode(make_test_actor) -> None:
+    """
+    SUT: Renderer._render_speech
+    Mock: なし
+    Level: unit
+    Objective: public モードでは SPEECH.reasoning が表示されないこと。
+    """
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=False)
+    event = _make_event(
+        EventType.SPEECH,
+        agent="Alice",
+        content="I think Bob is suspicious.",
+        reasoning="Bob avoided voting.",
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "Bob avoided voting." not in result.plain
+
+
+def test_speech_claimed_role_generates_co_line(make_test_actor) -> None:
+    """
+    SUT: Renderer._render_speech
+    Mock: なし
+    Level: unit
+    Objective: SPEECH.claimed_role から CO 表示が生成されること。
+    """
+    from src.domain.roles import get_role
+
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=False)
+    event = _make_event(
+        EventType.SPEECH,
+        agent="Alice",
+        content="I am the seer.",
+        claimed_role=get_role("Seer"),
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "[CO] Alice claims to be Seer" in result.plain
+    assert "Alice: I am the seer." in result.plain
 
 
 def test_vote_renders_agent_and_target(make_test_actor) -> None:
@@ -145,6 +223,62 @@ def test_simple_event_uses_mapping_prefix(make_test_actor) -> None:
 
     assert result is not None
     assert result.plain == "[GUARD] Knight guards Alice"
+
+
+def test_spectator_content_preferred_in_spectator_mode() -> None:
+    """
+    SUT: Renderer.on_event
+    Mock: なし
+    Level: unit
+    Objective: spectator モードでは spectator_content が content より優先表示されること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.GUARD_BLOCK,
+        content="No one died tonight.",
+        spectator_content="Alice was protected by the Knight.",
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert result.plain == "[GUARD BLOCK] Alice was protected by the Knight."
+
+
+def test_spectator_content_falls_back_to_content_when_empty() -> None:
+    """
+    SUT: Renderer.on_event
+    Mock: なし
+    Level: unit
+    Objective: spectator_content が空なら spectator モードでも content にフォールバックすること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(EventType.GUARD_BLOCK, content="No one died tonight.")
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert result.plain == "[GUARD BLOCK] No one died tonight."
+
+
+def test_spectator_content_hidden_in_public_mode() -> None:
+    """
+    SUT: Renderer.on_event
+    Mock: なし
+    Level: unit
+    Objective: public モードでは spectator_content ではなく content が表示されること。
+    """
+    renderer = Renderer([], spectator_mode=False)
+    event = _make_event(
+        EventType.GUARD_BLOCK,
+        content="No one died tonight.",
+        spectator_content="Alice was protected by the Knight.",
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert result.plain == "[GUARD BLOCK] No one died tonight."
 
 
 def test_night_attack_without_agent_falls_back_to_content(make_test_actor) -> None:
@@ -438,7 +572,31 @@ def test_wolf_chat_thought_renders_dim_red(make_test_actor) -> None:
     SUT: Renderer.on_event (WOLF_CHAT thought)
     Mock: なし
     Level: unit
-    Objective: WOLF_CHAT の thought ([THINK] プレフィックス) が dim red スタイルで描画されること。
+    Objective: WOLF_CHAT.reasoning が dim red スタイルで描画されること。
+    """
+    renderer = Renderer([], spectator_mode=True)
+    event = _make_event(
+        EventType.WOLF_CHAT,
+        agent="Wolf1",
+        content="Wolf1: let's attack Alice",
+        reasoning="secret plan",
+        is_public=False,
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "secret plan" in result.plain
+    spans = [s for s in result._spans if s.style == "dim red"]
+    assert len(spans) > 0
+
+
+def test_wolf_chat_legacy_think_prefix_renders_dim_red(make_test_actor) -> None:
+    """
+    SUT: Renderer.on_event (WOLF_CHAT legacy thought)
+    Mock: なし
+    Level: unit
+    Objective: 旧ログの WOLF_CHAT [THINK] 行が dim red スタイルで描画されること。
     """
     renderer = Renderer([], spectator_mode=True)
     event = _make_event(

--- a/tests/unit/ui/test_replay.py
+++ b/tests/unit/ui/test_replay.py
@@ -93,6 +93,45 @@ def test_pager_builds_lines(tmp_archive: Path) -> None:
     assert len(pager._lines) >= 1
 
 
+def test_pager_updates_claimed_role_from_speech_event(tmp_archive: Path) -> None:
+    """
+    SUT: ReplayPager._build_lines
+    Mock: なし
+    Level: unit
+    Objective: replay が新ログの SPEECH.claimed_role から CO 表示と以後の claimed_role 追跡を行うこと。
+    """
+    from src.domain.roles import get_role
+
+    first_speech = LogEvent.make(
+        day=1,
+        phase="day",
+        event_type=EventType.SPEECH,
+        agent="Alice",
+        content="Good morning.",
+        is_public=True,
+    )
+    co_speech = LogEvent.make(
+        day=1,
+        phase="day",
+        event_type=EventType.SPEECH,
+        agent="Alice",
+        content="I am the seer.",
+        claimed_role=get_role("Seer"),
+        is_public=True,
+    )
+    (tmp_archive / "spectator_log.jsonl").write_text(
+        _make_event_jsonl(first_speech, co_speech),
+        encoding="utf-8",
+    )
+
+    pager = ReplayPager(tmp_archive, spectator_mode=False)
+    rendered = "\n".join(pager._lines)
+
+    assert "Good morning." in rendered
+    assert "[CO] Alice claims to be Seer" in rendered
+    assert "I am the seer." in rendered
+
+
 def test_pager_spectator_shows_more_lines(tmp_archive: Path) -> None:
     """spectatorモードはpublicモード以上の行数を持つこと（同じログなら同数以上）。"""
     public_pager = ReplayPager(tmp_archive, spectator_mode=False)


### PR DESCRIPTION
## Summary
- Migrate CLI renderer display logic to reasoning, spectator_content, and speech.claimed_role
- Keep legacy replay fallbacks for [THINK] rows and co_announcement
- Update replay claimed-role tracking and DetailDesign notes
- Remove completed Issue #421 from Ideas.md

## Test plan
- [x] uv run ruff check .
- [x] uv run pytest
- [x] uv run pytest --cov=src --cov-report=term-missing

Closes #421