### PR TITLE
fix: render CO announcements from role transitions

### DIFF
--- a/doc/DataSpec.md
+++ b/doc/DataSpec.md
@@ -75,7 +75,12 @@ replay 用に read 側だけが解釈する。新規 emit はしない）の2層
 | **思考の付帯情報** | `reasoning` | `content` とは独立した、**常に spectator 限定**の思考・理由。`is_public` とは無関係に spectator のみ表示 |
 
 加えて `claimed_role`（CO 情報）は `speech` イベントに付随させ、別イベント化しない。
-CO の告知文は consumer 側が `claimed_role` から生成する。
+CO の告知文は consumer 側が `claimed_role` の状態遷移から生成する。
+つまり、同一エージェントについて表示済みの `claimed_role` と `speech.claimed_role` が異なる場合、
+その `speech` を CO 宣言として補助表示してよい。これは観客向けの表示補助であり、
+`decision="co"` の文字列フラグを CO 表示の正本にはしない。
+現行 producer は CO 済みエージェントの後続 `speech` にも現在の `claimed_role` を付与するため、
+`speech.claimed_role != null` かつ `decision == ""` は正常な後続発言として発生する。
 
 ---
 
@@ -130,7 +135,7 @@ CLI の色仕様（役職別カラーなど）は [Spec.md §5](Spec.md) を参�
 | `claimed_role` | `str \| null` | `null` | CO で公言した役職（`speech` に付随） |
 | `inspection_role` | `str \| null` | `null` | 占い結果の役職名（`"Werewolf"` / `"Villager"`） |
 | `reasoning` | `str` | `""` | spectator 限定の思考・理由（§2） |
-| `decision` | `str` | `""` | DISCUSSION 判断フェーズの行動選択 |
+| `decision` | `str` | `""` | イベント種別ごとに意味が異なる互換フィールド。`speech` では旧 CO 補助フラグ、`vote` では投票戦略、`judgment` では旧 DISCUSSION 判断選択。CO 表示の正本は `claimed_role` の状態遷移 |
 | `spectator_content` | `str` | `""` | spectator 版の本文。空なら `content` を使う（§2） |
 
 ---

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -18,7 +18,14 @@ from src.domain.roles import Role
 
 
 class Renderer:
-    """Convert ``LogEvent`` instances into Rich ``Text`` for console output."""
+    """Convert ``LogEvent`` instances into Rich ``Text`` for console output.
+
+    Stateful: tracks each agent's displayed ``claimed_role`` so a CO declaration
+    line is emitted only on a role-state transition. ``on_event`` therefore has a
+    side effect and assumes each event is passed exactly once, in order. A
+    re-rendering frontend (e.g. the planned web migration above) must reset or
+    rebuild this state rather than replay the same events through one instance.
+    """
 
     # Simple events where the output is ``[PREFIX] {display_content}`` in a fixed style.
     # Events needing dynamic style or extra fields (SPEECH, VOTE, JUDGMENT, PHASE_START,
@@ -180,6 +187,10 @@ class Renderer:
         return previous_claim != event.claimed_role
 
     def _track_claimed_role(self, event: LogEvent) -> None:
