### PR TITLE
feat: persist accumulated suspicion/threat snapshots for replay

### DIFF
--- a/doc/DataSpec.md
+++ b/doc/DataSpec.md
@@ -139,6 +139,10 @@ CLI の色仕様（役職別カラーなど）は [Spec.md §5](Spec.md) を参�
 | `decision` | `str` | `""` | エージェントのツール選択結果。`speech` イベントでは DISCUSSION ツール選択（`"speak"` / `"challenge"` / `"silent"` / `"co"`）を保持する。`judgment` イベントでは旧 DISCUSSION 判断選択を保持する。旧アーカイブの `speech` イベントには空文字が入っており、VOTE の投票戦略は `vote_strategy` フィールドへ移行済み |
 | `spectator_content` | `str` | `""` | spectator 版の本文。空なら `content` を使う（§2） |
 | `winner` | `str \| null` | `null` | `game_over` イベント専用。勝者陣営（`"Villagers"` / `"Werewolves"`）。他イベントでは `null` |
+| `suspicion_snapshot` | `dict[str, float] \| null` | `null` | `suspicion_update` イベント専用。デルタ適用**後**の累積疑念スコア（`agent.json` に永続化されるメモリと同一ソース）。`content` が LLM 由来のデルタトレースなのに対し、これは各時点の全体状態スナップショット。旧アーカイブには存在せず `null`。consumer は欠如時に snapshot 依存の表示をフォールバックし、`content` のデルタトレースは従来どおり表示する |
+| `threat_snapshot` | `dict[str, float] \| null` | `null` | `threat_update` イベント専用。デルタ適用**後**の累積脅威スコア（狼のみ）。`suspicion_snapshot` と同様、旧アーカイブには無く `null`・consumer は欠如時フォールバック |
+
+> **snapshot フィールドの後方互換**: `suspicion_snapshot` / `threat_snapshot` は追加フィールドであり、これらを持たない旧アーカイブも読み込み・replay 可能でなければならない（欠如＝`null` として扱う）。replay/Web consumer は `content` を累積状態の正本としてパースしてはならない。累積状態が必要なときは snapshot を読み、無ければ従来挙動にフォールバックする。
 
 ---
 

--- a/doc/DetailDesign.md
+++ b/doc/DetailDesign.md
@@ -364,6 +364,11 @@ CO 表示は `SPEECH` イベントの `claimed_role: str | None` フィールド
 エージェントが行動を選んだ理由を格納し、観戦者モードで表示する。他エージェントのゲーム状態には含めない（`is_public=False` または表示フィルタで制御）。
 既存アーカイブとの後方互換は `default=""` で対応する。
 
+`SUSPICION_UPDATE` / `THREAT_UPDATE` イベントには `suspicion_snapshot` / `threat_snapshot: dict[str, float] | None` フィールドを使う。
+`content` は LLM が返したデルタのテキストトレース（デバッグ用）として据え置き、snapshot にはデルタ適用**後**の累積スコアを格納する。replay consumer は1イベントだけで各時点の全体状態を復元でき、過去イベントの再生や `content` パースや `agent.json` 読み込みを要しない。
+snapshot の導出は `game.py` にインラインせず `agent/memory.py` の純粋ヘルパ（`suspicion_snapshot()` / `threat_snapshot()`）に置く。更新（`update_beliefs()` / `update_threat_scores()`）と同じ場所に導出を並べ、producer 側のイベント生成にメモリ状態のフラット化が散らばらないようにする。スナップショットと `agent.json` は同一の post-update メモリから導出され、replay 専用アキュムレータは持たない。
+既存アーカイブとの後方互換は `default=None` で対応し、`None` の場合は snapshot 依存表示をフォールバックする。
+
 ---
 
 ## src/ui/ — UIレイヤー

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,7 +21,6 @@
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#434 | bug | 🔴 | 2 | SpectatorScreen drops suspicion_update / threat_update (not displayed) | SpectatorScreen が suspicion_update / threat_update を SYSTEM_EVENT_VIEWS に持たず行ごと破棄。CLI renderer は [SUSPICION]/[THREAT] 表示可 |
-| yukkie/AgentVillage#451 | bug | 🔴 | 3 | Persist accumulated suspicion/threat snapshots for replay | suspicion_update/threat_update イベントに accumulated snapshot を extra_data として付与し、リプレイ消費者が単一イベントから状態を復元できるようにする。#434 の前提 |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -43,3 +43,23 @@ def update_threat_scores(actor: Actor, threat_scores: dict[str, float]) -> Actor
     except OSError as e:
         raise OSError(f"Failed to persist threat scores for {actor.name}: {e}") from e
     return actor
