### PR TITLE
feat: attach claimed role to speech events

### DIFF
--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -261,25 +261,6 @@ export function aggregateCoStatus(events, upToDay) {
 }
 
 /**
- * Attach a _coSnapshot to each event representing the cumulative CO state
- * (agentName → claimed_role) at the moment that event occurs.
- *
- * The snapshot is updated when a speech event carries a claimed_role, so the
- * CO speech itself and all subsequent events reflect the new CO state. Events
- * before the CO carry an empty (or partial) snapshot.
- *
- * @param {object[]} events
- * @returns {object[]} new array of events with _coSnapshot added (originals not mutated)
- */
-export function attachCoSnapshot(events, initialCoMap = {}) {
-  const map = { ...initialCoMap };
-  return events.map(ev => {
-    if (ev.claimed_role) map[ev.agent] = ev.claimed_role;
-    return { ...ev, _coSnapshot: { ...map } };
-  });
-}
-
-/**
  * Build a cumulative dead-map per day from elimination and night_attack events.
  *
  * Returns a map from day number → Map<agentName, { day: number, content: string }>.

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseEventLine, parseGameData, normalizeEvents, aggregateDaySummary, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, computeDeadByDay, attachCoSnapshot } from './parseGameData.js';
+import { parseEventLine, parseGameData, normalizeEvents, aggregateDaySummary, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, computeDeadByDay } from './parseGameData.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -810,103 +810,5 @@ describe('aggregateDaySummary action fields', () => {
     ];
     const result = aggregateDaySummary(events);
     expect(result[1]).toBeUndefined();
-  });
-});
-
-describe('attachCoSnapshot', () => {
-  it('adds empty _coSnapshot to events before any CO speech', () => {
-    /*
-     * SUT: attachCoSnapshot
-     * Mock: なし
-     * Level: unit
-     * Objective: CO 発言より前のイベントには空の _coSnapshot が付くことを検証する（contract テスト）。
-     */
-    const events = [
-      { event_type: 'speech', agent: 'Mira', claimed_role: null },
-      { event_type: 'speech', agent: 'Ren',  claimed_role: null },
-    ];
-    const result = attachCoSnapshot(events);
-    expect(result[0]._coSnapshot).toEqual({});
-    expect(result[1]._coSnapshot).toEqual({});
-  });
-
-  it('adds _coSnapshot with claimed_role starting from the CO speech itself', () => {
-    /*
-     * SUT: attachCoSnapshot
-     * Mock: なし
-     * Level: unit
-     * Objective: CO 発言自体とそれ以降のイベントに claimed_role が _coSnapshot に反映されることを検証する（contract テスト）。
-     */
-    const events = [
-      { event_type: 'speech', agent: 'Mira', claimed_role: null },
-      { event_type: 'speech', agent: 'Ren',  claimed_role: 'Seer' },
-      { event_type: 'speech', agent: 'Mira', claimed_role: null },
-    ];
-    const result = attachCoSnapshot(events);
-    expect(result[0]._coSnapshot).toEqual({});
-    expect(result[1]._coSnapshot).toEqual({ Ren: 'Seer' });
-    expect(result[2]._coSnapshot).toEqual({ Ren: 'Seer' });
-  });
-
-  it('accumulates multiple agents CO in order', () => {
-    /*
-     * SUT: attachCoSnapshot
-     * Mock: なし
-     * Level: unit
-     * Objective: 複数エージェントが順に CO した場合、それぞれの発言以降に累積されることを検証する。
-     */
-    const events = [
-      { event_type: 'speech', agent: 'Ren', claimed_role: 'Seer' },
-      { event_type: 'speech', agent: 'Nox', claimed_role: 'Seer' },
-      { event_type: 'speech', agent: 'Kai', claimed_role: null },
-    ];
-    const result = attachCoSnapshot(events);
-    expect(result[0]._coSnapshot).toEqual({ Ren: 'Seer' });
-    expect(result[1]._coSnapshot).toEqual({ Ren: 'Seer', Nox: 'Seer' });
-    expect(result[2]._coSnapshot).toEqual({ Ren: 'Seer', Nox: 'Seer' });
-  });
-
-  it('does not mutate original events', () => {
-    /*
-     * SUT: attachCoSnapshot
-     * Mock: なし
-     * Level: unit
-     * Objective: 入力イベント配列が変更されないことを検証する（副作用なし）。
-     */
-    const events = [
-      { event_type: 'speech', agent: 'Ren', claimed_role: 'Seer' },
-    ];
-    attachCoSnapshot(events);
-    expect(events[0]._coSnapshot).toBeUndefined();
-  });
-
-  it('shows CO badge on events with no claimed_role when initialCoMap carries prior CO', () => {
-    /*
-     * SUT: attachCoSnapshot
-     * Mock: なし
-     * Level: unit
-     * Objective: claimed_role がない発言でも initialCoMap に CO 済みエントリがあれば _coSnapshot に反映されることを検証する（day跨ぎ継続表示の contract テスト）。
-     */
-    const events = [
-      { event_type: 'speech', agent: 'Mira', claimed_role: null },
-      { event_type: 'speech', agent: 'Ren',  claimed_role: null },
-    ];
-    const result = attachCoSnapshot(events, { Nox: 'Hunter' });
-    expect(result[0]._coSnapshot).toEqual({ Nox: 'Hunter' });
-    expect(result[1]._coSnapshot).toEqual({ Nox: 'Hunter' });
-  });
-
-  it('initialCoMap is overridden by later CO speech in the feed', () => {
-    /*
-     * SUT: attachCoSnapshot
-     * Mock: なし
-     * Level: unit
-     * Objective: initialCoMap のエントリが同エージェントの新たな CO 発言で上書きされることを検証する。
-     */
-    const events = [
-      { event_type: 'speech', agent: 'Ren', claimed_role: 'Seer' },
-    ];
-    const result = attachCoSnapshot(events, { Ren: 'Hunter' });
-    expect(result[0]._coSnapshot).toEqual({ Ren: 'Seer' });
   });
 });

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -5,7 +5,7 @@ import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
-import { parseGameData, aggregateCoStatus, computeDeadByDay, attachCoSnapshot } from '../lib/parseGameData.js';
+import { parseGameData, aggregateCoStatus, computeDeadByDay } from '../lib/parseGameData.js';
 import { filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
 
@@ -63,7 +63,7 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
   const replied = ev.reply_to ? prevById[`${ev.day}-${ev.reply_to}`] : null;
   const isWolf = role === 'Werewolf';
   const isPublic = viewerMode === 'public';
-  const coedRole = ev._coSnapshot?.[ev.agent];
+  const coedRole = ev.claimed_role;
   const coColor = coedRole ? ROLES[coedRole]?.color : undefined;
 
   return (
@@ -533,7 +533,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     if (e.speech_id != null) prevById[`${e.day}-${e.speech_id}`] = e;
   });
 
