### PR TITLE
docs: backlog refinement #7

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -32,7 +32,6 @@
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |
-| yukkie/AgentVillage#402 | enhancement | 🟢 | 2 | Compact survivors/dead list in right pane | 右ペインの生存者/死亡者リストをコンパクトなレイアウトに変更しコンポーネント化 |
 | yukkie/AgentVillage#403 | enhancement | 🟢 | 2 | Add avatars to CO status and night action sections | CO状況・夜の行動セクションにアバターアイコンを追加しコンポーネント化 |
 | yukkie/AgentVillage#379 | enhancement | 🟢 | 3 | Add static type checking to frontend JS (JSDoc or TypeScript) | フィールド名ミスをエディタ/CIで検出できるようにする。スタブ撤廃（#318）以降に検討 |
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,13 +21,14 @@
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#434 | bug | 🔴 | 2 | SpectatorScreen drops suspicion_update / threat_update (not displayed) | SpectatorScreen が suspicion_update / threat_update を SYSTEM_EVENT_VIEWS に持たず行ごと破棄。CLI renderer は [SUSPICION]/[THREAT] 表示可 |
+| yukkie/AgentVillage#451 | bug | 🔴 | 3 | Persist accumulated suspicion/threat snapshots for replay | suspicion_update/threat_update イベントに accumulated snapshot を extra_data として付与し、リプレイ消費者が単一イベントから状態を復元できるようにする。#434 の前提 |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
-| yukkie/AgentVillage#455 | tech-debt | 🟡 | - | semantic HTML for the three screens | 3画面（GameList/Spectator/AgentDetail）本体の div soup を FrontendDesign.md §6.3 方針に沿って ul/li・article・time へ置換。#411 の follow-up |
+| yukkie/AgentVillage#453 | tech-debt | 🟡 | 3 | semantic HTML for the three screens | 3画面（GameList/Spectator/AgentDetail）本体の div soup を FrontendDesign.md §6.3 方針に沿って ul/li・article・time へ置換。#411 の follow-up |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |


### PR DESCRIPTION
## 変更内容

- **#451 を Ideas.md に追加**: Milestone 2 セクションの #434 直下に追加（bug, priority:high, sp:3）
- **#455 → #453 に差し替え**: 同タイトルの重複 Issue だったため #455 をクローズし、#453 を正として更新
- **#453 に sp:3 を追記**: SP 未設定だったため見積もり追加

## 優先度変更

なし（全 Issue の優先度ラベルは現状と合致）