+
+
+def suspicion_snapshot(actor: Actor) -> dict[str, float]:
+    """Return the actor's post-update accumulated suspicion state.
+
+    Derived from the same in-memory ``beliefs`` that ``update_beliefs`` writes
+    and ``store.save`` persists to ``agent.json``. No separate replay-only
+    accumulator is maintained.
+    """
+    return {name: belief.suspicion for name, belief in actor.state.beliefs.items()}
+
+
+def threat_snapshot(actor: Actor) -> dict[str, float]:
+    """Return the actor's post-update accumulated threat state.
+
+    Derived from the same in-memory ``threat_scores`` that
+    ``update_threat_scores`` writes and ``store.save`` persists to
+    ``agent.json``. Intended for Werewolf actors only.
+    """
+    return dict(actor.state.threat_scores)

--- a/src/domain/event.py
+++ b/src/domain/event.py
@@ -54,6 +54,8 @@ class LogEvent(BaseModel):
     vote_strategy: str = ""
     spectator_content: str = ""
     winner: str | None = None
+    suspicion_snapshot: dict[str, float] | None = None
+    threat_snapshot: dict[str, float] | None = None
 
     @classmethod
     def make(
@@ -74,6 +76,8 @@ class LogEvent(BaseModel):
         vote_strategy: str = "",
         spectator_content: str = "",
         winner: str | None = None,
+        suspicion_snapshot: dict[str, float] | None = None,
+        threat_snapshot: dict[str, float] | None = None,
     ) -> "LogEvent":
         return cls(
             day=day,
@@ -92,4 +96,6 @@ class LogEvent(BaseModel):
             vote_strategy=vote_strategy,
             spectator_content=spectator_content,
             winner=winner,
+            suspicion_snapshot=suspicion_snapshot,
+            threat_snapshot=threat_snapshot,
         )

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -230,6 +230,7 @@ class GameEngine:
                 event_type=EventType.SUSPICION_UPDATE,
                 agent=actor.name,
                 content=f"{actor.name} suspicion update: {scores_str}",
+                suspicion_snapshot=memory_mod.suspicion_snapshot(actor),
                 is_public=False,
             ))
 
@@ -244,6 +245,7 @@ class GameEngine:
                 event_type=EventType.THREAT_UPDATE,
                 agent=actor.name,
                 content=f"{actor.name} threat update: {scores_str}",
+                threat_snapshot=memory_mod.threat_snapshot(actor),
                 is_public=False,
             ))
 

--- a/tests/unit/test_game_day_loop.py
+++ b/tests/unit/test_game_day_loop.py
@@ -232,6 +232,81 @@ class TestApplyDiscussionResult:
         assert "Alice=0.90" in threat_events[0].content
         assert threat_events[0].is_public is False
 