-  const feedEvents = attachCoSnapshot(filterFeedEvents(events, activeDay, activePhase), replayCoStatus);
+  const feedEvents = filterFeedEvents(events, activeDay, activePhase);
   const speechCount = events.filter(e => e.event_type === 'speech').length;
   const coCount = Object.keys(replayCoStatus).length;
 

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -814,7 +814,6 @@ describe('SpeechCard: viewerMode public (AC2 / #314)', () => {
       speech_id: 1,
       reply_to: null,
       claimed_role: 'Seer',
-      _coSnapshot: { Alice: 'Seer' },
       reasoning: null,
       is_public: true,
     };

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -195,10 +195,10 @@ class GameEngine:
                 None,
             )
 
-        claim_role = result.claim_role if isinstance(result, CoResult) else None
-        if isinstance(result, CoResult) and actor.state.claimed_role != claim_role:
-            actor.state.claimed_role = claim_role
+        if isinstance(result, CoResult):
             actor.state.intended_co = None
+            if actor.state.claimed_role != result.claim_role:
+                actor.state.claimed_role = result.claim_role
             store.save(actor)
 
         speech_id = self._next_speech_id()
@@ -214,8 +214,9 @@ class GameEngine:
             is_public=True,
             speech_id=speech_id,
             reply_to=reply_to_entry.speech_id if reply_to_entry else None,
-            claimed_role=claim_role,
+            claimed_role=actor.state.claimed_role,
             reasoning=result.thought,
+            decision="co" if isinstance(result, CoResult) else "",
         ))
 
         if result.suspicion_scores:

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -197,8 +197,7 @@ class GameEngine:
 
         if isinstance(result, CoResult):
             actor.state.intended_co = None
