### PR TITLE
docs: add semantic-HTML follow-up issue to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -28,6 +28,7 @@
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
+| yukkie/AgentVillage#455 | tech-debt | 🟡 | - | semantic HTML for the three screens | 3画面（GameList/Spectator/AgentDetail）本体の div soup を FrontendDesign.md §6.3 方針に沿って ul/li・article・time へ置換。#411 の follow-up |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |


### PR DESCRIPTION
## Summary
- 3画面（GameList / Spectator / AgentDetail）のセマンティック HTML 化 follow-up Issue を `doc/Ideas.md` に追記。
- #411（共通コンポ編、マージ済み）の残スコープを引き継ぐ tech-debt として 🟡 区分に登録。

## Notes
- Ideas.md のテーブルは優先度順（🔴→🟡→🟢）。🟡 区分の末尾（旧 #411 の位置付近）に挿入。
- SP は未見積もりのため `-`。`/backlog` の refinement で見積もる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)