+    def test_suspicion_update_event_carries_post_update_snapshot(
+        self, make_test_actor, make_test_engine
+    ):
+        """
+        SUT: GameEngine._apply_discussion_result with SpeakResult
+        Mock: patch で store.save を no-op に差し替え
+        Level: unit
+        Objective: 複数回の部分 suspicion 更新で、2回目の SUSPICION_UPDATE イベントの
+                   suspicion_snapshot が累積状態（Bob と Carol 両方）を含み、content は
+                   その回のデルタのみを反映すること。
+        """
+        actor = make_test_actor("Alice")
+        engine, events = make_test_engine([actor, make_test_actor("Bob"), make_test_actor("Carol")])
+
+        with patch("src.agent.store.save"):
+            engine._apply_discussion_result(
+                actor,
+                SpeakResult(thought="t", speech="s", suspicion_scores={"Bob": 0.8}),
+                Phase.DAY_DISCUSSION,
+            )
+            engine._apply_discussion_result(
+                actor,
+                SpeakResult(thought="t", speech="s", suspicion_scores={"Carol": 0.3}),
+                Phase.DAY_DISCUSSION,
+            )
+
+        suspicion_events = [e for e in events if e.event_type == EventType.SUSPICION_UPDATE]
+        assert len(suspicion_events) == 2
+        # 1回目: snapshot は Bob のみ、content も Bob のデルタ
+        assert suspicion_events[0].suspicion_snapshot == {"Bob": pytest.approx(0.8)}
+        assert "Bob=0.80" in suspicion_events[0].content
+        assert "Carol" not in suspicion_events[0].content
+        # 2回目: snapshot は累積（Bob と Carol）、content は Carol のデルタのみ
+        assert suspicion_events[1].suspicion_snapshot == {
+            "Bob": pytest.approx(0.8),
+            "Carol": pytest.approx(0.3),
+        }
+        assert "Carol=0.30" in suspicion_events[1].content
+        assert "Bob" not in suspicion_events[1].content
+
+    def test_threat_update_event_carries_post_update_snapshot(
+        self, make_test_actor, make_test_engine
+    ):
+        """
+        SUT: GameEngine._apply_discussion_result with SpeakResult
+        Mock: patch で store.save を no-op に差し替え
+        Level: unit
+        Objective: 複数回の部分 threat 更新で、2回目の THREAT_UPDATE イベントの threat_snapshot
+                   が累積状態（Seer と Knight 両方）を含み、content はその回のデルタのみを反映すること。
+        """
+        wolf = make_test_actor("Wolf", "Werewolf")
+        engine, events = make_test_engine([wolf, make_test_actor("Seer"), make_test_actor("Knight")])
+
+        with patch("src.agent.store.save"):
+            engine._apply_discussion_result(
+                wolf,
+                SpeakResult(thought="t", speech="s", threat_scores={"Seer": 0.9}),
+                Phase.DAY_DISCUSSION,
+            )
+            engine._apply_discussion_result(
+                wolf,
+                SpeakResult(thought="t", speech="s", threat_scores={"Knight": 0.4}),
+                Phase.DAY_DISCUSSION,
+            )
+
+        threat_events = [e for e in events if e.event_type == EventType.THREAT_UPDATE]
+        assert len(threat_events) == 2
+        assert threat_events[0].threat_snapshot == {"Seer": pytest.approx(0.9)}
+        assert threat_events[1].threat_snapshot == {
+            "Seer": pytest.approx(0.9),
+            "Knight": pytest.approx(0.4),
+        }
+        assert "Knight=0.40" in threat_events[1].content
+        assert "Seer" not in threat_events[1].content
+
     def test_memory_update_is_applied(self, make_test_actor, make_test_engine):
         """
         SUT: GameEngine._apply_discussion_result with SpeakResult

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -1,7 +1,13 @@
 """src/agent/memory.py のテスト。"""
 import pytest
 
-from src.agent.memory import update_beliefs, update_memory, update_threat_scores
+from src.agent.memory import (
+    suspicion_snapshot,
+    threat_snapshot,
+    update_beliefs,
+    update_memory,
+    update_threat_scores,
+)
 
 def test_update_memory_appends_new_items(monkeypatch, make_test_actor) -> None:
     """
@@ -174,3 +180,60 @@ def test_update_threat_scores_raises_on_io_error(monkeypatch, make_test_actor) -
     actor = make_test_actor("Wolf")
     with pytest.raises(OSError, match="Failed to persist threat scores for Wolf"):
         update_threat_scores(actor, {"Seer": 0.7})
+
+
+def test_suspicion_snapshot_reflects_accumulated_beliefs(monkeypatch, make_test_actor) -> None:
+    """
+    SUT: suspicion_snapshot()
+    Mock: monkeypatch で store.save を no-op に差し替え
+    Level: unit
+    Objective: 複数回の部分更新後、snapshot が累積した全 belief の suspicion を返すこと。
+    """
+    from src.agent import memory as mem_mod
+    monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
+    actor = make_test_actor("Alice")
+    update_beliefs(actor, {"Bob": 0.8})
+    update_beliefs(actor, {"Carol": 0.3})
+    assert suspicion_snapshot(actor) == {"Bob": pytest.approx(0.8), "Carol": pytest.approx(0.3)}
+
+
+def test_suspicion_snapshot_empty_when_no_beliefs(make_test_actor) -> None:
+    """
+    SUT: suspicion_snapshot()
+    Mock: なし
+    Level: unit
+    Objective: belief が無い actor では空 dict を返すこと。
+    """
+    actor = make_test_actor("Alice")
+    assert suspicion_snapshot(actor) == {}
+
+
+def test_threat_snapshot_reflects_accumulated_scores(monkeypatch, make_test_actor) -> None:
+    """
+    SUT: threat_snapshot()
+    Mock: monkeypatch で store.save を no-op に差し替え
+    Level: unit
+    Objective: 複数回の部分更新後、snapshot が累積した全 threat_scores を返すこと。
+    """
+    from src.agent import memory as mem_mod
+    monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
+    actor = make_test_actor("Wolf")
+    update_threat_scores(actor, {"Seer": 0.9})
+    update_threat_scores(actor, {"Knight": 0.4})
+    assert threat_snapshot(actor) == {"Seer": pytest.approx(0.9), "Knight": pytest.approx(0.4)}
+
+
+def test_threat_snapshot_is_a_copy(monkeypatch, make_test_actor) -> None:
+    """
+    SUT: threat_snapshot()
+    Mock: monkeypatch で store.save を no-op に差し替え
+    Level: unit
+    Objective: 返す dict が actor.state.threat_scores と別オブジェクトで、後続更新の影響を受けないこと。
+    """
+    from src.agent import memory as mem_mod
+    monkeypatch.setattr(mem_mod.store, "save", lambda _: None)
+    actor = make_test_actor("Wolf")
+    update_threat_scores(actor, {"Seer": 0.9})
+    snap = threat_snapshot(actor)
+    update_threat_scores(actor, {"Seer": 0.1})
+    assert snap["Seer"] == pytest.approx(0.9)

