### PR TITLE
refactor: add dedicated LogEvent.vote_strategy field (closes #445)

### DIFF
--- a/doc/DataSpec.md
+++ b/doc/DataSpec.md
@@ -135,7 +135,8 @@ CLI の色仕様（役職別カラーなど）は [Spec.md §5](Spec.md) を参�
 | `claimed_role` | `str \| null` | `null` | CO で公言した役職（`speech` に付随） |
 | `inspection_role` | `str \| null` | `null` | 占い結果の役職名（`"Werewolf"` / `"Villager"`） |
 | `reasoning` | `str` | `""` | spectator 限定の思考・理由（§2） |
-| `decision` | `str` | `""` | イベント種別ごとに意味が異なる互換フィールド。`speech` では旧 CO 補助フラグ、`vote` では投票戦略、`judgment` では旧 DISCUSSION 判断選択。CO 表示の正本は `claimed_role` の状態遷移 |
+| `vote_strategy` | `str` | `""` | VOTE イベント専用の投票戦略。狼エージェントのみ `"wolf_side"` / `"village_side"` を設定する。旧アーカイブ（`vote_strategy` が存在しないログ）の replay では `decision` にフォールバックする |
+| `decision` | `str` | `""` | 後方互換フィールド。`speech` では旧 CO 補助フラグ、`judgment` では旧 DISCUSSION 判断選択。VOTE の投票戦略は `vote_strategy` へ移行済み（旧アーカイブの read フォールバック用に残存） |
 | `spectator_content` | `str` | `""` | spectator 版の本文。空なら `content` を使う（§2） |
 
 ---

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -113,6 +113,8 @@ const SYSTEM_EVENT_VIEWS = {
     label: '投票',
     leftName: ev => ev.agent,
     rightName: ev => ev.target,
+    // Legacy-Adapter: old logs store vote strategy in decision; new logs use vote_strategy.
+    strategy: ev => ev.vote_strategy || ev.decision || null,
     reasoning: ev => ev.reasoning,
   },
   elimination: {
@@ -156,6 +158,7 @@ function renderConfiguredSystemEvent(ev, roleAssignment, viewerMode) {
       kind={view.kind}
       icon={view.icon}
       label={view.label}
+      strategy={view.strategy?.(ev)}
       reasoning={view.reasoning?.(ev)}
       leftName={view.leftName?.(ev)}
       rightName={view.rightName?.(ev)}
@@ -168,7 +171,7 @@ function renderConfiguredSystemEvent(ev, roleAssignment, viewerMode) {
 }
 
 // --- システム行 ---
-function SystemRow({ kind, icon, label, children, reasoning, ts, leftName, rightName, roleAssignment = {}, viewerMode = 'spectator' }) {
+function SystemRow({ kind, icon, label, children, strategy, reasoning, ts, leftName, rightName, roleAssignment = {}, viewerMode = 'spectator' }) {
   const defaultIcon = { gm: '👁', death: '💀', exec: '⚑', phase: '☾' }[kind] || '⌘';
   return (
     <div className={`${styles.sysrow} ${styles[kind] || ''}`}>
@@ -187,6 +190,9 @@ function SystemRow({ kind, icon, label, children, reasoning, ts, leftName, right
             <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
           )}
         </div>
+        {strategy && viewerMode === 'spectator' && (
+          <div className={styles.strategyBadge}>[strategy: {strategy}]</div>
+        )}
         <ThoughtDetails reasoning={reasoning} viewerMode={viewerMode} />
       </div>
     </div>

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -507,3 +507,6 @@
 
 /* viewerMode: public */
 .lockBadge { font-size: 11px; color: var(--tx-4); padding: 2px 6px; cursor: default; user-select: none; }
+
+/* vote strategy badge */
+.strategyBadge { font-size: 11px; color: var(--tx-3); font-family: var(--mono); margin-top: 2px; }

--- a/src/domain/event.py
+++ b/src/domain/event.py
@@ -51,6 +51,7 @@ class LogEvent(BaseModel):
     inspection_role: RoleField = None
     reasoning: str = ""
     decision: str = ""
+    vote_strategy: str = ""
     spectator_content: str = ""
 
     @classmethod
@@ -69,6 +70,7 @@ class LogEvent(BaseModel):
         inspection_role: RoleField = None,
         reasoning: str = "",
         decision: str = "",
+        vote_strategy: str = "",
         spectator_content: str = "",
     ) -> "LogEvent":
         return cls(
@@ -85,5 +87,6 @@ class LogEvent(BaseModel):
             inspection_role=inspection_role,
             reasoning=reasoning,
             decision=decision,
+            vote_strategy=vote_strategy,
             spectator_content=spectator_content,
         )

--- a/src/engine/phase_day.py
+++ b/src/engine/phase_day.py
@@ -83,7 +83,7 @@ def _run_vote(engine: GameEngine) -> str | None:
             content=f"{actor.name} votes for {target}",
             is_public=True,
             reasoning=vote_output.reasoning,
-            decision=vote_output.strategy or "",
+            vote_strategy=vote_output.strategy or "",
         ))
 
     if not votes:

--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -63,8 +63,10 @@ class Renderer:
 
         elif event.event_type == EventType.VOTE:
             text.append(f"[VOTE] {event.agent} → {event.target}", style="white")
-            if self.spectator_mode and event.decision:
-                text.append(f" [strategy: {event.decision}]", style="dim red")
+            # Legacy-Adapter: old logs store vote strategy in decision; new logs use vote_strategy.
+            strategy = event.vote_strategy or event.decision
+            if self.spectator_mode and strategy:
+                text.append(f" [strategy: {strategy}]", style="dim red")
             if self.spectator_mode and event.reasoning:
                 text.append(f" — {event.reasoning}", style="dim")
 

--- a/tests/contract/test_day_phase_contract.py
+++ b/tests/contract/test_day_phase_contract.py
@@ -284,7 +284,8 @@ class TestVoteOutputFlowContract:
 
         vote_events = [e for e in events if e.event_type == EventType.VOTE and e.agent == "Wolf1"]
         assert len(vote_events) == 1
-        assert vote_events[0].decision == "wolf_side"
+        assert vote_events[0].vote_strategy == "wolf_side"
+        assert vote_events[0].decision == ""
         assert vote_events[0].reasoning == "Seer1 should be eliminated."
         assert vote_events[0].target == "Seer1"
 
@@ -311,7 +312,7 @@ class TestVoteOutputFlowContract:
 
         vote_events = [e for e in events if e.event_type == EventType.VOTE and e.agent == "V1"]
         assert len(vote_events) == 1
-        assert vote_events[0].decision == ""
+        assert vote_events[0].vote_strategy == ""
 
     def test_vote_event_reasoning_comes_from_vote_output(self, make_test_actor, make_test_engine):
         """


### PR DESCRIPTION
## Summary
- `LogEvent` に `vote_strategy: str = ""` フィールドを追加
- `phase_day.py` の VOTE emit を `decision` から `vote_strategy` に移行
- CLI renderer・フロントエンドで `vote_strategy`（旧ログは `decision` にフォールバック）を表示
- `DataSpec.md` に新フィールドとフォールバック仕様を追記

## Implementation notes
- `decision` フィールドは削除しない（`judgment` 後方互換・`speech` CO補助フラグの別用途が残る）
- フォールバック箇所（renderer.py / SpectatorScreen.jsx）に `Legacy-Adapter` コメントを付与

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` 380件パス
- [x] frontend tests 144件パス
- [x] `test_wolf_side_strategy_recorded_in_vote_event`: `vote_strategy=="wolf_side"` かつ `decision==""` をアサート

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)