### PR TITLE
feat: add winner field to game_over event and display result in SpectatorScreen

### DIFF
--- a/doc/DataSpec.md
+++ b/doc/DataSpec.md
@@ -33,7 +33,7 @@ replay 用に read 側だけが解釈する。新規 emit はしない）の2層
 | `medium_result` | false | — | — | 霊媒結果（観戦者のみ・黄色表示） |
 | `suspicion_update` | false | — | — | 村人視点の疑念スコア更新（観戦者のみ） |
 | `threat_update` | false | — | — | 人狼視点の脅威スコア更新（観戦者のみ） |
-| `game_over` | true | — | — | ゲーム終了 |
+| `game_over` | true | — | — | ゲーム終了。`winner` フィールドに勝者陣営を設定する（`"Villagers"` / `"Werewolves"`） |
 | `phase_start` | true | — | — | フェーズ開始マーカー |
 
 ### 1.2 後方互換イベント（read のみ・新規 emit しない）
@@ -138,6 +138,7 @@ CLI の色仕様（役職別カラーなど）は [Spec.md §5](Spec.md) を参�
 | `vote_strategy` | `str` | `""` | VOTE イベント専用の投票戦略。狼エージェントのみ `"wolf_side"` / `"village_side"` を設定する。旧アーカイブ（`vote_strategy` が存在しないログ）の replay では `decision` にフォールバックする |
 | `decision` | `str` | `""` | エージェントのツール選択結果。`speech` イベントでは DISCUSSION ツール選択（`"speak"` / `"challenge"` / `"silent"` / `"co"`）を保持する。`judgment` イベントでは旧 DISCUSSION 判断選択を保持する。旧アーカイブの `speech` イベントには空文字が入っており、VOTE の投票戦略は `vote_strategy` フィールドへ移行済み |
 | `spectator_content` | `str` | `""` | spectator 版の本文。空なら `content` を使う（§2） |
+| `winner` | `str \| null` | `null` | `game_over` イベント専用。勝者陣営（`"Villagers"` / `"Werewolves"`）。他イベントでは `null` |
 
 ---
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,7 +20,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#351 | enhancement | 🔴 | 2 | Structured game_over event with winner field + frontend result screen | game_over に winner フィールドを追加し文字列パース依存を除去。観戦画面の最終日末尾に勝敗を表示（生存者数等のサマリーは後続） |
 | yukkie/AgentVillage#434 | bug | 🔴 | 2 | SpectatorScreen drops suspicion_update / threat_update (not displayed) | SpectatorScreen が suspicion_update / threat_update を SYSTEM_EVENT_VIEWS に持たず行ごと破棄。CLI renderer は [SUSPICION]/[THREAT] 表示可 |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |

--- a/frontend/src/lib/feedFilter.js
+++ b/frontend/src/lib/feedFilter.js
@@ -36,6 +36,10 @@ export function filterFeedEvents(events, day, phase) {
       return false;
     }
 
+    if (phase === 'game_over') {
+      return ev.event_type === 'game_over';
+    }
+
     return false;
   });
 }

--- a/frontend/src/lib/feedFilter.test.js
+++ b/frontend/src/lib/feedFilter.test.js
@@ -161,4 +161,36 @@ describe('filterFeedEvents', () => {
     const result = filterFeedEvents(events, 1, 'unknown');
     expect(result).toHaveLength(0);
   });
+
+  /*
+  SUT: filterFeedEvents
+  Mock: なし
+  Level: unit
+  Objective: game_over フェーズで game_over イベントのみ返すことを検証する
+  */
+  it('game_over: game_over イベントのみ返す', () => {
+    const events = [
+      ev({ day: 3, event_type: 'game_over', phase: 'game_over', is_public: true, content: 'GAME OVER — Werewolves win!', winner: 'Werewolves' }),
+      ev({ day: 3, event_type: 'speech', phase: 'day_discussion', content: 'hello' }),
+    ];
+    const result = filterFeedEvents(events, 3, 'game_over');
+    expect(result).toHaveLength(1);
+    expect(result[0].event_type).toBe('game_over');
+  });
+
+  /*
+  SUT: filterFeedEvents
+  Mock: なし
+  Level: unit
+  Objective: game_over フェーズで日が一致しないイベントを除外することを検証する
+  */
+  it('game_over: 日が一致しないイベントを除外する', () => {
+    const events = [
+      ev({ day: 3, event_type: 'game_over', phase: 'game_over', is_public: true }),
+      ev({ day: 2, event_type: 'game_over', phase: 'game_over', is_public: true }),
+    ];
+    const result = filterFeedEvents(events, 3, 'game_over');
+    expect(result).toHaveLength(1);
+    expect(result[0].day).toBe(3);
+  });
 });

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -336,11 +336,13 @@ export function parseGameData(jsonlText, agentJsonByName = {}) {
   });
 
   const events = normalizeEvents(rawEvents);
