### PR TITLE
docs: add datetime policy issue to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -29,6 +29,7 @@
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
 | yukkie/AgentVillage#453 | tech-debt | 🟡 | 3 | semantic HTML for the three screens | 3画面（GameList/Spectator/AgentDetail）本体の div soup を FrontendDesign.md §6.3 方針に沿って ul/li・article・time へ置換。#411 の follow-up |
+| yukkie/AgentVillage#464 | tech-debt | 🟡 | 1 | Define datetime policy for UI time elements | `<time>` 要素の `datetime` 付与方針を整理し、ゲーム内模擬時刻・実世界日時・ログ由来 timestamp の扱いを FrontendDesign.md に明記 |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |


### PR DESCRIPTION
## Summary
- Add the newly created follow-up issue for `<time datetime>` policy to `doc/Ideas.md`

## Test plan
- [x] pre-commit hook ran `pytest`

Note: this PR intentionally does not use auto-close keywords.