--- a/tests/unit/test_vote_candidates_event.py
+++ b/tests/unit/test_vote_candidates_event.py
@@ -138,3 +138,51 @@ class TestSuspicionUpdateRenderer:
         result = renderer.on_event(event)
 
         assert result is None
+
+
+# ── backward compatibility ────────────────────────────────────────────────────
+
+
+class TestSnapshotBackwardCompat:
+    def test_legacy_event_without_snapshot_defaults_to_none(self):
+        """
+        SUT: LogEvent (model validation)
+        Mock: なし
+        Level: unit
+        Objective: snapshot フィールドを持たない旧アーカイブ相当の dict を
+                   LogEvent として検証でき、suspicion_snapshot/threat_snapshot が None になること。
+        """
+        legacy = {
+            "day": 1,
+            "phase": "day_discussion",
+            "event_type": "suspicion_update",
+            "agent": "Alice",
+            "content": "Alice suspicion update: Bob=0.70",
+            "is_public": False,
+        }
+
+        event = LogEvent.model_validate(legacy)
+
+        assert event.suspicion_snapshot is None
+        assert event.threat_snapshot is None
+
+    def test_renderer_handles_event_without_snapshot(self):
+        """
+        SUT: Renderer.on_event (SUSPICION_UPDATE)
+        Mock: なし
+        Level: unit
+        Objective: snapshot を持たない旧イベントでも renderer が content デルタトレースを
+                   従来どおり表示すること（snapshot 欠如時フォールバック）。
+        """
+        renderer = Renderer([], spectator_mode=True)
+        event = _make_event(
+            EventType.SUSPICION_UPDATE,
+            agent="Alice",
+            content="Alice suspicion update: Bob=0.70",
+            is_public=False,
+        )
+
+        result = renderer.on_event(event)
+
+        assert result is not None
+        assert "Alice suspicion update" in result.plain


### PR DESCRIPTION
## Summary
- `LogEvent` に top-level optional フィールド `suspicion_snapshot` / `threat_snapshot: dict[str, float] | None` を追加（Option A — 既存の `winner`/`vote_strategy` 等と同スタイル）
- `suspicion_update` / `threat_update` イベントに、デルタ適用**後**の累積スコアを載せ、replay consumer が過去イベント再生・`content` パース・`agent.json` 読み込みなしに各時点の全体状態を復元できるようにした
- snapshot 導出は `game.py` にインラインせず `agent/memory.py` の純粋ヘルパ（`suspicion_snapshot()` / `threat_snapshot()`）に集約。`agent.json` と同一メモリから導出し、replay 専用アキュムレータは持たない

## Implementation notes
- **追加制約（#466 由来）**: 導出ロジックを engine にフラット化して散らさないため、更新（`update_beliefs` / `update_threat_scores`）と同じ `memory.py` に導出ヘルパを置いた。更新関数のシグネチャ（`-> Actor`）は温存し、既存呼び出しへの波及を回避
- `content` は LLM デルタのテキストトレースとして据え置き（挙動変更なし）
- schema 方針論（`extra_data` / discriminated union）は #466 に切り出し済みで本 PR では決めない
- 後方互換: 旧アーカイブは snapshot 欠如 → `None` default でパース可能。CLI renderer・JS parser は新フィールドを読まないため挙動不変
- ドキュメント更新: `doc/DataSpec.md` §4 フィールド表 + 後方互換注記、`doc/DetailDesign.md` の LogEvent フィールド節

## Test plan
- [x] `ruff check .` パス
- [x] `pytest` パス（394 passed）
- [x] 複数回部分更新で snapshot が累積（Bob→Carol / Seer→Knight）し、`content` はその回のデルタのみ
- [x] `memory.py` 導出ヘルパの単体テスト（累積・空・コピー独立性）
- [x] 旧アーカイブ相当 dict が `LogEvent` として検証でき snapshot が `None`／renderer フォールバック

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)