### PR TITLE
refactor: semantic HTML for shared components (TopBar/ThreePaneLayout)

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -466,6 +466,10 @@ stateDiagram-v2
 | `collapsibleRight` | `boolean?` | 右ペインに折りたたみボタンを表示 |
 | `leftLabel` | `string?` | 左ペイン折りたたみ時に縦書き表示するラベル |
 | `rightLabel` | `string?` | 右ペイン折りたたみ時に縦書き表示するラベル |
+| `leftAriaLabel` | `string?` | 左 `<aside>` の `aria-label`（complementary landmark の区別用。デフォルト `'左サイドパネル'`） |
+| `rightAriaLabel` | `string?` | 右 `<aside>` の `aria-label`（デフォルト `'右サイドパネル'`） |
+
+左ペインを `<aside aria-label={leftAriaLabel}>`、中央を `<main>`、右ペインを `<aside aria-label={rightAriaLabel}>` でレンダリングする（#411）。grid シェルは純レイアウトのため `<div>` を維持。
 
 CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを制御。`--lcol` / `--rcol` は open 時 256px / 360px、collapsed 時 32px に切り替わり `transition: 220ms ease` でアニメーションする。
 
@@ -556,6 +560,46 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 | `MatrixRow` / `NightRow` | 各リストの行コンポーネント |
 
 データソース: `stub/agentDetail.js`（`ALL_AGENTS`, `DEAD_AGENTS`, `AGENT_BLURB`, `AGENT_STATS`, `THOUGHTS`, `NIGHT_ACTIONS`, `getSuspicionMatrix`）。
+
+### 6.3 セマンティック HTML 設計方針（#411）
+
+意味のあるコンテンツには `<div>`/`<span>` ではなくセマンティック要素を使い、`getByRole`・スクリーンリーダー・クローラーが構造を読み取れるようにする。一方で**装飾目的・レイアウト用の要素は意図的に `<div>`/`<span>` を維持する**。「意味があるか / 装飾か」の線引きを以下に明示する。
+
+> **進捗**: #411 で **共通コンポーネント（`TopBar` / `ThreePaneLayout`）** をセマンティック化済み。3 Screen（GameList / Spectator / AgentDetail）の本体は別 Issue で順次対応する。本セクションは全画面共通の判断基準として維持する。
+
+#### セマンティック要素を使う箇所
+
+| 要素 | 用途 | 適用箇所 |
+|---|---|---|
+| `<main>` | ページの主コンテンツ領域（landmark、1ページ1個） | `ThreePaneLayout` 中央ペイン。各画面は `ThreePaneLayout` を1個マウントするため各画面1 `<main>` |
+| `<aside>` | 補足的サイド領域（role=complementary） | `ThreePaneLayout` 左右ペイン。複数 aside を区別するため `aria-label` を必須にする（`leftAriaLabel` / `rightAriaLabel` props） |
+| `<nav>` | ナビゲーション・パンくず（role=navigation） | `TopBar` パンくず、`GameListScreen` サイドナビ |
+| `<ol>` / `<li>` | 順序のあるリスト（パンくずの階層） | `TopBar` パンくずの `nav > ol > li` 構造 |
+| `<ul>` / `<li>` | 順序を問わないリスト | ロスター・CO ボード・ランキング等（3 Screen 側で順次） |
+| `<article>` | 自己完結したカード | `GameCard`、将来 `SpeechCard` 等（3 Screen 側） |
+| `<h1>`〜`<h5>` | 見出し階層 | 各画面の見出し（適用済み多数） |
+| `<time>` | 日時 | タイムスタンプ（3 Screen 側で順次） |
+| `<strong>` / `<em>` | 強調・他要素との区別 | 本文中の強調語（適用済み多数） |
+
+#### 装飾として `<div>`/`<span>` を維持する箇所
+
+| 箇所 | 維持する理由 |
+|---|---|
+| `ThreePaneLayout` の `.shell`（grid コンテナ） | 純レイアウト。意味は内側の `<main>`/`<aside>` が担う。シェル自体に landmark を付けない |
+| `Avatar` コンポーネント | **装飾ラッパー**。意味（誰のアバターか）は内側の `<img alt={name}>` が既に担保する。`<button>`/`<article>` 化すると、遷移と無関係な装飾箇所（`SystemRow` の左右アイコン・ヒーロー・ランキング等）にまで誤った role が付く |
+| `RoleTag` / `Icon` | インラインの装飾ラベル / `<img>` の薄いラッパー。意味は alt・ラベルテキストが担保 |
+| アイコン・装飾セパレータ（パンくずの `/` 等） | 視覚装飾。`aria-hidden="true"` で読み上げ対象から外す |
+
+#### クリック遷移トリガの扱い（重要）
+
+クリックで画面遷移する要素は、**装飾ラッパー（`Avatar` 等）自体ではなく、それを内包する「行・カード」を interactive 要素（`<button>` / `<a>`(Link)）にする**。`<div onClick>` のままにしない（キーボードフォーカス・role 欠落を避ける）。
+
+- 例: ロスター行クリックで AgentDetail へ遷移する場合、`Avatar` を button 化するのではなく、行 `<a>`(Link) で包む。
+- roster/picker 行の interactive 化（遷移ロジックを伴う）は #342（React Router）で扱う。
+
+#### パンくずの呼び出し契約（`TopBar`）
+
+`crumbs` 配列の各要素は `{ label, onClick? }`。`onClick` を持つ要素のみ `<a href="#">`（link role）としてレンダリングされ、持たない中間要素は非リンクの `<span>` になる（dead link を作らない）。クリック可能にしたい中間 crumb には呼び出し側で `onClick` を渡すこと。
 
 ---
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -28,7 +28,6 @@
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
-| yukkie/AgentVillage#411 | tech-debt | 🟡 | 5 | Replace div soup with semantic HTML elements | div/span を意味のある要素に置き換え Playwright・アクセシビリティを改善。FrontendDesign.md に方針追記 |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |

--- a/frontend/src/components/ThreePaneLayout.jsx
+++ b/frontend/src/components/ThreePaneLayout.jsx
@@ -7,6 +7,8 @@ export default function ThreePaneLayout({
   collapsibleRight = false,
   leftLabel = '',
   rightLabel = '',
+  leftAriaLabel = '左サイドパネル',
+  rightAriaLabel = '右サイドパネル',
 }) {
   const [leftOpen, setLeftOpen] = useState(true);
   const [rightOpen, setRightOpen] = useState(true);
@@ -16,21 +18,21 @@ export default function ThreePaneLayout({
 
   return (
     <div className={styles.shell} style={{ '--lcol': lcol, '--rcol': rcol }}>
-      <div className={`${styles.colLeft} ${!leftOpen ? styles.collapsed : ''}`}>
+      <aside className={`${styles.colLeft} ${!leftOpen ? styles.collapsed : ''}`} aria-label={leftAriaLabel}>
         <div className={styles.colContent}>{left}</div>
         {collapsibleLeft && !leftOpen && leftLabel && (
           <span className={styles.rail}>{leftLabel}</span>
         )}
-      </div>
+      </aside>
 
-      <div className={styles.colCenter}>{children}</div>
+      <main className={styles.colCenter}>{children}</main>
 
-      <div className={`${styles.colRight} ${!rightOpen ? styles.collapsed : ''}`}>
+      <aside className={`${styles.colRight} ${!rightOpen ? styles.collapsed : ''}`} aria-label={rightAriaLabel}>
         {collapsibleRight && !rightOpen && rightLabel && (
           <span className={styles.rail}>{rightLabel}</span>
         )}
         <div className={styles.colContent}>{right}</div>
-      </div>
+      </aside>
 
       {collapsibleLeft && (
         <button

--- a/frontend/src/components/ThreePaneLayout.test.jsx
+++ b/frontend/src/components/ThreePaneLayout.test.jsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import ThreePaneLayout from './ThreePaneLayout.jsx';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ThreePaneLayout landmark semantics', () => {
+  it('renders the center pane as the main landmark', () => {
+    /*
+    SUT: ThreePaneLayout
+    Mock: なし
+    Level: component
+    Objective: 中央ペインが main landmark としてレンダリングされ、children を内包することを検証する。
+    */
+    render(
+      <ThreePaneLayout left={<p>L</p>} right={<p>R</p>}>
+        <p>center content</p>
+      </ThreePaneLayout>
+    );
+
+    const main = screen.getByRole('main');
+    expect(main).toBeTruthy();
+    expect(main.textContent).toContain('center content');
+  });
+
+  it('renders left and right panes as complementary landmarks distinguished by aria-label', () => {
+    /*
+    SUT: ThreePaneLayout
+    Mock: なし
+    Level: component
+    Objective: 左右ペインが aria-label 付き complementary landmark として個別に特定できることを検証する。
+    */
+    render(
+      <ThreePaneLayout
+        left={<p>left content</p>}
+        right={<p>right content</p>}
+        leftAriaLabel="タイムライン"
+        rightAriaLabel="ロスター"
+      >
+        <p>center</p>
+      </ThreePaneLayout>
+    );
+
+    const left = screen.getByRole('complementary', { name: 'タイムライン' });
+    const right = screen.getByRole('complementary', { name: 'ロスター' });
+
+    expect(left.textContent).toContain('left content');
+    expect(right.textContent).toContain('right content');
+  });
+
+  it('falls back to default aria-labels when none are provided', () => {
+    /*
+    SUT: ThreePaneLayout
+    Mock: なし
+    Level: component
+    Objective: aria-label 未指定時にデフォルト値が付き、左右の complementary landmark が依然区別できることを検証する。
+    */
+    render(
+      <ThreePaneLayout left={<p>L</p>} right={<p>R</p>}>
+        <p>center</p>
+      </ThreePaneLayout>
+    );
+
+    expect(screen.getByRole('complementary', { name: '左サイドパネル' })).toBeTruthy();
+    expect(screen.getByRole('complementary', { name: '右サイドパネル' })).toBeTruthy();
+  });
+});

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -13,17 +13,24 @@ export default function TopBar({ crumbs = [], children }) {
         AGENT-WOLF
         <small>v0.13 / Spectator Hub</small>
       </div>
-      <div className={styles.crumb}>
-        {crumbs.map((c, i) => (
-          <span key={i} style={{ display: 'contents' }}>
-            <span className={styles.sep}>/</span>
-            {i < crumbs.length - 1
-              ? <a onClick={c.onClick}>{c.label}</a>
-              : <span className={styles.now}>{c.label}</span>
-            }
-          </span>
-        ))}
-      </div>
+      <nav className={styles.crumb} aria-label="パンくず">
+        <ol className={styles.crumbList}>
+          {crumbs.map((c, i) => {
+            const isCurrent = i === crumbs.length - 1;
+            return (
+              <li key={i} className={styles.crumbItem}>
+                {i > 0 && <span className={styles.sep} aria-hidden="true">/</span>}
+                {isCurrent
+                  ? <span className={styles.now} aria-current="page">{c.label}</span>
+                  : c.onClick
+                    ? <a href="#" onClick={(e) => { e.preventDefault(); c.onClick(); }}>{c.label}</a>
+                    : <span>{c.label}</span>
+                }
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
       <span className={styles.spacer} />
       {children}
     </div>

--- a/frontend/src/components/TopBar.module.css
+++ b/frontend/src/components/TopBar.module.css
@@ -46,9 +46,21 @@
 .crumb {
   display: flex;
   align-items: center;
-  gap: 8px;
   font-size: 12px;
   color: var(--tx-3);
+}
+.crumbList {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.crumbItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 .sep { color: var(--tx-4); }
 .crumb a { color: var(--tx-2); text-decoration: none; cursor: pointer; }

--- a/frontend/src/components/TopBar.test.jsx
+++ b/frontend/src/components/TopBar.test.jsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TopBar from './TopBar.jsx';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TopBar breadcrumb semantics', () => {
+  it('renders breadcrumbs as a navigation landmark', () => {
+    /*
+    SUT: TopBar
+    Mock: なし
+    Level: component
+    Objective: パンくず領域が aria-label 付き navigation landmark として特定できることを検証する。
+    */
+    render(<TopBar crumbs={[{ label: 'r/agent-jinrou', onClick: () => {} }, { label: 'Day 2' }]} />);
+
+    expect(screen.getByRole('navigation', { name: 'パンくず' })).toBeTruthy();
+  });
+
+  it('exposes a clickable crumb as a link and fires onClick on activation', async () => {
+    /*
+    SUT: TopBar
+    Mock: vi.fn（onClick の発火を観測）
+    Level: component
+    Objective: onClick を持つ中間 crumb が link role を持ち、クリックで onClick が発火し、href="#" のデフォルト遷移が抑止されることを検証する。
+    */
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<TopBar crumbs={[{ label: 'r/agent-jinrou', onClick }, { label: 'Day 2' }]} />);
+
+    const link = screen.getByRole('link', { name: 'r/agent-jinrou' });
+    await user.click(link);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render a crumb without onClick as a link', () => {
+    /*
+    SUT: TopBar
+    Mock: なし
+    Level: component
+    Objective: onClick を持たない中間 crumb が link role を持たない（dead link を作らない）ことを検証する退行防止テスト。
+    */
+    render(<TopBar crumbs={[{ label: '観戦' }, { label: 'Day 2' }]} />);
+
+    expect(screen.queryByRole('link', { name: '観戦' })).toBeNull();
+    expect(screen.getByText('観戦')).toBeTruthy();
+  });
+
+  it('marks the last crumb as the current page', () => {
+    /*
+    SUT: TopBar
+    Mock: なし
+    Level: component
+    Objective: 最後の crumb（現在地）に aria-current="page" が付くことを検証する。
+    */
+    render(<TopBar crumbs={[{ label: 'r/agent-jinrou', onClick: () => {} }, { label: 'Day 2' }]} />);
+
+    const current = screen.getByText('Day 2');
+    expect(current.getAttribute('aria-current')).toBe('page');
+  });
+});


### PR DESCRIPTION
@
## Summary
- `TopBar`: パンくずを `<nav><ol><li>` 構造に。`onClick` を持つ crumb のみ `<a href="#">`（link role）にし、持たない crumb は `<span>`（dead link を作らない）。現在地に `aria-current="page"`。
- `ThreePaneLayout`: 中央ペインを `<main>`、左右ペインを `<aside aria-label>` に。2つの complementary landmark を区別するため `leftAriaLabel`/`rightAriaLabel` props を新設（デフォルト値あり）。
- `Avatar`/`RoleTag`/`Icon` は装飾ラッパーのため `<div>`/`<span>` 維持（意味は `<img alt>`／ラベルが担保）。クリック遷移トリガは親の行/カードを interactive 化する方針で #342 に申し送り。
- `doc/FrontendDesign.md` §6.3 にセマンティック HTML 設計方針（セマンティック／装飾の区別、Avatar=装飾の根拠、パンくず契約）を追記。

## Implementation notes
- **スコープ縮小**: #411 は当初全画面対象だったが、横断変更が大きいため本 PR は**共通コンポーネント + doc 方針**に限定。3 Screen のセマンティック化は別 Issue に切り出す（本 PR マージ後に作成）。AC は #411 本文で縮小更新済み。
- **要素種別変更に伴う UA スタイル差分**: `<ol>` の `list-style`/`margin`/`padding` を CSS reset で打ち消し。`<main>`/`<aside>` は既存クラスで `display`/border 指定済みのため見た目不変（Playwright で確認済み）。
- **a11y 改善**: `<a href="#">` でキーボードフォーカス可能に（従来の裸 `<a>` は tab 対象外だった）。`#` スクロール抑止のため `preventDefault`。

## Test plan
- [x] `npm test` パス（全151テスト、回帰なし）
- [x] 新規 contract テスト 7件パス（`TopBar.test.jsx` / `ThreePaneLayout.test.jsx`）
- [x] `getByRole(navigation/link/main/complementary)` で主要要素を特定
- [x] Playwright 目視: `<main>`×1 / `<aside>`×2 / パンくず `<nav>`+`<ol><li>`+`aria-current`、UA reset 有効、dead link なし、レイアウト崩れなし
- [x] pre-commit（pytest / frontend test / coverage）パス

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@