+  const gameOverEvent = rawEvents.find(ev => ev.event_type === 'game_over');
   return {
     events,
     agents,
     daySummary: aggregateDaySummary(rawEvents),
     nightResults: aggregateNightResults(rawEvents),
     actionsTimeline: buildActionsTimeline(rawEvents),
+    winner: gameOverEvent?.winner ?? null,
   };
 }

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -812,3 +812,42 @@ describe('aggregateDaySummary action fields', () => {
     expect(result[1]).toBeUndefined();
   });
 });
+
+describe('parseGameData winner extraction', () => {
+  it('extracts winner from game_over event', () => {
+    /*
+     * SUT: parseGameData
+     * Mock: なし
+     * Level: unit
+     * Objective: spectator_log.jsonl に game_over イベントがあるとき winner フィールドが
+     *            parseGameData の戻り値に含まれることを検証する。
+     */
+    const jsonl = JSON.stringify({ day: 3, phase: 'game_over', event_type: 'game_over', content: 'GAME OVER — Werewolves win!', winner: 'Werewolves', is_public: true });
+    const result = parseGameData(jsonl);
+    expect(result.winner).toBe('Werewolves');
+  });
+
+  it('returns null winner when game_over has no winner field (legacy log)', () => {
+    /*
+     * SUT: parseGameData
+     * Mock: なし
+     * Level: unit
+     * Objective: winner フィールドのない旧アーカイブを読んでもクラッシュせず winner=null になることを検証する。
+     */
+    const jsonl = JSON.stringify({ day: 3, phase: 'game_over', event_type: 'game_over', content: 'GAME OVER — Villagers win!', is_public: true });
+    const result = parseGameData(jsonl);
+    expect(result.winner).toBeNull();
+  });
+
+  it('returns null winner when no game_over event exists', () => {
+    /*
+     * SUT: parseGameData
+     * Mock: なし
+     * Level: unit
+     * Objective: game_over イベントがない場合 winner=null になることを検証する。
+     */
+    const jsonl = JSON.stringify({ day: 1, phase: 'day_discussion', event_type: 'speech', agent: 'Alice', content: 'hello', is_public: true });
+    const result = parseGameData(jsonl);
+    expect(result.winner).toBeNull();
+  });
+});

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -246,6 +246,17 @@ export function FeedItem({ ev, prevById, roleAssignment, title, viewerMode = 'sp
       : <SystemRow kind="exec" icon="🐺" label="人狼の襲撃" rightName={ev.target} roleAssignment={roleAssignment} viewerMode={viewerMode}>{contentForViewer(ev, viewerMode)}</SystemRow>;
   }
 
+  if (ev.event_type === 'game_over') {
+    const winnerClass = ev.winner === 'Werewolves' ? styles.gameOverWolf
+      : ev.winner === 'Villagers' ? styles.gameOverVillage
+      : styles.gameOverUnknown;
+    return (
+      <SystemRow kind="phase" icon="🏁" label="勝敗結果">
+        <span className={`${styles.gameOverText} ${winnerClass}`}>{ev.content}</span>
+      </SystemRow>
+    );
+  }
+
   if (ev.event_type === 'phase_start') {
     if (ev.phase === 'init') {
       return (
@@ -262,7 +273,7 @@ export function FeedItem({ ev, prevById, roleAssignment, title, viewerMode = 'sp
 }
 
 // === 左ペイン ===
-export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary = {} }) {
+export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agentNames, daySummary = {}, gameOverDay = null }) {
   const handlePhase = (d, phase) => {
     setDay(d);
     setPhase(phase);
@@ -302,6 +313,21 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
             </div>
           </div>
         ))}
+        {gameOverDay != null && (
+          <div className={`${styles.dayBlock} ${activePhase === 'game_over' ? styles.dayBlockActive : ''}`}>
+            <div className={styles.phaseDay}>
+              <h3>最終日</h3>
+            </div>
+            <div className={styles.phaseList}>
+              <div
+                className={`${styles.phaseItem} ${styles.phaseGameOver} ${activePhase === 'game_over' ? styles.active : ''}`}
+                onClick={() => { setDay(gameOverDay); setPhase('game_over'); }}
+              >
+                <span className={styles.dot} /> 勝敗結果
+              </div>
+            </div>
+          </div>
+        )}
       </div>
       <div className={styles.filt}>
         <div className={styles.sectionLabel}>参加者で絞る</div>
@@ -472,6 +498,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   const [replayAgents, setReplayAgents] = useState({});
   const [replayDaySummary, setReplayDaySummary] = useState({});
   const [replayDeadByDay, setReplayDeadByDay] = useState({});
+  const [gameWinner, setGameWinner] = useState(null);
+  const [gameOverDay, setGameOverDay] = useState(null);
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
   const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
   const [loadError, setLoadError] = useState(null);
@@ -485,6 +513,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     setReplayAgents({});
     setReplayDaySummary({});
     setReplayDeadByDay({});
+    setGameWinner(null);
+    setGameOverDay(null);
     setLoadingEvents(true);
     setLoadingAgents(true);
     setLoadError(null);
@@ -507,8 +537,10 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         const parsed = parseGameData(jsonlText);
         setReplayEvents(parsed.events);
         setReplayDaySummary(parsed.daySummary);
-
         setReplayDeadByDay(computeDeadByDay(parsed.events));
+        setGameWinner(parsed.winner ?? null);
+        const goEvent = parsed.events.find(e => e.event_type === 'game_over');
+        if (goEvent) setGameOverDay(goEvent.day);
         const firstDay = parsed.events.find(event => event.day)?.day;
         if (firstDay) { setActiveDay(firstDay); setActivePhase('discuss'); }
       })
