### PR TITLE
docs: remove deferred issue 435 from Ideas

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -29,7 +29,6 @@
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
 | yukkie/AgentVillage#411 | tech-debt | 🟡 | 5 | Replace div soup with semantic HTML elements | div/span を意味のある要素に置き換え Playwright・アクセシビリティを改善。FrontendDesign.md に方針追記 |
-| yukkie/AgentVillage#435 | bug | 🟡 | 2 | SpectatorScreen drops legacy events (judgment) on replay | 後方互換 read 専用イベント（judgment / 移行前 vote_candidates）を null 破棄し、古いアーカイブ replay で該当行が消える |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |


### PR DESCRIPTION
## Summary
- Remove deferred issue #435 from `doc/Ideas.md`
- Leave implementation design in the closed GitHub issue instead of changing Web replay code

## Test plan
- [x] pre-commit pytest passed during commit
- [x] no frontend source changes

Issue #435 was closed as deferred after adding design notes to the issue thread.

🤖 Generated with [Codex](https://Codex.com/Codex)