### PR TITLE
refactor: structure DISCUSSION speech action semantics (#444)

### DIFF
--- a/doc/DataSpec.md
+++ b/doc/DataSpec.md
@@ -136,7 +136,7 @@ CLI の色仕様（役職別カラーなど）は [Spec.md §5](Spec.md) を参�
 | `inspection_role` | `str \| null` | `null` | 占い結果の役職名（`"Werewolf"` / `"Villager"`） |
 | `reasoning` | `str` | `""` | spectator 限定の思考・理由（§2） |
 | `vote_strategy` | `str` | `""` | VOTE イベント専用の投票戦略。狼エージェントのみ `"wolf_side"` / `"village_side"` を設定する。旧アーカイブ（`vote_strategy` が存在しないログ）の replay では `decision` にフォールバックする |
-| `decision` | `str` | `""` | 後方互換フィールド。`speech` では旧 CO 補助フラグ、`judgment` では旧 DISCUSSION 判断選択。VOTE の投票戦略は `vote_strategy` へ移行済み（旧アーカイブの read フォールバック用に残存） |
+| `decision` | `str` | `""` | エージェントのツール選択結果。`speech` イベントでは DISCUSSION ツール選択（`"speak"` / `"challenge"` / `"silent"` / `"co"`）を保持する。`judgment` イベントでは旧 DISCUSSION 判断選択を保持する。旧アーカイブの `speech` イベントには空文字が入っており、VOTE の投票戦略は `vote_strategy` フィールドへ移行済み |
 | `spectator_content` | `str` | `""` | spectator 版の本文。空なら `content` を使う（§2） |
 
 ---

--- a/src/domain/schema.py
+++ b/src/domain/schema.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
-from typing import Annotated, Literal
+from enum import Enum
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import BaseModel, BeforeValidator, PlainSerializer
 
@@ -18,6 +19,13 @@ RoleField = Annotated[
 ]
 
 
+class DiscussionAction(str, Enum):
+    SPEAK = "speak"
+    CHALLENGE = "challenge"
+    SILENT = "silent"
+    CO = "co"
+
+
 class SpeechEntry(BaseModel):
     speech_id: int
     agent: str
@@ -32,6 +40,8 @@ class SpeakResult:
         DISCUSSION tool use result contract. Tests must not synthesize
         free-form replacements. See ``tests/TestStrategy.md`` §5.
     """
+
+    action: ClassVar[DiscussionAction] = DiscussionAction.SPEAK
 
     thought: str
     speech: str
@@ -49,6 +59,8 @@ class ChallengeResult:
         DISCUSSION tool use result contract. See ``tests/TestStrategy.md`` §5.
     """
 
+    action: ClassVar[DiscussionAction] = DiscussionAction.CHALLENGE
+
     thought: str
     speech: str
     reply_to: int
@@ -65,6 +77,8 @@ class CoResult:
         DISCUSSION tool use result contract. See ``tests/TestStrategy.md`` §5.
     """
 
+    action: ClassVar[DiscussionAction] = DiscussionAction.CO
+
     thought: str
     speech: str
     claim_role: Role
@@ -80,6 +94,8 @@ class SilentResult:
     Mock-Policy: Forbidden
         DISCUSSION tool use result contract. See ``tests/TestStrategy.md`` §5.
     """
+
+    action: ClassVar[DiscussionAction] = DiscussionAction.SILENT
 
     reasoning: str
 

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -184,6 +184,7 @@ class GameEngine:
                 agent=actor.name,
                 content=f"{actor.name} is watching the village silently...",
                 is_public=True,
+                decision=result.action,
             ))
             return None
 
@@ -215,7 +216,7 @@ class GameEngine:
             reply_to=reply_to_entry.speech_id if reply_to_entry else None,
             claimed_role=actor.state.claimed_role,
             reasoning=result.thought,
-            decision="co" if isinstance(result, CoResult) else "",
+            decision=result.action,
         ))
 
         if result.suspicion_scores:

--- a/tests/contract/test_day_phase_contract.py
+++ b/tests/contract/test_day_phase_contract.py
@@ -194,7 +194,7 @@ class TestDiscussionCoDecisionContract:
             if e.event_type == EventType.SPEECH and e.agent == "Seer1" and e.speech_id is not None
         ]
         assert [e.claimed_role.name for e in seer_speeches] == ["Seer", "Seer"]