@@ -545,7 +577,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
 
   return (
     <div className={styles.frame}>
-      <TopBar crumbs={[{ label: '観戦' }, { label: title || sessionId || '第13回 桜霞村' }, { label: `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}` }]}>
+      <TopBar crumbs={[{ label: '観戦' }, { label: title || sessionId || '第13回 桜霞村' }, { label: activePhase === 'game_over' ? '勝敗結果' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}` }]}>
         {onBack && <TopBarBtn onClick={onBack}>← 一覧</TopBarBtn>}
         <TopBarBtn><span className={topBarStyles.liveDot} /> REPLAY</TopBarBtn>
         <TopBarBtn>同時観戦 142</TopBarBtn>
@@ -559,11 +591,11 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
       <ThreePaneLayout
         collapsibleLeft
         collapsibleRight
-        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} />}
+        left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} gameOverDay={gameOverDay} />}
         right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} daySummary={daySummary} activeDay={activeDay} deadByDay={replayDeadByDay} viewerMode={viewerMode} />}
       >
         <div className={styles.feedHead}>
-          <h2>Day {activeDay} {{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]} <small>{sessionId ? sessionId : '3:47 経過 / 残り 4:13'}</small></h2>
+          <h2>{activePhase === 'game_over' ? '勝敗結果' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}`} <small>{sessionId ? sessionId : '3:47 経過 / 残り 4:13'}</small></h2>
           <span className={styles.stat}>発言 <strong>{speechCount}</strong></span>
           <span className={styles.stat}>CO <strong>{coCount}</strong></span>
           <span className={styles.spacer} />

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -510,3 +510,13 @@
 
 /* vote strategy badge */
 .strategyBadge { font-size: 11px; color: var(--tx-3); font-family: var(--mono); margin-top: 2px; }
+
+/* game_over result row in left pane */
+.phaseGameOver { color: var(--tx-2); }
+
+/* game_over result text in centre feed */
+.gameOverText { font-weight: 600; font-family: var(--serif); }
+.gameOverWolf    { color: var(--r-werewolf); }
+.gameOverVillage { color: var(--r-villager); }
+.gameOverUnknown { color: var(--tx); }
+

--- a/src/domain/event.py
+++ b/src/domain/event.py
@@ -53,6 +53,7 @@ class LogEvent(BaseModel):
     decision: str = ""
     vote_strategy: str = ""
     spectator_content: str = ""
+    winner: str | None = None
 
     @classmethod
     def make(
@@ -72,6 +73,7 @@ class LogEvent(BaseModel):
         decision: str = "",
         vote_strategy: str = "",
         spectator_content: str = "",
+        winner: str | None = None,
     ) -> "LogEvent":
         return cls(
             day=day,
@@ -89,4 +91,5 @@ class LogEvent(BaseModel):
             decision=decision,
             vote_strategy=vote_strategy,
             spectator_content=spectator_content,
+            winner=winner,
         )

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -265,4 +265,5 @@ class GameEngine:
             event_type=EventType.GAME_OVER,
             content=f"GAME OVER — {winner} win!",
             is_public=True,
+            winner=winner,
         ))

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -273,6 +273,38 @@ class TestGameOver:
         assert "Werewolves" in game_over_events[0].content
         assert game_over_events[0].is_public is True
 
