### PR TITLE
fix(frontend): CO badge role color + persistent display across days (#417)

### DIFF
--- a/doc/DataSpec.md
+++ b/doc/DataSpec.md
@@ -103,7 +103,7 @@ CO の告知文は consumer 側が `claimed_role` から生成する。
 | 要素 | spectator | public |
 |---|---|---|
 | 役職タグ | 真の役職を常時表示 | 未CO は「役職不明」 |
-| 偽CO バッジ | 赤＋「偽」マーク | 中立色 |
+| CO バッジ | 公言役職の役職色で表示。真の役職タグと見比えることで偽CO と判別可能 | 公言役職の役職色で表示（同一） |
 | 思考ログ（`reasoning`） | 展開可 | ロックバッジ（存在のみ示す） |
 | 文面択一（`spectator_content`） | `spectator_content` を表示 | `content` を表示 |
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,7 +19,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#417 | bug | ❌ | — | CO badge style ignores viewerMode; false-CO detection not implemented | CO バッジのスタイルが viewerMode を無視、偽CO判定未実装。両モードでスタイル統一し spectator モードのみ偽COマークを付ける|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面に勝敗サマリーを表示 |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -261,6 +261,25 @@ export function aggregateCoStatus(events, upToDay) {
 }
 
 /**
+ * Attach a _coSnapshot to each event representing the cumulative CO state
+ * (agentName → claimed_role) at the moment that event occurs.
+ *
+ * The snapshot is updated when a speech event carries a claimed_role, so the
+ * CO speech itself and all subsequent events reflect the new CO state. Events
+ * before the CO carry an empty (or partial) snapshot.
+ *
+ * @param {object[]} events
+ * @returns {object[]} new array of events with _coSnapshot added (originals not mutated)
+ */
+export function attachCoSnapshot(events, initialCoMap = {}) {
+  const map = { ...initialCoMap };
+  return events.map(ev => {
+    if (ev.claimed_role) map[ev.agent] = ev.claimed_role;
+    return { ...ev, _coSnapshot: { ...map } };
+  });
+}
+
+/**
  * Build a cumulative dead-map per day from elimination and night_attack events.
  *
  * Returns a map from day number → Map<agentName, { day: number, content: string }>.

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseEventLine, parseGameData, normalizeEvents, aggregateDaySummary, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, computeDeadByDay } from './parseGameData.js';
+import { parseEventLine, parseGameData, normalizeEvents, aggregateDaySummary, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, computeDeadByDay, attachCoSnapshot } from './parseGameData.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -810,5 +810,103 @@ describe('aggregateDaySummary action fields', () => {
     ];
     const result = aggregateDaySummary(events);
     expect(result[1]).toBeUndefined();
+  });
+});
+
+describe('attachCoSnapshot', () => {
+  it('adds empty _coSnapshot to events before any CO speech', () => {
+    /*
+     * SUT: attachCoSnapshot
+     * Mock: なし
+     * Level: unit
+     * Objective: CO 発言より前のイベントには空の _coSnapshot が付くことを検証する（contract テスト）。
+     */
+    const events = [
+      { event_type: 'speech', agent: 'Mira', claimed_role: null },
+      { event_type: 'speech', agent: 'Ren',  claimed_role: null },
+    ];
+    const result = attachCoSnapshot(events);
+    expect(result[0]._coSnapshot).toEqual({});
+    expect(result[1]._coSnapshot).toEqual({});
+  });
+
+  it('adds _coSnapshot with claimed_role starting from the CO speech itself', () => {
+    /*
+     * SUT: attachCoSnapshot
+     * Mock: なし
+     * Level: unit
+     * Objective: CO 発言自体とそれ以降のイベントに claimed_role が _coSnapshot に反映されることを検証する（contract テスト）。
+     */
+    const events = [
+      { event_type: 'speech', agent: 'Mira', claimed_role: null },
+      { event_type: 'speech', agent: 'Ren',  claimed_role: 'Seer' },
+      { event_type: 'speech', agent: 'Mira', claimed_role: null },
+    ];
+    const result = attachCoSnapshot(events);
+    expect(result[0]._coSnapshot).toEqual({});
+    expect(result[1]._coSnapshot).toEqual({ Ren: 'Seer' });
+    expect(result[2]._coSnapshot).toEqual({ Ren: 'Seer' });
+  });
+
+  it('accumulates multiple agents CO in order', () => {
+    /*
+     * SUT: attachCoSnapshot
+     * Mock: なし
+     * Level: unit
+     * Objective: 複数エージェントが順に CO した場合、それぞれの発言以降に累積されることを検証する。
+     */
+    const events = [
+      { event_type: 'speech', agent: 'Ren', claimed_role: 'Seer' },
+      { event_type: 'speech', agent: 'Nox', claimed_role: 'Seer' },
+      { event_type: 'speech', agent: 'Kai', claimed_role: null },
+    ];
+    const result = attachCoSnapshot(events);
+    expect(result[0]._coSnapshot).toEqual({ Ren: 'Seer' });
+    expect(result[1]._coSnapshot).toEqual({ Ren: 'Seer', Nox: 'Seer' });
+    expect(result[2]._coSnapshot).toEqual({ Ren: 'Seer', Nox: 'Seer' });
+  });
+
+  it('does not mutate original events', () => {
+    /*
+     * SUT: attachCoSnapshot
+     * Mock: なし
+     * Level: unit
+     * Objective: 入力イベント配列が変更されないことを検証する（副作用なし）。
+     */
+    const events = [
+      { event_type: 'speech', agent: 'Ren', claimed_role: 'Seer' },
+    ];
+    attachCoSnapshot(events);
+    expect(events[0]._coSnapshot).toBeUndefined();
+  });
+
+  it('shows CO badge on events with no claimed_role when initialCoMap carries prior CO', () => {
+    /*
+     * SUT: attachCoSnapshot
+     * Mock: なし
+     * Level: unit
+     * Objective: claimed_role がない発言でも initialCoMap に CO 済みエントリがあれば _coSnapshot に反映されることを検証する（day跨ぎ継続表示の contract テスト）。
+     */
+    const events = [
+      { event_type: 'speech', agent: 'Mira', claimed_role: null },
+      { event_type: 'speech', agent: 'Ren',  claimed_role: null },
+    ];
+    const result = attachCoSnapshot(events, { Nox: 'Hunter' });
+    expect(result[0]._coSnapshot).toEqual({ Nox: 'Hunter' });
+    expect(result[1]._coSnapshot).toEqual({ Nox: 'Hunter' });
+  });
+
+  it('initialCoMap is overridden by later CO speech in the feed', () => {
+    /*
+     * SUT: attachCoSnapshot
+     * Mock: なし
+     * Level: unit
+     * Objective: initialCoMap のエントリが同エージェントの新たな CO 発言で上書きされることを検証する。
+     */
+    const events = [
+      { event_type: 'speech', agent: 'Ren', claimed_role: 'Seer' },
+    ];
+    const result = attachCoSnapshot(events, { Ren: 'Hunter' });
+    expect(result[0]._coSnapshot).toEqual({ Ren: 'Seer' });
   });
 });

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -5,7 +5,7 @@ import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
-import { parseGameData, aggregateCoStatus, computeDeadByDay } from '../lib/parseGameData.js';
+import { parseGameData, aggregateCoStatus, computeDeadByDay, attachCoSnapshot } from '../lib/parseGameData.js';
 import { filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
 
@@ -63,6 +63,8 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
   const replied = ev.reply_to ? prevById[`${ev.day}-${ev.reply_to}`] : null;
   const isWolf = role === 'Werewolf';
   const isPublic = viewerMode === 'public';
+  const coedRole = ev._coSnapshot?.[ev.agent];
+  const coColor = coedRole ? ROLES[coedRole]?.color : undefined;
 
   return (
     <div
@@ -76,9 +78,9 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
           <span className={styles.name}>{ev.agent}</span>
           <span className={styles.turn}>{fmtTurn(ev.day, ev.speech_id || 0)}</span>
           {!isPublic && <RoleTag role={role} />}
-          {ev.claimed_role && (
-            <span className={styles.coBadge}>
-              ▶ {ROLES[ev.claimed_role]?.ja || ev.claimed_role} CO
+          {coedRole && (
+            <span className={styles.coBadge} style={{ '--co-color': coColor }}>
+              ▶ {ROLES[coedRole]?.ja || coedRole} CO
             </span>
           )}
           <span className={styles.ts}>{fmtTime(ev.day, ev.speech_id || 0)}</span>
@@ -418,7 +420,7 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
                   {n}
                   {viewerMode === 'spectator' && <RoleTag role={role} />}
                   {coRole && (
-                    <span className={styles.coBadge}>▶ {ROLES[coRole]?.ja || coRole} CO</span>
+                    <span className={styles.coBadge} style={{ '--co-color': ROLES[coRole]?.color }}>▶ {ROLES[coRole]?.ja || coRole} CO</span>
                   )}
                 </span>
               </div>
@@ -531,7 +533,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     if (e.speech_id != null) prevById[`${e.day}-${e.speech_id}`] = e;
   });
 
-  const feedEvents = filterFeedEvents(events, activeDay, activePhase);
+  const feedEvents = attachCoSnapshot(filterFeedEvents(events, activeDay, activePhase), replayCoStatus);
   const speechCount = events.filter(e => e.event_type === 'speech').length;
   const coCount = Object.keys(replayCoStatus).length;
 

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -169,9 +169,9 @@
 .spHead .coBadge {
   font-family: var(--serif);
   font-size: 10px;
-  background: color-mix(in oklab, var(--acc) 18%, transparent);
-  border: 1px solid color-mix(in oklab, var(--acc) 50%, transparent);
-  color: var(--acc);
+  background: color-mix(in oklab, var(--co-color, var(--acc)) 18%, transparent);
+  border: 1px solid color-mix(in oklab, var(--co-color, var(--acc)) 50%, transparent);
+  color: var(--co-color, var(--acc));
   padding: 1px 5px;
   border-radius: 2px;
   letter-spacing: 0.04em;
@@ -430,9 +430,9 @@
 .ts     { font-size: 10px; color: var(--tx-3); margin-left: auto; font-family: var(--mono); }
 .coBadge {
   font-family: var(--serif); font-size: 10px;
-  background: color-mix(in oklab, var(--acc) 18%, transparent);
-  border: 1px solid color-mix(in oklab, var(--acc) 50%, transparent);
-  color: var(--acc); padding: 1px 5px; border-radius: 2px; letter-spacing: 0.04em;
+  background: color-mix(in oklab, var(--co-color, var(--acc)) 18%, transparent);
+  border: 1px solid color-mix(in oklab, var(--co-color, var(--acc)) 50%, transparent);
+  color: var(--co-color, var(--acc)); padding: 1px 5px; border-radius: 2px; letter-spacing: 0.04em;
 }
 .qhead { font-size: 10px; color: var(--tx-4); margin-bottom: 2px; font-family: var(--mono); }
 .mention { color: var(--info); font-weight: 500; }

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -814,6 +814,7 @@ describe('SpeechCard: viewerMode public (AC2 / #314)', () => {
       speech_id: 1,
       reply_to: null,
       claimed_role: 'Seer',
+      _coSnapshot: { Alice: 'Seer' },
       reasoning: null,
       is_public: true,
     };


### PR DESCRIPTION
## Summary
- CO バッジのスタイルを `--acc` から公言役職の役職色（`--co-color`）ベースに変更（spectator / public 両モードで統一）
- `attachCoSnapshot(events, initialCoMap)` を `parseGameData.js` に追加。フィード走査時に各イベントへ累積 CO 状態（`_coSnapshot`）を付与する
- `SpeechCard` が `ev.claimed_role` 直接参照から `ev._coSnapshot[ev.agent]` 参照に変更。CO 発言以降のすべての発言に CO バッジが継続表示される
- `initialCoMap` に `replayCoStatus`（前 day までの累積）を渡すことで day をまたいだ CO バッジ継続表示を実現
- `DataSpec.md §3.2` の偽CO バッジ欄を仕様変更に合わせて更新

## Implementation notes
- `attachCoSnapshot` は純粋関数として `parseGameData.js` に切り出し、6ケースの contract テストで検証
- `replayCoStatus` は右ペインですでに計算済みの値を再利用するため追加計算なし
- `ev.claimed_role` の直接参照（旧デッドコード）を削除

## Test plan
- [x] `attachCoSnapshot` contract テスト 6件（新規）
- [x] 既存 `SpeechCard` CO バッジテストを `_coSnapshot` ベースに更新
- [x] `pytest` パス
- [x] `ruff` パス
- [x] Playwright: Day 2 CO バッジ役職色・継続表示確認
- [x] Playwright: Day 4 で Day 3 CO が継続表示されることを確認

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)