-            if actor.state.claimed_role != result.claim_role:
-                actor.state.claimed_role = result.claim_role
+            actor.state.claimed_role = result.claim_role
             store.save(actor)
 
         speech_id = self._next_speech_id()

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -143,7 +143,7 @@ class Renderer:
         style = self._speech_style(event.agent, event.claimed_role)
         prefix = f"[{event.speech_id}] " if event.speech_id is not None else ""
         reply = f" (→[{event.reply_to}])" if event.reply_to is not None else ""
-        if event.claimed_role is not None:
+        if self._is_co_declaration(event):
             text.append(
                 f"[CO] {event.agent} claims to be {event.claimed_role.name}\n",
                 style="bold white",
@@ -164,6 +164,10 @@ class Renderer:
         if event.content.startswith("[THINK]"):
             return event.content[len("[THINK]"):].lstrip()
         return None
+
+    @staticmethod
+    def _is_co_declaration(event: LogEvent) -> bool:
+        return event.claimed_role is not None and event.decision == "co"
 
     def _get_agent(self, agent_name: str | None) -> Actor | None:
         if agent_name is None:

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -155,6 +155,17 @@ class ReplayPager:
                 and event.agent
                 and event.claimed_role
             ):
+                actor = dynamic_actors.get(event.agent)
+                # Defensive replay fallback: some archived speech events carry
+                # claimed_role but no decision="co". Treat the first role-state
+                # transition as the declaration so CO display remains intact.
+                if (
+                    event.event_type == EventType.SPEECH
+                    and event.decision == ""
+                    and actor is not None
+                    and actor.state.claimed_role != event.claimed_role
+                ):
+                    event = event.model_copy(update={"decision": "co"})
                 if event.agent in dynamic_actors:
                     dynamic_actors[event.agent].state.claimed_role = event.claimed_role
 

--- a/tests/contract/test_day_phase_contract.py
+++ b/tests/contract/test_day_phase_contract.py
@@ -156,6 +156,108 @@ class TestDiscussionCoDecisionContract:
 
         assert wolf.state.claimed_role.name == "Medium"
 