+    def test_game_over_winner_field_is_set(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._game_over()
+        Mock: なし（make_test_engine の LLMClient mock）
+        Level: unit
+        Objective: _game_over() が emit する GAME_OVER イベントに winner フィールドが
+                   正しくセットされること。Villagers / Werewolves 両方を検証する。
+        """
+        villager = make_test_actor("Alice")
+        engine, events = make_test_engine([villager])
+
+        engine._game_over("Werewolves")
+        wolf_event = next(e for e in events if e.event_type == EventType.GAME_OVER)
+        assert wolf_event.winner == "Werewolves"
+
+        events.clear()
+        engine._game_over("Villagers")
+        village_event = next(e for e in events if e.event_type == EventType.GAME_OVER)
+        assert village_event.winner == "Villagers"
+
+    def test_game_over_winner_default_is_none(self):
+        """
+        SUT: LogEvent
+        Mock: なし
+        Level: unit
+        Objective: winner フィールドがない旧アーカイブ行（winner 未指定）を読んでも
+                   クラッシュせず winner=None になること。
+        """
+        from src.domain.event import LogEvent, EventType
+        ev = LogEvent(day=1, phase="game_over", event_type=EventType.GAME_OVER, content="GAME OVER")
+        assert ev.winner is None
+
 
 class TestResolvePostVote:
     def test_medium_receives_memory_update_and_medium_result_event(


### PR DESCRIPTION
## Summary
- `LogEvent` に `winner: str | None` フィールドを追加（`default=None` で旧アーカイブ後方互換）
- `GameEngine._game_over()` で `winner` フィールドをセットして emit
- `parseGameData()` 戻り値に `winner` を追加（`game_over` イベントから抽出）
- `feedFilter.js` に `game_over` フェーズ対応を追加
- `SpectatorScreen` 左ペインに「最終日 / 勝敗結果」行を追加、中央フィードに勝敗を表示
- `DataSpec.md` の `game_over` 行と §4 スキーマ表に `winner` フィールドを追記

## Implementation notes
- `winner` フィールドがない旧アーカイブを読んでも `winner=null` となりクラッシュしない。`content` による勝敗行は表示される（色分けのみ効かない）
- `activePhase` に `'game_over'` を追加。バックエンドの `Phase.GAME_OVER = "game_over"` と一致させた
- 昼処刑でゲーム終了した際に空の「夜フェーズ」行が残る UI バグは #459 で別途対応
- `game_over` イベントの `day` が最終ゲーム日と同値になっている問題は #458 で別途対応

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `npm test` パス
- [ ] Playwright で「最終日 / 勝敗結果」行クリック → 中央フィードに勝敗表示を目視確認済み

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)