### PR TITLE
fix: game_over day修正と夜フェーズ未実行行の非表示 (#458/#459)

### DIFF
--- a/doc/DataSpec.md
+++ b/doc/DataSpec.md
@@ -33,7 +33,7 @@ replay 用に read 側だけが解釈する。新規 emit はしない）の2層
 | `medium_result` | false | — | — | 霊媒結果（観戦者のみ・黄色表示） |
 | `suspicion_update` | false | — | — | 村人視点の疑念スコア更新（観戦者のみ） |
 | `threat_update` | false | — | — | 人狼視点の脅威スコア更新（観戦者のみ） |
-| `game_over` | true | — | — | ゲーム終了。`winner` フィールドに勝者陣営を設定する（`"Villagers"` / `"Werewolves"`） |
+| `game_over` | true | — | — | ゲーム終了。`winner` フィールドに勝者陣営を設定する（`"Villagers"` / `"Werewolves"`）。`day` は最終ゲーム日 + 1（`Phase.GAME_OVER` 専用フェーズとして扱うため、最終日とは別の day 値を持つ） |
 | `phase_start` | true | — | — | フェーズ開始マーカー |
 
 ### 1.2 後方互換イベント（read のみ・新規 emit しない）

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -304,12 +304,14 @@ export function LeftPane({ activeDay, setDay, activePhase, setPhase, days, agent
               >
                 <span className={styles.dot} /> 投票・処刑 <span className={styles.phaseTurn}>{daySummary[d]?.execResult?.target || '—'}</span>
               </div>
-              <div
-                className={`${styles.phaseItem} ${styles.phaseNight} ${activeDay === d && activePhase === 'night' ? styles.active : ''}`}
-                onClick={() => handlePhase(d, 'night')}
-              >
-                <span className={styles.dot} /> 夜フェーズ <span className={styles.phaseTurn}>{daySummary[d]?.nightActions?.find(a => a.event_type === 'night_attack')?.target ?? ''}</span>
-              </div>
+              {(daySummary[d]?.nightActions?.length > 0 || daySummary[d]?.nightDone) && (
+                <div
+                  className={`${styles.phaseItem} ${styles.phaseNight} ${activeDay === d && activePhase === 'night' ? styles.active : ''}`}
+                  onClick={() => handlePhase(d, 'night')}
+                >
+                  <span className={styles.dot} /> 夜フェーズ <span className={styles.phaseTurn}>{daySummary[d]?.nightActions?.find(a => a.event_type === 'night_attack')?.target ?? ''}</span>
+                </div>
+              )}
             </div>
           </div>
         ))}
@@ -564,7 +566,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
   ), [agents]);
   const replayCoStatus = useMemo(() => aggregateCoStatus(events, activeDay), [events, activeDay]);
   const agentNames = Object.keys(agents);
-  const visibleDays = [...new Set(events.map(event => event.day).filter(Boolean))].sort((a, b) => a - b);
+  const visibleDays = [...new Set(events.filter(e => e.event_type !== 'game_over').map(e => e.day).filter(Boolean))].sort((a, b) => a - b);
 
   const prevById = {};
   events.forEach(e => {

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -577,6 +577,59 @@ describe('RightPane: night actions for activeDay', () => {
   });
 });
 
+describe('LeftPane night phase visibility', () => {
+  it('hides the night phase row when nightActions is empty and nightDone is false', () => {
+    /**
+     * SUT: LeftPane
+     * Mock: なし
+     * Level: unit
+     * Objective: nightActions が空かつ nightDone=false のとき（昼処刑終了など夜フェーズ未実行の日）
+     *            夜フェーズ行が左ペインに表示されないことを検証する (#459)。
+     */
+    renderLeftPane({
+      daySummary: {
+        1: { nightActions: [], execResult: null, speechCount: 0, nightDone: false },
+      },
+    });
+    expect(screen.queryByText(/夜フェーズ/)).toBeNull();
+  });
+
+  it('shows the night phase row when nightActions has entries', () => {
+    /**
+     * SUT: LeftPane
+     * Mock: なし
+     * Level: unit
+     * Objective: nightActions にエントリがある日は夜フェーズ行が表示されることを検証する (#459)。
+     */
+    renderLeftPane({
+      daySummary: {
+        1: {
+          nightActions: [{ event_type: 'inspection', agent: 'Alice', target: 'Bob', is_public: false }],
+          execResult: null,
+          speechCount: 0,
+          nightDone: false,
+        },
+      },
+    });
+    expect(screen.getByText(/夜フェーズ/)).toBeTruthy();
+  });
+
+  it('shows the night phase row when nightDone is true', () => {
+    /**
+     * SUT: LeftPane
+     * Mock: なし
+     * Level: unit
+     * Objective: nightDone=true（公開 night_attack が存在する）日は夜フェーズ行が表示されることを検証する (#459)。
+     */
+    renderLeftPane({
+      daySummary: {
+        1: { nightActions: [], execResult: null, speechCount: 0, nightDone: true },
+      },
+    });
+    expect(screen.getByText(/夜フェーズ/)).toBeTruthy();
+  });
+});
+
 describe('LeftPane phase interaction', () => {
   it.each([
     ['議論フェーズ', 'discuss'],

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -260,7 +260,7 @@ class GameEngine:
 
     def _game_over(self, winner: str) -> None:
         self._emit(LogEvent.make(
-            day=self.day,
+            day=self.day + 1,
             phase=Phase.GAME_OVER.value,
             event_type=EventType.GAME_OVER,
             content=f"GAME OVER — {winner} win!",

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -305,6 +305,24 @@ class TestGameOver:
         ev = LogEvent(day=1, phase="game_over", event_type=EventType.GAME_OVER, content="GAME OVER")
         assert ev.winner is None
 
+    def test_game_over_day_is_last_day_plus_one(self, make_test_actor, make_test_engine):
+        """
+        SUT: GameEngine._game_over()
+        Mock: なし（make_test_engine の LLMClient mock）
+        Level: unit
+        Objective: _game_over() が emit する GAME_OVER イベントの day が self.day + 1 であること。
+                   最終ゲーム日と game_over イベントの day が衝突しないことを保証する (#458)。
+        """
+        villager = make_test_actor("Alice")
+        engine, events = make_test_engine([villager])
+        engine.day = 3
+
+        engine._game_over("Villagers")
+
+        game_over_events = [e for e in events if e.event_type == EventType.GAME_OVER]
+        assert len(game_over_events) == 1
+        assert game_over_events[0].day == 4
+
 
 class TestResolvePostVote:
     def test_medium_receives_memory_update_and_medium_result_event(


### PR DESCRIPTION
## Summary
- `GameEngine._game_over()` の `day` を `self.day + 1` に修正し、最終ゲーム日と `game_over` イベントの衝突を解消 (#458)
- `SpectatorScreen` の `visibleDays` から `game_over` イベントを除外し、左ペインに不正な日付ブロックが表示されないよう修正
- 夜行動イベントが存在しない日（昼処刑終了など）の夜フェーズ行を左ペインに表示しないよう修正 (#459)
- `DataSpec.md` に `game_over` イベントの `day` 仕様を明記

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `vitest run` パス（JS 159件）
- [ ] Playwright でブラウザ動作確認済み（勝敗結果表示・夜フェーズ行の表示/非表示）

Closes #458, closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)