+    def test_speech_events_keep_claimed_role_after_co(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result()
+        Mock: call_discussion_parallel returns CoResult then SpeakResult for the same actor
+        Level: contract
+        Architecture ref: doc/Architecture.md §2.4, §3.2
+        Objective: CO 発言以降の SPEECH イベントすべてに actor.state.claimed_role が添付されることを検証する。
+        """
+        seer = make_test_actor("Seer1", "Seer")
+        other = make_test_actor("V1")
+        engine, events = make_test_engine([seer, other])
+        call_count = [0]
+
+        def discussion_with_followup(_actors, *_, **__):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return iter([
+                    (seer, CoResult(thought="CO now", speech="I am the Seer!", claim_role=seer.role)),
+                    (other, SilentResult(reasoning="nothing")),
+                ])
+            return iter([
+                (seer, SpeakResult(thought="followup", speech="My result still matters.")),
+                (other, SilentResult(reasoning="nothing")),
+            ])
+
+        engine._llm_client.call_discussion_parallel.side_effect = discussion_with_followup
+
+        with (
+            patch("src.engine.phase_day.DISCUSSION_ROUNDS", 2),
+            patch("src.agent.store.save"),
+        ):
+            engine._run_day()
+
+        seer_speeches = [
+            e for e in events
+            if e.event_type == EventType.SPEECH and e.agent == "Seer1" and e.speech_id is not None
+        ]
+        assert [e.claimed_role.name for e in seer_speeches] == ["Seer", "Seer"]
+        assert [e.decision for e in seer_speeches] == ["co", ""]
+
+    def test_repeated_co_speech_keeps_co_decision(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result()
+        Mock: call_discussion_parallel returns CoResult twice for the same actor
+        Level: contract
+        Architecture ref: doc/Architecture.md §2.4, §3.2
+        Objective: 同じエージェントの二回目以降の CO 発言も decision="co" として emit されることを検証する。
+        """
+        seer = make_test_actor("Seer1", "Seer")
+        other = make_test_actor("V1")
+        engine, events = make_test_engine([seer, other])
+        call_count = [0]
+
+        def repeated_co(_actors, *_, **__):
+            call_count[0] += 1
+            return iter([
+                (seer, CoResult(thought=f"CO {call_count[0]}", speech="I am the Seer!", claim_role=seer.role)),
+                (other, SilentResult(reasoning="nothing")),
+            ])
+
+        engine._llm_client.call_discussion_parallel.side_effect = repeated_co
+
+        with (
+            patch("src.engine.phase_day.DISCUSSION_ROUNDS", 2),
+            patch("src.agent.store.save"),
+        ):
+            engine._run_day()
+
+        seer_speeches = [
+            e for e in events
+            if e.event_type == EventType.SPEECH and e.agent == "Seer1" and e.speech_id is not None
+        ]
+        assert [e.claimed_role.name for e in seer_speeches] == ["Seer", "Seer"]
+        assert [e.decision for e in seer_speeches] == ["co", "co"]
+
+    def test_unclaimed_speech_event_keeps_claimed_role_none(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result()
+        Mock: call_discussion_parallel returns SpeakResult for an unclaimed actor
+        Level: contract
+        Architecture ref: doc/Architecture.md §2.4, §3.2
+        Objective: 未COエージェントの SPEECH イベントは claimed_role=None のまま emit されることを検証する。
+        """
+        actor = make_test_actor("Alice")
+        other = make_test_actor("Bob")
+        engine, events = make_test_engine([actor, other])
+
+        engine._llm_client.call_discussion_parallel.side_effect = lambda _actors, *_, **__: iter([
+            (actor, SpeakResult(thought="t", speech="I have no claim.")),
+            (other, SilentResult(reasoning="nothing")),
+        ])
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        speech_events = [
+            e for e in events
+            if e.event_type == EventType.SPEECH and e.agent == "Alice" and e.speech_id is not None
+        ]
+        assert len(speech_events) >= 1
+        assert all(e.claimed_role is None for e in speech_events)
+
 
 class TestVoteOutputFlowContract:
     def test_wolf_side_strategy_recorded_in_vote_event(self, make_test_actor, make_test_engine):

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -151,6 +151,7 @@ def test_speech_claimed_role_generates_co_line(make_test_actor) -> None:
         agent="Alice",
         content="I am the seer.",
         claimed_role=get_role("Seer"),
+        decision="co",
     )
 
     result = renderer.on_event(event)
@@ -158,6 +159,58 @@ def test_speech_claimed_role_generates_co_line(make_test_actor) -> None:
     assert result is not None
     assert "[CO] Alice claims to be Seer" in result.plain
     assert "Alice: I am the seer." in result.plain
+
+
+def test_speech_claimed_role_without_co_decision_does_not_generate_co_line(make_test_actor) -> None:
+    """
+    SUT: Renderer._render_speech
+    Mock: なし
+    Level: unit
+    Objective: CO 済み後続発言に claimed_role が添付されても [CO] 宣言行を二重表示しないこと。
+    """
+    from src.domain.roles import get_role
+
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=False)
+    event = _make_event(
+        EventType.SPEECH,
+        agent="Alice",
+        content="I will share my result.",
+        claimed_role=get_role("Seer"),
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "[CO] Alice claims to be Seer" not in result.plain
+    assert "Alice: I will share my result." in result.plain
+
+
+def test_repeated_co_decision_generates_co_line(make_test_actor) -> None:
+    """
+    SUT: Renderer._render_speech
+    Mock: なし
+    Level: unit
+    Objective: claimed_role が既にある状態でも decision="co" の発言は CO 宣言行として表示されること。
+    """
+    from src.domain.roles import get_role
+
+    actor = make_test_actor("Alice", "Villager")
+    actor.state.claimed_role = get_role("Seer")
+    renderer = Renderer([actor], spectator_mode=False)
+    event = _make_event(
+        EventType.SPEECH,
+        agent="Alice",
+        content="Again, I am the seer.",
+        claimed_role=get_role("Seer"),
+        decision="co",
+    )
+
+    result = renderer.on_event(event)
+
+    assert result is not None
+    assert "[CO] Alice claims to be Seer" in result.plain
+    assert "Alice: Again, I am the seer." in result.plain
 
 
 def test_vote_renders_agent_and_target(make_test_actor) -> None:


### PR DESCRIPTION
﻿## Summary
- Attach `actor.state.claimed_role` to every new speech event after CO, while keeping unclaimed speech events as `null`
- Use `decision="co"` to distinguish CO declaration speech from later CO-state speech in CLI/replay rendering
- Remove frontend `attachCoSnapshot` usage and render speech CO badges from `ev.claimed_role` directly

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest --cov=src --cov-report=term-missing`
- [x] `uv run pytest --cov=src --cov-report=json -q`
- [x] `npm test` in `frontend/`
- [x] `coverage_diff.py --unstaged`

Closes #437

Follow-up: #441

🤖 Generated with [Codex](https://Codex.com/Codex)