-        assert [e.decision for e in seer_speeches] == ["co", ""]
+        assert [e.decision for e in seer_speeches] == ["co", "speak"]
 
     def test_repeated_co_speech_keeps_co_decision(self, make_test_actor, make_test_engine):
         """
@@ -440,6 +440,98 @@ class TestIntendedCoLifecycleContract:
         assert wolf.state.intended_co is None
         assert wolf.state.claimed_role is not None
         assert wolf.state.claimed_role.name == "Seer"
+
+
+class TestDiscussionActionDecisionContract:
+    def test_speak_result_sets_decision_speak(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result()
+        Mock: call_discussion_parallel returns SpeakResult
+        Level: contract
+        Objective: SpeakResult が返ったとき SPEECH イベントの decision="speak" が emit される契約を検証する。
+        """
+        actor = make_test_actor("Alice")
+        other = make_test_actor("Bob")
+        engine, events = make_test_engine([actor, other])
+
+        engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
+            (actor, SpeakResult(thought="t", speech="Hello")),
+            (other, SilentResult(reasoning="quiet")),
+        ])
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        speech_events = [
+            e for e in events
+            if e.event_type == EventType.SPEECH and e.agent == "Alice" and e.speech_id is not None
+        ]
+        assert len(speech_events) >= 1
+        assert all(e.decision == "speak" for e in speech_events)
+
+    def test_challenge_result_sets_decision_challenge(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result()
+        Mock: call_discussion_parallel returns SpeakResult then ChallengeResult
+        Level: contract
+        Objective: ChallengeResult が返ったとき SPEECH イベントの decision="challenge" が emit される契約を検証する。
+        """
+        actors_list = [make_test_actor("A"), make_test_actor("B")]
+        engine, events = make_test_engine(actors_list)
+        call_count = [0]
+
+        def discussion_with_challenge(actors, *_, **__):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return iter([
+                    (actors_list[0], SpeakResult(thought="t", speech="Hello")),
+                    (actors_list[1], SilentResult(reasoning="quiet")),
+                ])
+            return iter([
+                (actors_list[0], SilentResult(reasoning="quiet")),
+                (actors_list[1], ChallengeResult(thought="t", speech="I disagree!", reply_to=1)),
+            ])
+
+        engine._llm_client.call_discussion_parallel.side_effect = discussion_with_challenge
+
+        with (
+            patch("src.engine.phase_day.DISCUSSION_ROUNDS", 2),
+            patch("src.agent.store.save"),
+        ):
+            engine._run_day()
+
+        challenge_events = [
+            e for e in events
+            if e.event_type == EventType.SPEECH and e.agent == "B" and e.reply_to is not None
+        ]
+        assert len(challenge_events) == 1
+        assert challenge_events[0].decision == "challenge"
+
+    def test_silent_result_sets_decision_silent(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._apply_discussion_result()
+        Mock: call_discussion_parallel returns SilentResult
+        Level: contract
+        Objective: SilentResult が返ったとき SPEECH イベントの decision="silent" が emit される契約を検証する。
+        """
+        actor = make_test_actor("Alice")
+        other = make_test_actor("Bob")
+        engine, events = make_test_engine([actor, other])
+
+        engine._llm_client.call_discussion_parallel.side_effect = lambda actors, *_, **__: iter([
+            (actor, SilentResult(reasoning="nothing to add")),
+            (other, SpeakResult(thought="t", speech="Hi")),
+        ])
+
+        with patch("src.agent.store.save"):
+            engine._run_day()
+
+        silent_events = [
+            e for e in events
+            if e.event_type == EventType.SPEECH and e.agent == "Alice" and e.speech_id is None
+        ]
+        assert len(silent_events) >= 1
+        assert all(e.decision == "silent" for e in silent_events)
 
 
 class TestSpeechThinkHackContract:

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -96,7 +96,7 @@ class TestDiscussionCoDecision:
         assert speech_events[0].claimed_role == get_role("Seer")
         assert speech_events[0].decision == "co"
         assert speech_events[1].claimed_role == get_role("Seer")
-        assert speech_events[1].decision == ""
+        assert speech_events[1].decision == "speak"
 
     def test_vote_crashes_when_no_other_alive_player(self, make_test_actor, make_test_engine):
         """

--- a/tests/unit/ui/test_renderer.py
+++ b/tests/unit/ui/test_renderer.py
@@ -704,3 +704,4 @@ def test_wolf_chat_legacy_think_prefix_renders_dim_red(make_test_actor) -> None:
     assert "secret plan" in result.plain
     spans = [s for s in result._spans if s.style == "dim red"]
     assert len(spans) > 0
+


### PR DESCRIPTION
## Summary
- `DiscussionAction` enum (`str` 継承) を `schema.py` に追加し、`speak`/`challenge`/`silent`/`co` の4値を定義
- 各 `Result` クラス (`SpeakResult`/`ChallengeResult`/`CoResult`/`SilentResult`) に `ClassVar[DiscussionAction]` の `action` フィールドを追加
- producer (`game.py`) で `decision=result.action` と書けるようになり、isinstance チェーンを除去
- `doc/DataSpec.md` の `decision` フィールド説明を「エージェントのツール選択結果を保持する」と前向きに書き直し

## Implementation notes
- `str` 継承 enum なので JSON シリアライズ値は変わらず後方互換を維持
- `decision=""` の旧ログ replay に影響なし

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `TestDiscussionActionDecisionContract` — speak/challenge/silent それぞれの `decision` emit を検証

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)