### PR TITLE
refactor: semantic HTML for frontend screens

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -216,7 +216,7 @@ stateDiagram-v2
     {+
       == SideWidgets (280px)
       {+
-        == 次回開催 (<section><ul><li>)
+        == 次回開催 (<section>)
         第14回「夜霧の灯台」
         本日 21:00 〜 / 11人標準
         [リマインダー登録]
@@ -488,7 +488,7 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 
 データソース: `stub/gameList.js`（`GAMES`, `TOP_AGENTS`, `COMMUNITY_POSTS`, `VILLAGE_NAME_PRESETS`）。
 
-Semantic HTML: `GameCard` は自己完結したゲーム項目として `<article>`、サイドナビと右ウィジェットの項目群は `<ul><li>` で表現する。リンク風の装飾・投票列・Avatar は従来どおり装飾または操作部品として扱う。
+Semantic HTML: `GameCard` は自己完結したゲーム項目として `<article>`、サイドナビと複数項目を持つ右ウィジェットの項目群は `<ul><li>` で表現する。単独項目の「次回開催」は `<section>` 内の通常コンテンツとして扱う。リンク風の装飾・投票列・Avatar は従来どおり装飾または操作部品として扱う。
 
 #### `SpectatorScreen`
 

--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -159,7 +159,7 @@ stateDiagram-v2
   }
   {+
     {+
-      == SideNav (240px)
+      == SideNav (240px, <nav><ul><li>)
       -- マイページ --
       [⌂] ホーム
       [★] ウォッチ中
@@ -199,7 +199,7 @@ stateDiagram-v2
         [▶ 観戦に戻る]
       }
       {+
-        == GameCard
+        == GameCard (<article>)
         ▲         | 【第13回】観測村「桜霞」— 11人標準ルール
         247        | ● LIVE Day2  r/agent-jinrou  標準11人
         ▼          | [Nox][Mira][Kai][Toma][Shiki]+6  Renの偽占CO疑惑...
@@ -216,13 +216,13 @@ stateDiagram-v2
     {+
       == SideWidgets (280px)
       {+
-        == 次回開催
+        == 次回開催 (<section><ul><li>)
         第14回「夜霧の灯台」
         本日 21:00 〜 / 11人標準
         [リマインダー登録]
       }
       {+
-        == 今週の勝率トップ
+        == 今週の勝率トップ (<section><ul><li>)
         1 | [Nox]  | 72%
         2 | [Kai]  | 68%
         3 | [Sera] | 64%
@@ -230,7 +230,7 @@ stateDiagram-v2
         5 | [Mira] | 58%
       }
       {+
-        == コミュニティ投稿
+        == コミュニティ投稿 (<section><ul><li>)
         Kai の戦術ノート（Sera との連携）
         r/agent-jinrou · 312 upvotes
         ---
@@ -279,14 +279,14 @@ stateDiagram-v2
         Day2 議論  3:47経過/残り4:13 | 発言 19 | CO 2 | 投票確定 6/9 | [⇅ 新しい順][🔍 検索]
       }
       {+
-        == SpeechCard
+        == SpeechCard (<article>, <time>)
         [Ren] | Ren  #42  占い師  ▶占い師CO  D2-01  08:03
                | ▶ (引用なし)
                | 皆さん、重要な情報があります。私は占い師です...
                | [💬 思考ログを読む  213字 · spectator限定]
       }
       {+
-        == SpeechCard
+        == SpeechCard (<article>, <time>)
         [Nox] | Nox  #77  占い師  ▶占い師CO  D2-02  08:06
                | 対抗します。私が真の占い師です。昨夜 Kai を占い...
                | [💬 思考ログを読む  189字 · spectator限定]
@@ -305,7 +305,7 @@ stateDiagram-v2
     } |
     {+
       == RightPane (360px)
-      -- 参加エージェント  9/11生存 --
+      -- 参加エージェント (<ul><li>)  9/11生存 --
       生存 9
       [Nox] Nox  占い師
       [Mira] Mira 狩人
@@ -314,12 +314,12 @@ stateDiagram-v2
       死亡 2
       [Sora] Sora 村人   Day1夜・襲撃
       [Toma] Toma 村人   Day1昼・処刑
-      -- カミングアウト状況 --
+      -- カミングアウト状況 (<ul><li>) --
       占い師 | Ren  | →Mira（白）
       占い師 | Nox  | →Kai（黒）
       霊媒師 | —    | 未CO
       狩人   | —    | 未CO
-      -- 夜の行動・推測 --
+      -- 夜の行動・推測 (<ul><li>) --
       D1N | ◉ Nox    → Kai   占い 黒
       D1N | 盾 Rei   → Nox   護衛
       D1N | ✕ Kai+Sera→Sora  襲撃
@@ -341,7 +341,7 @@ stateDiagram-v2
   }
   {+
     {+
-      == AgentPicker (240px)
+      == AgentPicker (240px, <ul><li>)
       第13回 桜霞 · 全11名  9alive · 2dead
       --
       ▶[Nox]  Nox   占い師  ●  ← selected
@@ -361,7 +361,7 @@ stateDiagram-v2
     {+
       == Center (1fr)
       {+
-        == AgentHero
+        == AgentHero (<header>)
         [Nox]  | Nox
                | 占い師  村人陣営  第13回・桜霞村  生存中・Day2
                | 「静かな夜のように、相手の言葉のほつれを見つける。」
@@ -376,7 +376,7 @@ stateDiagram-v2
         現在の目標  Day2 議論フェーズ
         真の占い師として認知を取りつつ、Kai を確実に処刑へ追い込む...
         --
-        直近の推論  2件 · spectator限定
+        直近の推論 (<ul><li>, <time>)  2件 · spectator限定
         D2 #1 発言前の思考  08:02
         Renが占い師COしてきた。自分と競合する。対抗COするべきか...
         --
@@ -387,7 +387,7 @@ stateDiagram-v2
     {+
       == RightPane (320px)
       {+
-        == 疑い度マトリクス
+        == 疑い度マトリクス (<ul><li>)
         対象  | 疑い←→信頼     | 疑  | 信
         Kai   | ████░░░░░░░░ | 88  | 12
         Sera  | ███░░░░░░░░░ | 74  | 18
@@ -399,7 +399,7 @@ stateDiagram-v2
         Kael  | ███░░░░░░░░░ | 67  | 21
       }
       {+
-        == 夜の行動
+        == 夜の行動 (<ul><li>)
         D1N | 占いを実行 | [Kai]  Kai  | 黒
         D2N | 占いを実行 | [Sera] Sera | 黒
       }
@@ -488,6 +488,8 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 
 データソース: `stub/gameList.js`（`GAMES`, `TOP_AGENTS`, `COMMUNITY_POSTS`, `VILLAGE_NAME_PRESETS`）。
 
+Semantic HTML: `GameCard` は自己完結したゲーム項目として `<article>`、サイドナビと右ウィジェットの項目群は `<ul><li>` で表現する。リンク風の装飾・投票列・Avatar は従来どおり装飾または操作部品として扱う。
+
 #### `SpectatorScreen`
 
 特定ゲームの議論フィードを観戦する画面。発言・処刑・夜の通知をタイムライン順に表示する。SpectatorScreen は全情報開示モード（wolf_chat / inspection / guard 等の非公開イベントも表示する）。
@@ -502,6 +504,8 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 | `RightPane` | ロスター（生存/死亡）/ COボード / 夜の行動タイムライン |
 
 #### viewerMode トグル（#314）
+
+Semantic HTML: `SpeechCard` / `WolfChatCard` は独立した発言カードとして `<article>`、発言時刻は `<time>`、ロスター・COボード・夜行動タイムラインは `<ul><li>` で表現する。`SystemRow` はシステム通知行であり、発言カードとは別扱いにする。
 
 ヘッダーの「観戦者モード / 参加者視点」トグルで `viewerMode: 'spectator' | 'public'` を切り替える。
 
@@ -561,11 +565,13 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 
 データソース: `stub/agentDetail.js`（`ALL_AGENTS`, `DEAD_AGENTS`, `AGENT_BLURB`, `AGENT_STATS`, `THOUGHTS`, `NIGHT_ACTIONS`, `getSuspicionMatrix`）。
 
+Semantic HTML: `AgentHero` は画面内のエージェント見出しとして `<header>`、AgentPicker・推論ログ・夜行動・過去戦績・疑い度マトリクスの行群は `<ul><li>` で表現する。picker 行の clickable 化は React Router 導入時（#342）に `<a>` / `<Link>` として扱う。
+
 ### 6.3 セマンティック HTML 設計方針（#411）
 
 意味のあるコンテンツには `<div>`/`<span>` ではなくセマンティック要素を使い、`getByRole`・スクリーンリーダー・クローラーが構造を読み取れるようにする。一方で**装飾目的・レイアウト用の要素は意図的に `<div>`/`<span>` を維持する**。「意味があるか / 装飾か」の線引きを以下に明示する。
 
-> **進捗**: #411 で **共通コンポーネント（`TopBar` / `ThreePaneLayout`）** をセマンティック化済み。3 Screen（GameList / Spectator / AgentDetail）の本体は別 Issue で順次対応する。本セクションは全画面共通の判断基準として維持する。
+> **進捗**: #411 で **共通コンポーネント（`TopBar` / `ThreePaneLayout`）** をセマンティック化済み。#453 で 3 Screen（GameList / Spectator / AgentDetail）本体の主要カード・リスト・日時・ヘッダーをセマンティック化する。本セクションは全画面共通の判断基準として維持する。
 
 #### セマンティック要素を使う箇所
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -28,7 +28,6 @@
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
-| yukkie/AgentVillage#453 | tech-debt | 🟡 | 3 | semantic HTML for the three screens | 3画面（GameList/Spectator/AgentDetail）本体の div soup を FrontendDesign.md §6.3 方針に沿って ul/li・article・time へ置換。#411 の follow-up |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -158,13 +158,13 @@ function TabSuspicion({ agent }) {
   return (
     <div className={styles.panel}>
       <h3>疑い度マトリクス <small>{agent} 視点</small></h3>
+      <div className={styles.matrixHeader} aria-hidden="true">
+        <div className={styles.matrixHead}>対象</div>
+        <div className={styles.matrixHead}>疑い ←→ 信頼</div>
+        <div className={styles.matrixHead}>疑</div>
+        <div className={styles.matrixHead}>信</div>
+      </div>
       <ul className={styles.matrix} aria-label="疑い度マトリクス">
-        <li className={styles.matrixHeader}>
-          <div className={styles.matrixHead}>対象</div>
-          <div className={styles.matrixHead}>疑い ←→ 信頼</div>
-          <div className={styles.matrixHead}>疑</div>
-          <div className={styles.matrixHead}>信</div>
-        </li>
         {matrix.map(m => (
           <MatrixRow key={m.name} m={m} />
         ))}
@@ -277,13 +277,13 @@ function RightPane({ agent }) {
     <div className={styles.rightInner}>
       <div className={styles.panel}>
         <h3>疑い度マトリクス</h3>
+        <div className={styles.matrixHeader} aria-hidden="true">
+          <div className={styles.matrixHead}>対象</div>
+          <div className={styles.matrixHead}>疑い ←→ 信頼</div>
+          <div className={styles.matrixHead}>疑</div>
+          <div className={styles.matrixHead}>信</div>
+        </div>
         <ul className={styles.matrix} aria-label="疑い度マトリクス">
-          <li className={styles.matrixHeader}>
-            <div className={styles.matrixHead}>対象</div>
-            <div className={styles.matrixHead}>疑い ←→ 信頼</div>
-            <div className={styles.matrixHead}>疑</div>
-            <div className={styles.matrixHead}>信</div>
-          </li>
           {matrix.map(m => <MatrixRow key={m.name} m={m} />)}
         </ul>
       </div>

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -24,12 +24,13 @@ function LeftPane({ current, onPick }) {
         <span className={styles.pickerCount}>{alive.length} alive · {dead.length} dead</span>
       </div>
       <div className={styles.agentPicker}>
+        <ul className={styles.pickerList} aria-label="エージェント一覧">
         {ALL_AGENTS.map(n => {
           const role  = ROLE_ASSIGNMENT[n];
           const r     = ROLES[role];
           const isDead = DEAD_AGENTS.has(n);
           return (
-            <div
+            <li
               key={n}
               className={`${styles.pick} ${current === n ? styles.pickOn : ''} ${isDead ? styles.pickDead : ''}`}
               style={{ '--r-color': r?.color }}
@@ -41,9 +42,10 @@ function LeftPane({ current, onPick }) {
                 <span className={styles.pickRole}>{r?.ja}</span>
               </div>
               <span className={styles.statusDot} />
-            </div>
+            </li>
           );
         })}
+        </ul>
         <div className={styles.sectionLabel} style={{ marginTop: 12 }}>並べ替え</div>
         <div style={{ padding: '0 6px', display: 'flex', flexDirection: 'column', gap: 2 }}>
           <button className={styles.sortBtn}>発言数 ↓</button>
@@ -63,7 +65,7 @@ function AgentHero({ agent }) {
   const winPct = stats.games ? Math.round(stats.wins / stats.games * 100) : 0;
 
   return (
-    <div className={styles.agentHero} style={{ '--r-color': r?.color }}>
+    <header className={styles.agentHero} style={{ '--r-color': r?.color }}>
       <Avatar name={agent} role={role} highlight />
       <div className={styles.heroInfo}>
         <h1>{agent}</h1>
@@ -91,7 +93,7 @@ function AgentHero({ agent }) {
           <div className={styles.statLabel}>応援スコア</div>
         </div>
       </div>
-    </div>
+    </header>
   );
 }
 
@@ -109,15 +111,17 @@ function TabOverview({ agent }) {
       {thoughts.length > 0 && (
         <div className={styles.panel}>
           <h3>直近の推論 <small>{thoughts.length} 件 · spectator限定</small></h3>
-          {thoughts.map((t, i) => (
-            <div className={styles.thought} key={i}>
-              <div className={styles.thoughtHead}>
-                <strong>D{t.day} #{t.speechId} 発言前の思考</strong>
-                <span className={styles.thoughtTs}>{(8 + t.speechId * 2) % 24}:{String((t.speechId * 13) % 60).padStart(2, '0')}</span>
-              </div>
-              <div className={styles.thoughtBody}>{t.text.slice(0, 180)}{t.text.length > 180 ? '…' : ''}</div>
-            </div>
-          ))}
+          <ul className={styles.thoughtList} aria-label="直近の推論">
+            {thoughts.map((t, i) => (
+              <li className={styles.thought} key={i}>
+                <div className={styles.thoughtHead}>
+                  <strong>D{t.day} #{t.speechId} 発言前の思考</strong>
+                  <time className={styles.thoughtTs}>{(8 + t.speechId * 2) % 24}:{String((t.speechId * 13) % 60).padStart(2, '0')}</time>
+                </div>
+                <div className={styles.thoughtBody}>{t.text.slice(0, 180)}{t.text.length > 180 ? '…' : ''}</div>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </>
@@ -133,15 +137,17 @@ function TabThoughts({ agent }) {
   return (
     <div className={styles.panel}>
       <h3>推論ログ <small>{thoughts.length} 件 · spectator限定</small></h3>
-      {thoughts.map((t, i) => (
-        <div className={styles.thought} key={i}>
-          <div className={styles.thoughtHead}>
-            <strong>D{t.day} #{t.speechId} 発言前の思考</strong>
-            <span className={styles.thoughtTs}>{(8 + t.speechId * 2) % 24}:{String((t.speechId * 13) % 60).padStart(2, '0')}</span>
-          </div>
-          <div className={styles.thoughtBody}>{t.text}</div>
-        </div>
-      ))}
+      <ul className={styles.thoughtList} aria-label="推論ログ">
+        {thoughts.map((t, i) => (
+          <li className={styles.thought} key={i}>
+            <div className={styles.thoughtHead}>
+              <strong>D{t.day} #{t.speechId} 発言前の思考</strong>
+              <time className={styles.thoughtTs}>{(8 + t.speechId * 2) % 24}:{String((t.speechId * 13) % 60).padStart(2, '0')}</time>
+            </div>
+            <div className={styles.thoughtBody}>{t.text}</div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -152,15 +158,17 @@ function TabSuspicion({ agent }) {
   return (
     <div className={styles.panel}>
       <h3>疑い度マトリクス <small>{agent} 視点</small></h3>
-      <div className={styles.matrix}>
-        <div className={styles.matrixHead}>対象</div>
-        <div className={styles.matrixHead}>疑い ←→ 信頼</div>
-        <div className={styles.matrixHead}>疑</div>
-        <div className={styles.matrixHead}>信</div>
+      <ul className={styles.matrix} aria-label="疑い度マトリクス">
+        <li className={styles.matrixHeader}>
+          <div className={styles.matrixHead}>対象</div>
+          <div className={styles.matrixHead}>疑い ←→ 信頼</div>
+          <div className={styles.matrixHead}>疑</div>
+          <div className={styles.matrixHead}>信</div>
+        </li>
         {matrix.map(m => (
           <MatrixRow key={m.name} m={m} />
         ))}
-      </div>
+      </ul>
     </div>
   );
 }
@@ -174,7 +182,9 @@ function TabNightActions({ agent }) {
   return (
     <div className={styles.panel}>
       <h3>夜の行動</h3>
-      {actions.map((a, i) => <NightRow key={i} a={a} />)}
+      <ul className={styles.nightList} aria-label="夜の行動">
+        {actions.map((a, i) => <NightRow key={i} a={a} />)}
+      </ul>
     </div>
   );
 }
@@ -192,19 +202,21 @@ function TabHistory({ agent }) {
   return (
     <div className={styles.panel}>
       <h3>過去の戦績 <small>通算 {stats.games} 戦 {stats.wins} 勝</small></h3>
-      {records.map((rec, i) => {
-        const r = ROLES[rec.role];
-        return (
-          <div key={i} className={styles.recordRow} style={{ '--r-color': r?.color }}>
-            <span className={styles.recordNum}>#{rec.game}</span>
-            <span style={{ color: 'var(--tx-3)', fontSize: 11 }}>{rec.village}</span>
-            <span className={styles.recordRole}>{r?.ja}</span>
-            <span className={`${styles.recordResult} ${rec.result ? styles.win : styles.lose}`}>
-              {rec.result ? '勝利' : '敗北'}
-            </span>
-          </div>
-        );
-      })}
+      <ul className={styles.recordList} aria-label="過去の戦績">
+        {records.map((rec, i) => {
+          const r = ROLES[rec.role];
+          return (
+            <li key={i} className={styles.recordRow} style={{ '--r-color': r?.color }}>
+              <span className={styles.recordNum}>#{rec.game}</span>
+              <span style={{ color: 'var(--tx-3)', fontSize: 11 }}>{rec.village}</span>
+              <span className={styles.recordRole}>{r?.ja}</span>
+              <span className={`${styles.recordResult} ${rec.result ? styles.win : styles.lose}`}>
+                {rec.result ? '勝利' : '敗北'}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }
@@ -220,7 +232,7 @@ function NightRow({ a }) {
     : '—';
 
   return (
-    <div className={styles.nightRow}>
+    <li className={styles.nightRow}>
       <div className={styles.nightDay}>D{a.day}{a.phase}</div>
       <div>
         <div className={styles.nightAction}>{a.action}</div>
@@ -230,14 +242,14 @@ function NightRow({ a }) {
         </div>
       </div>
       <div className={`${styles.nightResult} ${resultClass}`}>{resultLabel}</div>
-    </div>
+    </li>
   );
 }
 
 // --- 共通パーツ: マトリクス行 ---
 function MatrixRow({ m }) {
   return (
-    <>
+    <li className={styles.matrixRow}>
       <div className={styles.matrixName}>
         <Avatar name={m.name} size="xs" />
         {m.name}
@@ -252,7 +264,7 @@ function MatrixRow({ m }) {
       </div>
       <div className={styles.matrixNum} style={{ color: 'var(--danger)' }}>{m.suspicion}</div>
       <div className={styles.matrixNum} style={{ color: 'var(--info)' }}>{m.trust}</div>
-    </>
+    </li>
   );
 }
 
@@ -265,18 +277,22 @@ function RightPane({ agent }) {
     <div className={styles.rightInner}>
       <div className={styles.panel}>
         <h3>疑い度マトリクス</h3>
-        <div className={styles.matrix}>
-          <div className={styles.matrixHead}>対象</div>
-          <div className={styles.matrixHead}>疑い ←→ 信頼</div>
-          <div className={styles.matrixHead}>疑</div>
-          <div className={styles.matrixHead}>信</div>
+        <ul className={styles.matrix} aria-label="疑い度マトリクス">
+          <li className={styles.matrixHeader}>
+            <div className={styles.matrixHead}>対象</div>
+            <div className={styles.matrixHead}>疑い ←→ 信頼</div>
+            <div className={styles.matrixHead}>疑</div>
+            <div className={styles.matrixHead}>信</div>
+          </li>
           {matrix.map(m => <MatrixRow key={m.name} m={m} />)}
-        </div>
+        </ul>
       </div>
       {actions.length > 0 && (
         <div className={styles.panel}>
           <h3>夜の行動</h3>
-          {actions.map((a, i) => <NightRow key={i} a={a} />)}
+          <ul className={styles.nightList} aria-label="夜の行動">
+            {actions.map((a, i) => <NightRow key={i} a={a} />)}
+          </ul>
         </div>
       )}
     </div>

--- a/frontend/src/screens/AgentDetailScreen.module.css
+++ b/frontend/src/screens/AgentDetailScreen.module.css
@@ -37,6 +37,15 @@
   flex: 1;
 }
 
+.pickerList,
+.thoughtList,
+.nightList,
+.recordList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .pick {
   display: grid;
   grid-template-columns: 32px 1fr 8px;
@@ -373,10 +382,17 @@
 }
 
 .matrix {
+  font-size: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.matrixHeader,
+.matrixRow {
   display: grid;
   grid-template-columns: 80px 1fr 38px 38px;
   gap: 4px 8px;
-  font-size: 12px;
   align-items: center;
 }
 

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import AgentDetailScreen from './AgentDetailScreen.jsx';
 
 afterEach(() => {
@@ -27,13 +28,14 @@ describe('AgentDetailScreen semantic structure', () => {
      * Level: component
      * Objective: 推論ログ・疑い度マトリクス・夜行動・過去戦績が list/listitem role で特定できることを検証する。
      */
+    const user = userEvent.setup();
     render(<AgentDetailScreen />);
 
     expect(within(screen.getByRole('list', { name: '直近の推論' })).getAllByRole('listitem').length).toBeGreaterThan(0);
-    expect(within(screen.getByRole('list', { name: '疑い度マトリクス' })).getAllByRole('listitem').length).toBeGreaterThan(0);
+    expect(within(screen.getByRole('list', { name: '疑い度マトリクス' })).getAllByRole('listitem')).toHaveLength(8);
     expect(within(screen.getByRole('list', { name: '夜の行動' })).getAllByRole('listitem').length).toBeGreaterThan(0);
 
-    await screen.getByRole('button', { name: '過去の戦績' }).click();
+    await user.click(screen.getByRole('button', { name: '過去の戦績' }));
 
     expect(within(screen.getByRole('list', { name: '過去の戦績' })).getAllByRole('listitem')).toHaveLength(5);
   });

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import AgentDetailScreen from './AgentDetailScreen.jsx';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AgentDetailScreen semantic structure', () => {
+  it('exposes the agent hero as a banner-like header and picker as a list', () => {
+    /*
+     * SUT: AgentDetailScreen / AgentHero / LeftPane
+     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
+     * Level: component
+     * Objective: AgentHero が header、AgentPicker が list/listitem role で特定できることを検証する。
+     */
+    render(<AgentDetailScreen />);
+
+    expect(document.querySelector('header')?.textContent).toContain('Nox');
+    expect(within(screen.getByRole('list', { name: 'エージェント一覧' })).getAllByRole('listitem').length).toBeGreaterThan(0);
+  });
+
+  it('exposes overview thoughts, suspicion matrix, night actions, and history as semantic lists', async () => {
+    /*
+     * SUT: AgentDetailScreen tab panels
+     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
+     * Level: component
+     * Objective: 推論ログ・疑い度マトリクス・夜行動・過去戦績が list/listitem role で特定できることを検証する。
+     */
+    render(<AgentDetailScreen />);
+
+    expect(within(screen.getByRole('list', { name: '直近の推論' })).getAllByRole('listitem').length).toBeGreaterThan(0);
+    expect(within(screen.getByRole('list', { name: '疑い度マトリクス' })).getAllByRole('listitem').length).toBeGreaterThan(0);
+    expect(within(screen.getByRole('list', { name: '夜の行動' })).getAllByRole('listitem').length).toBeGreaterThan(0);
+
+    await screen.getByRole('button', { name: '過去の戦績' }).click();
+
+    expect(within(screen.getByRole('list', { name: '過去の戦績' })).getAllByRole('listitem')).toHaveLength(5);
+  });
+});

--- a/frontend/src/screens/GameListScreen.jsx
+++ b/frontend/src/screens/GameListScreen.jsx
@@ -249,12 +249,8 @@ function RightPane() {
     <div className={styles.sideWidgets}>
       <section className={styles.sideCard}>
         <h5>📅 次回開催</h5>
-        <ul className={styles.sideList} aria-label="次回開催">
-          <li>
-            <div className={styles.nextDate}>第14回「夜霧の灯台」</div>
-            <div className={styles.nextMeta}>本日 21:00 〜 / 11人標準 / 解説付</div>
-          </li>
-        </ul>
+        <div className={styles.nextDate}>第14回「夜霧の灯台」</div>
+        <div className={styles.nextMeta}>本日 21:00 〜 / 11人標準 / 解説付</div>
         <button className={styles.reminderBtn}>リマインダー登録</button>
       </section>
 

--- a/frontend/src/screens/GameListScreen.jsx
+++ b/frontend/src/screens/GameListScreen.jsx
@@ -188,44 +188,56 @@ function GameCard({ g, onOpen }) {
 // === 左サイドナビ ===
 function LeftPane() {
   return (
-    <nav className={styles.sideNav}>
+    <nav className={styles.sideNav} aria-label="ゲーム一覧サイドナビ">
       <div className={styles.sec}>
         <h5>マイページ</h5>
-        <a className={styles.on}><span className={styles.ico}>⌂</span> ホーム</a>
-        <a><span className={styles.ico}>★</span> ウォッチ中</a>
-        <a><span className={styles.ico}>↻</span> 履歴</a>
-        <a><span className={styles.ico}>◎</span> 自分のbot</a>
+        <ul>
+          <li><a className={styles.on}><span className={styles.ico}>⌂</span> ホーム</a></li>
+          <li><a><span className={styles.ico}>★</span> ウォッチ中</a></li>
+          <li><a><span className={styles.ico}>↻</span> 履歴</a></li>
+          <li><a><span className={styles.ico}>◎</span> 自分のbot</a></li>
+        </ul>
       </div>
       <div className={styles.sec}>
         <h5>カテゴリ</h5>
-        <a>
-          <span className={`${styles.ico} ${styles.rCls}`}>🜲</span>
-          進行中の村
-          <span style={{ marginLeft: 'auto', color: 'var(--danger)', fontFamily: 'var(--mono)', fontSize: 11 }}>3</span>
-        </a>
-        <a><span className={`${styles.ico} ${styles.rV}`}>村</span> 村人陣営勝</a>
-        <a><span className={`${styles.ico} ${styles.rW}`}>狼</span> 狼陣営勝</a>
-        <a><span className={styles.ico}>研</span> 研究村</a>
-        <a><span className={styles.ico}>講</span> 解説付き</a>
+        <ul>
+          <li>
+            <a>
+              <span className={`${styles.ico} ${styles.rCls}`}>🜲</span>
+              進行中の村
+              <span style={{ marginLeft: 'auto', color: 'var(--danger)', fontFamily: 'var(--mono)', fontSize: 11 }}>3</span>
+            </a>
+          </li>
+          <li><a><span className={`${styles.ico} ${styles.rV}`}>村</span> 村人陣営勝</a></li>
+          <li><a><span className={`${styles.ico} ${styles.rW}`}>狼</span> 狼陣営勝</a></li>
+          <li><a><span className={styles.ico}>研</span> 研究村</a></li>
+          <li><a><span className={styles.ico}>講</span> 解説付き</a></li>
+        </ul>
       </div>
       <div className={styles.sec}>
         <h5>ルール</h5>
-        <a><span className={styles.ico}>11</span> 標準11人</a>
-        <a><span className={styles.ico}>15</span> 拡張15人</a>
-        <a><span className={styles.ico}>妖</span> 妖狐入り</a>
-        <a><span className={styles.ico}>短</span> 短期戦</a>
+        <ul>
+          <li><a><span className={styles.ico}>11</span> 標準11人</a></li>
+          <li><a><span className={styles.ico}>15</span> 拡張15人</a></li>
+          <li><a><span className={styles.ico}>妖</span> 妖狐入り</a></li>
+          <li><a><span className={styles.ico}>短</span> 短期戦</a></li>
+        </ul>
       </div>
       <div className={styles.sec}>
         <h5>注目エージェント</h5>
-        {TOP_AGENTS.map(({ name, winRate }) => (
-          <a key={name}>
-            <Avatar name={name} size="xs" />
-            {name}
-            <span style={{ marginLeft: 'auto', color: 'var(--tx-3)', fontSize: 11, fontFamily: 'var(--mono)' }}>
-              勝率 {winRate}%
-            </span>
-          </a>
-        ))}
+        <ul>
+          {TOP_AGENTS.map(({ name, winRate }) => (
+            <li key={name}>
+              <a>
+                <Avatar name={name} size="xs" />
+                {name}
+                <span style={{ marginLeft: 'auto', color: 'var(--tx-3)', fontSize: 11, fontFamily: 'var(--mono)' }}>
+                  勝率 {winRate}%
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
     </nav>
   );
@@ -235,34 +247,42 @@ function LeftPane() {
 function RightPane() {
   return (
     <div className={styles.sideWidgets}>
-      <div className={styles.sideCard}>
+      <section className={styles.sideCard}>
         <h5>📅 次回開催</h5>
-        <div className={styles.nextDate}>第14回「夜霧の灯台」</div>
-        <div className={styles.nextMeta}>本日 21:00 〜 / 11人標準 / 解説付</div>
+        <ul className={styles.sideList} aria-label="次回開催">
+          <li>
+            <div className={styles.nextDate}>第14回「夜霧の灯台」</div>
+            <div className={styles.nextMeta}>本日 21:00 〜 / 11人標準 / 解説付</div>
+          </li>
+        </ul>
         <button className={styles.reminderBtn}>リマインダー登録</button>
-      </div>
+      </section>
 
-      <div className={styles.sideCard}>
+      <section className={styles.sideCard}>
         <h5>🏆 今週の勝率トップ</h5>
-        {TOP_AGENTS.map(({ name, winRate }, i) => (
-          <div className={styles.rankRow} key={name}>
-            <span className={styles.rank}>{i + 1}</span>
-            <Avatar name={name} size="xs" />
-            <span className={styles.rankName}>{name}</span>
-            <span className={styles.rankNum}>{winRate}%</span>
-          </div>
-        ))}
-      </div>
+        <ul className={styles.sideList} aria-label="今週の勝率トップ">
+          {TOP_AGENTS.map(({ name, winRate }, i) => (
+            <li className={styles.rankRow} key={name}>
+              <span className={styles.rank}>{i + 1}</span>
+              <Avatar name={name} size="xs" />
+              <span className={styles.rankName}>{name}</span>
+              <span className={styles.rankNum}>{winRate}%</span>
+            </li>
+          ))}
+        </ul>
+      </section>
 
-      <div className={styles.sideCard}>
+      <section className={styles.sideCard}>
         <h5>📰 観戦コミュニティ</h5>
-        {COMMUNITY_POSTS.map((p, i) => (
-          <div className={styles.postItem} key={i}>
-            <div className={styles.postTitle}>{p.title}</div>
-            <div className={styles.postVotes}>r/agent-jinrou · {p.votes} upvotes</div>
-          </div>
-        ))}
-      </div>
+        <ul className={styles.sideList} aria-label="観戦コミュニティ">
+          {COMMUNITY_POSTS.map((p, i) => (
+            <li className={styles.postItem} key={i}>
+              <div className={styles.postTitle}>{p.title}</div>
+              <div className={styles.postVotes}>r/agent-jinrou · {p.votes} upvotes</div>
+            </li>
+          ))}
+        </ul>
+      </section>
     </div>
   );
 }

--- a/frontend/src/screens/GameListScreen.module.css
+++ b/frontend/src/screens/GameListScreen.module.css
@@ -32,6 +32,12 @@
   text-transform: uppercase;
   margin: 8px 0 6px;
 }
+.sec ul,
+.sideList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 .sec a {
   display: flex;
   align-items: center;
@@ -321,6 +327,10 @@
   color: var(--tx-2);
   margin: 0 0 10px;
   letter-spacing: 0.02em;
+}
+
+.sideList {
+  display: block;
 }
 
 .rankRow {

--- a/frontend/src/screens/GameListScreen.test.jsx
+++ b/frontend/src/screens/GameListScreen.test.jsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GameListScreen from './GameListScreen.jsx';
 import * as archiveLoader from '../lib/archiveLoader.js';
@@ -70,5 +70,30 @@ describe('GameListScreen GameCard semantics', () => {
     await waitFor(() => {
       expect(onOpenGame).toHaveBeenCalledWith(game);
     });
+  });
+});
+
+describe('GameListScreen list semantics', () => {
+  it('exposes side navigation and right widgets as semantic lists', async () => {
+    /*
+     * SUT: GameListScreen / LeftPane / RightPane
+     * Mock: fetchGameList（state_archive index の取得を固定）
+     * Level: component
+     * Objective: 左サイドナビと右ウィジェットの項目群が list/listitem role で特定できることを検証する。
+     */
+    mockGameList();
+
+    render(<GameListScreen />);
+    await screen.findByRole('article', { name: '20260510_102927' });
+
+    const sideNav = screen.getByRole('navigation', { name: 'ゲーム一覧サイドナビ' });
+    expect(within(sideNav).getAllByRole('list').length).toBeGreaterThanOrEqual(4);
+    expect(within(sideNav).getAllByRole('listitem').length).toBeGreaterThanOrEqual(10);
+
+    const ranking = screen.getByRole('list', { name: '今週の勝率トップ' });
+    expect(within(ranking).getAllByRole('listitem')).toHaveLength(5);
+
+    const posts = screen.getByRole('list', { name: '観戦コミュニティ' });
+    expect(within(posts).getAllByRole('listitem').length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -67,9 +67,10 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
   const coColor = coedRole ? ROLES[coedRole]?.color : undefined;
 
   return (
-    <div
+    <article
       className={`${styles.speech} ${isWolf ? styles.speechWolf : ''}`}
       style={{ '--r-color': r?.color }}
+      aria-label={`${ev.agent} ${fmtTurn(ev.day, ev.speech_id || 0)} ${fmtTime(ev.day, ev.speech_id || 0)}`}
     >
       <Avatar name={ev.agent} role={isPublic ? undefined : role} />
       <div className={styles.vert} />
@@ -83,7 +84,7 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
               ▶ {ROLES[coedRole]?.ja || coedRole} CO
             </span>
           )}
-          <span className={styles.ts}>{fmtTime(ev.day, ev.speech_id || 0)}</span>
+          <time className={styles.ts}>{fmtTime(ev.day, ev.speech_id || 0)}</time>
         </div>
         {replied && (
           <div className={styles.spQuote}>
@@ -96,7 +97,7 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
         </div>
         <ThoughtDetails reasoning={ev.reasoning} viewerMode={viewerMode} />
       </div>
-    </div>
+    </article>
   );
 }
 
@@ -202,7 +203,7 @@ function SystemRow({ kind, icon, label, children, strategy, reasoning, ts, leftN
 // --- 人狼会話カード ---
 function WolfChatCard({ ev, viewerMode = 'spectator' }) {
   return (
-    <div className={`${styles.speech} ${styles.wolfChat}`}>
+    <article className={`${styles.speech} ${styles.wolfChat}`} aria-label={`${ev.agent} wolf chat`}>
       <Avatar name={ev.agent} />
       <div className={styles.vert} />
       <div>
@@ -212,7 +213,7 @@ function WolfChatCard({ ev, viewerMode = 'spectator' }) {
         <div className={styles.spBody}>{ev.content}</div>
         <ThoughtDetails reasoning={ev.reasoning} viewerMode={viewerMode} />
       </div>
-    </div>
+    </article>
   );
 }
 
@@ -379,7 +380,7 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
   return (
     <div className={styles.roster}>
       <div className={styles.sectionLabel}>カミングアウト状況</div>
-      <div className={styles.coBoard}>
+      <ul className={styles.coBoard} aria-label="カミングアウト状況">
         {Object.entries(ROLES)
           .filter(([k]) => k !== 'Villager' && k !== 'Werewolf' && k !== 'Madman')
           .map(([roleKey, roleDef]) => {
@@ -387,32 +388,32 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
               .filter(([, cr]) => cr === roleKey)
               .map(([name]) => name);
             return (
-              <div key={roleKey} className={styles.coRow} style={{ '--r-color': roleDef.color }}>
+              <li key={roleKey} className={styles.coRow} style={{ '--r-color': roleDef.color }}>
                 <span className={styles.coRole}>{roleDef.ja}</span>
                 <span className={styles.coName} style={{ color: coAgents.length ? 'var(--tx)' : 'var(--tx-3)' }}>
                   {coAgents.length ? coAgents.join(', ') : '未CO'}
                 </span>
-              </div>
+              </li>
             );
           })}
-      </div>
+      </ul>
 
       <div className={styles.sectionLabel}>Day {activeDay} 夜の行動</div>
-      <div className={styles.actionList}>
+      <ul className={styles.actionList} aria-label={`Day ${activeDay} 夜の行動`}>
         {nightActions.map((a, i) => (
-          <div key={i} className={`${styles.action} ${styles[a.event_type] || ''}`}>
+          <li key={i} className={`${styles.action} ${styles[a.event_type] || ''}`}>
             <div className={styles.actionIco}>{NIGHT_ACTION_ICON[a.event_type] || '・'}</div>
             <div className={styles.what}>
               <strong>{a.agent}</strong>
               {a.target && <> → <em style={{ '--r-color': ROLES[roleAssignment[a.target]]?.color }}>{a.target}</em></>}
               <span style={{ color: 'var(--tx-4)', marginLeft: 6 }}>{NIGHT_ACTION_LABEL[a.event_type]}</span>
             </div>
-          </div>
+          </li>
         ))}
         {nightActions.length === 0 && (
-          <div className={styles.action} style={{ color: 'var(--tx-3)' }}>夜の行動ログなし</div>
+          <li className={styles.action} style={{ color: 'var(--tx-3)' }}>夜の行動ログなし</li>
         )}
-      </div>
+      </ul>
 
       {execResult && (
         <>
@@ -440,53 +441,57 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
         <span style={{ float: 'right', color: 'var(--tx-4)' }}>{alive.length} / {order.length} 生存</span>
       </div>
 
-      <div className={styles.rosterSection}>
+      <section className={styles.rosterSection}>
         <h4>生存 <span className={styles.count}>{alive.length}</span></h4>
-        {alive.map(n => {
-          const role = roleAssignment[n];
-          const r = ROLES[role];
-          const coRole = coStatus[n];
-          return (
-            <div key={n} className={styles.rosterRow} style={{ '--r-color': r?.color }}>
-              <Avatar name={n} role={viewerMode === 'spectator' ? role : undefined} size="sm" />
-              <div className={styles.who}>
-                <span className={styles.rosterName}>
-                  {n}
-                  {viewerMode === 'spectator' && <RoleTag role={role} />}
-                  {coRole && (
-                    <span className={styles.coBadge} style={{ '--co-color': ROLES[coRole]?.color }}>▶ {ROLES[coRole]?.ja || coRole} CO</span>
-                  )}
-                </span>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-
-      <div className={styles.rosterSection}>
-        <h4>死亡者 <span className={styles.count}>{deadNames.length}</span></h4>
-        {deadNames.map(n => {
-          const role = roleAssignment[n];
-          const r = ROLES[role];
-          const meta = activeDead.get(n);
-          return (
-            <div key={n} className={`${styles.rosterRow} ${styles.dead}`} style={{ '--r-color': r?.color }}>
-              <Avatar name={n} role={role} size="sm" dead />
-              <div className={styles.whoMeta}>
-                <div className={styles.whoBlock}>
-                  <span className={styles.rosterName}>{n}</span>
-                  <span className={styles.sub}>
-                    <RoleTag role={role} />
+        <ul className={styles.rosterList} aria-label="生存エージェント">
+          {alive.map(n => {
+            const role = roleAssignment[n];
+            const r = ROLES[role];
+            const coRole = coStatus[n];
+            return (
+              <li key={n} className={styles.rosterRow} style={{ '--r-color': r?.color }}>
+                <Avatar name={n} role={viewerMode === 'spectator' ? role : undefined} size="sm" />
+                <div className={styles.who}>
+                  <span className={styles.rosterName}>
+                    {n}
+                    {viewerMode === 'spectator' && <RoleTag role={role} />}
+                    {coRole && (
+                      <span className={styles.coBadge} style={{ '--co-color': ROLES[coRole]?.color }}>▶ {ROLES[coRole]?.ja || coRole} CO</span>
+                    )}
                   </span>
                 </div>
-                {meta && (
-                  <span className={styles.deathReason}>Day {meta.day} · {meta.content}</span>
-                )}
-              </div>
-            </div>
-          );
-        })}
-      </div>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      <section className={styles.rosterSection}>
+        <h4>死亡者 <span className={styles.count}>{deadNames.length}</span></h4>
+        <ul className={styles.rosterList} aria-label="死亡者">
+          {deadNames.map(n => {
+            const role = roleAssignment[n];
+            const r = ROLES[role];
+            const meta = activeDead.get(n);
+            return (
+              <li key={n} className={`${styles.rosterRow} ${styles.dead}`} style={{ '--r-color': r?.color }}>
+                <Avatar name={n} role={role} size="sm" dead />
+                <div className={styles.whoMeta}>
+                  <div className={styles.whoBlock}>
+                    <span className={styles.rosterName}>{n}</span>
+                    <span className={styles.sub}>
+                      <RoleTag role={role} />
+                    </span>
+                  </div>
+                  {meta && (
+                    <span className={styles.deathReason}>Day {meta.day} · {meta.content}</span>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
     </div>
   );
 }

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -441,8 +441,8 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
         <span style={{ float: 'right', color: 'var(--tx-4)' }}>{alive.length} / {order.length} 生存</span>
       </div>
 
-      <section className={styles.rosterSection}>
-        <h4>生存 <span className={styles.count}>{alive.length}</span></h4>
+      <section className={styles.rosterSection} aria-labelledby="roster-alive-heading">
+        <h4 id="roster-alive-heading">生存 <span className={styles.count}>{alive.length}</span></h4>
         <ul className={styles.rosterList} aria-label="生存エージェント">
           {alive.map(n => {
             const role = roleAssignment[n];
@@ -466,8 +466,8 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
         </ul>
       </section>
 
-      <section className={styles.rosterSection}>
-        <h4>死亡者 <span className={styles.count}>{deadNames.length}</span></h4>
+      <section className={styles.rosterSection} aria-labelledby="roster-dead-heading">
+        <h4 id="roster-dead-heading">死亡者 <span className={styles.count}>{deadNames.length}</span></h4>
         <ul className={styles.rosterList} aria-label="死亡者">
           {deadNames.map(n => {
             const role = roleAssignment[n];

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -337,6 +337,11 @@
 /* === Right pane: roster === */
 .roster { flex: 1; overflow-y: auto; padding-bottom: 32px; }
 .rosterSection { padding: 6px 14px 16px; }
+.rosterList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 .rosterSection h4 {
   font-size: 10px;
   letter-spacing: 0.16em;
@@ -381,6 +386,7 @@
 
 /* CO board */
 .coBoard {
+  list-style: none;
   background: var(--bg-2);
   border: 1px solid var(--bd);
   border-radius: var(--r2);
@@ -399,7 +405,11 @@
 .coRow .coMeta { margin-left: auto; color: var(--tx-3); font-size: 10px; font-family: var(--mono); }
 
 /* Action timeline */
-.actionList { padding: 0 12px; }
+.actionList {
+  list-style: none;
+  margin: 0;
+  padding: 0 12px;
+}
 .action {
   display: flex; gap: 10px;
   padding: 8px 6px;
@@ -519,4 +529,3 @@
 .gameOverWolf    { color: var(--r-werewolf); }
 .gameOverVillage { color: var(--r-villager); }
 .gameOverUnknown { color: var(--tx); }
-

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -183,6 +183,41 @@ describe('FeedItem event routing', () => {
   });
 });
 
+describe('FeedItem semantic cards', () => {
+  it.each([
+    ['speech', { event_type: 'speech', agent: 'Alice', content: 'こんにちは', speech_id: 1, is_public: true }, 'Alice D1-01 10:03'],
+    ['wolf_chat', { event_type: 'wolf_chat', agent: 'Bob', content: 'Attack Alice tonight.', is_public: false }, 'Bob wolf chat'],
+  ])('renders %s as an article', (_type, event, name) => {
+    /*
+     * SUT: FeedItem → SpeechCard / WolfChatCard
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: component
+     * Objective: 発言カード相当が article role で特定できることを検証する。
+     */
+    renderFeedItem(event);
+
+    expect(screen.getByRole('article', { name })).toBeTruthy();
+  });
+
+  it('renders speech timestamp as a time element', () => {
+    /*
+     * SUT: FeedItem → SpeechCard
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: component
+     * Objective: 発言タイムスタンプが <time> 要素としてレンダリングされることを検証する。
+     */
+    const { container } = renderFeedItem({
+      event_type: 'speech',
+      agent: 'Alice',
+      content: 'こんにちは',
+      speech_id: 1,
+      is_public: true,
+    });
+
+    expect(container.querySelector('time')?.textContent).toBe('10:03');
+  });
+});
+
 describe('FeedItem: phase_start visibility', () => {
   it('hides day_vote phase_start', () => {
     /**
@@ -448,6 +483,38 @@ describe('RightPane: death reason display (#391)', () => {
       activeDay: 1,
     });
     expect(container.querySelector('[class*="deathReason"]')).toBeNull();
+  });
+});
+
+describe('RightPane semantic lists', () => {
+  it('exposes CO board, night actions, and roster groups as semantic lists', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし（agents / daySummary plain object を入力）
+     * Level: component
+     * Objective: COボード・夜行動・生存/死亡ロスターが list/listitem role で特定できることを検証する。
+     */
+    const daySummary = {
+      1: {
+        nightActions: [
+          { day: 1, event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf', is_public: false },
+        ],
+        execResult: null,
+        speechCount: 0,
+        nightDone: false,
+      },
+    };
+
+    renderRightPane({
+      daySummary,
+      activeDay: 1,
+      coStatus: { Alice: 'Seer' },
+    });
+
+    expect(within(screen.getByRole('list', { name: 'カミングアウト状況' })).getAllByRole('listitem').length).toBeGreaterThan(0);
+    expect(within(screen.getByRole('list', { name: 'Day 1 夜の行動' })).getAllByRole('listitem')).toHaveLength(1);
+    expect(within(screen.getByRole('list', { name: '生存エージェント' })).getAllByRole('listitem')).toHaveLength(2);
+    expect(within(screen.getByRole('list', { name: '死亡者' })).getAllByRole('listitem')).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- Semantic HTML 化を 3 Screen 本体へ適用
  - GameList: side nav / right widgets を `ul/li`、right widgets を `section` 化
  - Spectator: SpeechCard / WolfChatCard を `article`、timestamp を `time`、CO board / night actions / roster を `ul/li` 化
  - AgentDetail: AgentHero を `header`、picker / thoughts / matrix / night actions / history を `ul/li` 化
- `doc/FrontendDesign.md` のワイヤーフレームと screen responsibility に semantic HTML の構造をバックポート
- `doc/Ideas.md` から完了済み #453 を削除

## Implementation notes
- `Avatar` / `RoleTag` / `Icon` は設計方針どおり装飾要素として維持
- roster/picker の clickable 化は本 Issue では扱わず、#342 React Router に委譲
- `ul` の UA stylesheet 差分は CSS Modules 内で `list-style: none; margin: 0; padding: 0;` により打ち消し

## Test plan
- [x] `npm.cmd test`
- [x] `npm.cmd run test:coverage`
- [x] `npm.cmd run build`
- [x] `git diff --check`
- [x] `localhost:5173` HTTP 200 確認
- [ ] Playwright screenshot は環境制約で未実施
  - MCP Playwright: 既存 browser profile が使用中
  - Node REPL Playwright: sandbox 起因で kernel exit

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)