+        # Also track legacy CO_ANNOUNCEMENT events: they render their own [CO]
+        # line via _SIMPLE_EVENT_STYLES (so they are not _is_co_declaration
+        # candidates), but they still advance the displayed claim so a later
+        # SPEECH with the same role is not mistaken for a new declaration.
         if (
             event.event_type in (EventType.SPEECH, EventType.CO_ANNOUNCEMENT)
             and event.agent is not None

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -33,6 +33,9 @@ class Renderer:
     def __init__(self, agents: list[Actor], spectator_mode: bool = False):
         self.agents = agents
         self.spectator_mode = spectator_mode
+        self._displayed_claimed_roles: dict[str, Role | None] = {
+            agent.name: None for agent in agents
+        }
 
     def on_event(self, event: LogEvent) -> Text | None:
         """Convert a LogEvent to a Rich Text object for display.
@@ -120,6 +123,7 @@ class Renderer:
         else:
             text.append(content)
 
+        self._track_claimed_role(event)
         return text if len(text) > 0 else None
 
     def _render_inspection(self, event: LogEvent, text: Text) -> None:
@@ -165,9 +169,23 @@ class Renderer:
             return event.content[len("[THINK]"):].lstrip()
         return None
 
-    @staticmethod
-    def _is_co_declaration(event: LogEvent) -> bool:
-        return event.claimed_role is not None and event.decision == "co"
+    def _is_co_declaration(self, event: LogEvent) -> bool:
+        if (
+            event.event_type != EventType.SPEECH
+            or event.agent is None
+            or event.claimed_role is None
+        ):
+            return False
+        previous_claim = self._displayed_claimed_roles.get(event.agent)
+        return previous_claim != event.claimed_role
+
+    def _track_claimed_role(self, event: LogEvent) -> None:
+        if (
+            event.event_type in (EventType.SPEECH, EventType.CO_ANNOUNCEMENT)
+            and event.agent is not None
+            and event.claimed_role is not None
+        ):
+            self._displayed_claimed_roles[event.agent] = event.claimed_role
 
     def _get_agent(self, agent_name: str | None) -> Actor | None:
         if agent_name is None:

--- a/src/ui/replay.py
+++ b/src/ui/replay.py
@@ -149,26 +149,6 @@ class ReplayPager:
             all_lines.append(f"\n{build_roster_summary(self._agents)}\n")
 
         for event in events:
-            # Use event.claimed_role (structured field) rather than parsing content text.
-            if (
-                event.event_type in (EventType.SPEECH, EventType.CO_ANNOUNCEMENT)
-                and event.agent
-                and event.claimed_role
-            ):
-                actor = dynamic_actors.get(event.agent)
-                # Defensive replay fallback: some archived speech events carry
-                # claimed_role but no decision="co". Treat the first role-state
-                # transition as the declaration so CO display remains intact.
-                if (
-                    event.event_type == EventType.SPEECH
-                    and event.decision == ""
-                    and actor is not None
-                    and actor.state.claimed_role != event.claimed_role
-                ):
-                    event = event.model_copy(update={"decision": "co"})
-                if event.agent in dynamic_actors:
-                    dynamic_actors[event.agent].state.claimed_role = event.claimed_role
-
             rich_text = renderer.on_event(event)
             if rich_text is None:
                 continue
@@ -177,6 +157,13 @@ class ReplayPager:
             while rendered and rendered[-1] == "":
                 rendered.pop()
             all_lines.extend(rendered)
+            # Use event.claimed_role (structured field) rather than parsing content text.
+            if (
+                event.event_type in (EventType.SPEECH, EventType.CO_ANNOUNCEMENT)
+                and event.agent in dynamic_actors
+                and event.claimed_role
+            ):
+                dynamic_actors[event.agent].state.claimed_role = event.claimed_role
         return all_lines
 
     def run(self) -> None:

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import patch
 
 from src.engine.phase import Phase
-from src.domain.schema import SilentResult, SpeakResult
+from src.domain.schema import CoResult, SilentResult, SpeakResult
 from src.domain.event import EventType
 from src.engine.phase_day import _resolve_post_vote
 
@@ -56,6 +56,47 @@ class TestDiscussionCoDecision:
             if e.event_type == EventType.SPEECH and e.is_public and "silently" in e.content
         ]
         assert len(silent_events) >= 1
+
+    def test_post_co_speech_keeps_claimed_role_without_co_decision(
+        self, make_test_actor, make_test_engine
+    ):
+        """
+        SUT: GameEngine._apply_discussion_result
+        Mock: patch で store.save を no-op に差し替え
+        Level: unit
+        Objective: CO 後の通常発言は claimed_role を保持するが decision="co" は再emitしないこと。
+        """
+        from src.domain.roles import get_role
+
+        seer = make_test_actor("Seer1", "Seer")
+        other = make_test_actor("V1")
+        engine, events = make_test_engine([seer, other])
+
+        with patch("src.agent.store.save"):
+            engine._apply_discussion_result(
+                seer,
+                CoResult(
+                    thought="I should claim.",
+                    speech="I am the seer.",
+                    claim_role=get_role("Seer"),
+                ),
+                Phase.DAY_DISCUSSION,
+            )
+            engine._apply_discussion_result(
+                seer,
+                SpeakResult(
+                    thought="Share result.",
+                    speech="My result is white.",
+                ),
+                Phase.DAY_DISCUSSION,
+            )
+
+        speech_events = [e for e in events if e.event_type == EventType.SPEECH]
+
+        assert speech_events[0].claimed_role == get_role("Seer")
+        assert speech_events[0].decision == "co"
+        assert speech_events[1].claimed_role == get_role("Seer")
+        assert speech_events[1].decision == ""
 
     def test_vote_crashes_when_no_other_alive_player(self, make_test_actor, make_test_engine):
         """

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -161,12 +161,12 @@ def test_speech_claimed_role_generates_co_line(make_test_actor) -> None:
     assert "Alice: I am the seer." in result.plain
 
 
-def test_speech_claimed_role_without_co_decision_does_not_generate_co_line(make_test_actor) -> None:
+def test_speech_claimed_role_transition_generates_co_line_without_decision(make_test_actor) -> None:
     """
     SUT: Renderer._render_speech
     Mock: なし
     Level: unit
-    Objective: CO 済み後続発言に claimed_role が添付されても [CO] 宣言行を二重表示しないこと。
+    Objective: SPEECH.claimed_role が表示済み状態から変化したとき decision に依存せず [CO] 宣言行を表示すること。
     """
     from src.domain.roles import get_role
 
@@ -182,23 +182,28 @@ def test_speech_claimed_role_without_co_decision_does_not_generate_co_line(make_
     result = renderer.on_event(event)
 
     assert result is not None
-    assert "[CO] Alice claims to be Seer" not in result.plain
+    assert "[CO] Alice claims to be Seer" in result.plain
     assert "Alice: I will share my result." in result.plain
 
 
-def test_repeated_co_decision_generates_co_line(make_test_actor) -> None:
+def test_repeated_claimed_role_does_not_generate_co_line(make_test_actor) -> None:
     """
     SUT: Renderer._render_speech
     Mock: なし
     Level: unit
-    Objective: claimed_role が既にある状態でも decision="co" の発言は CO 宣言行として表示されること。
+    Objective: 表示済み claimed_role と同じ役職の後続発言では decision="co" があっても CO 宣言行を二重表示しないこと。
     """
     from src.domain.roles import get_role
 
     actor = make_test_actor("Alice", "Villager")
-    actor.state.claimed_role = get_role("Seer")
     renderer = Renderer([actor], spectator_mode=False)
-    event = _make_event(
+    first_event = _make_event(
+        EventType.SPEECH,
+        agent="Alice",
+        content="I am the seer.",
+        claimed_role=get_role("Seer"),
+    )
+    repeated_event = _make_event(
         EventType.SPEECH,
         agent="Alice",
         content="Again, I am the seer.",
@@ -206,11 +211,44 @@ def test_repeated_co_decision_generates_co_line(make_test_actor) -> None:
         decision="co",
     )
 
-    result = renderer.on_event(event)
+    first_result = renderer.on_event(first_event)
+    repeated_result = renderer.on_event(repeated_event)
+
+    assert first_result is not None
+    assert repeated_result is not None
+    assert "[CO] Alice claims to be Seer" in first_result.plain
+    assert "[CO] Alice claims to be Seer" not in repeated_result.plain
+    assert "Alice: Again, I am the seer." in repeated_result.plain
+
+
+def test_claimed_role_change_generates_new_co_line(make_test_actor) -> None:
+    """
+    SUT: Renderer._render_speech
+    Mock: なし
+    Level: unit
+    Objective: claimed_role が別役職へ変化したとき、新しい CO 宣言行を表示すること。
+    """
+    from src.domain.roles import get_role
+
+    actor = make_test_actor("Alice", "Villager")
+    renderer = Renderer([actor], spectator_mode=False)
+
+    renderer.on_event(_make_event(
+        EventType.SPEECH,
+        agent="Alice",
+        content="I am the seer.",
+        claimed_role=get_role("Seer"),
+    ))
+    result = renderer.on_event(_make_event(
+        EventType.SPEECH,
+        agent="Alice",
+        content="Actually, I am the medium.",
+        claimed_role=get_role("Medium"),
+    ))
 
     assert result is not None
-    assert "[CO] Alice claims to be Seer" in result.plain
-    assert "Alice: Again, I am the seer." in result.plain
+    assert "[CO] Alice claims to be Medium" in result.plain
+    assert "Alice: Actually, I am the medium." in result.plain
 
 
 def test_vote_renders_agent_and_target(make_test_actor) -> None:


### PR DESCRIPTION
﻿## Summary
- Render CO announcement helper lines from `claimed_role` state transitions instead of `decision="co"`.
- Clarify `LogEvent.decision` semantics in `DataSpec.md`, including the normal post-CO case where `claimed_role != null` and `decision == ""`.
- Document and test the #441 producer path: post-CO speech keeps `claimed_role` but does not re-emit `decision="co"`.

## Implementation notes
- `Renderer` now tracks displayed claimed roles and emits `[CO] ...` only when a speech event changes the displayed claim.
- `ReplayPager` no longer mutates archived speech events to inject `decision="co"`; replay display relies on the same role-transition behavior.
- Follow-up scope was split into #444 and #445.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest`
- [x] `uv run pytest --cov=src --cov-report=term-missing`
- [x] `coverage_diff.py --unstaged`

Closes #443
Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
