### PR TITLE
docs: sync issue #434 in Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,7 +20,7 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#434 | bug | 🔴 | 2 | SpectatorScreen drops suspicion_update / threat_update (not displayed) | SpectatorScreen が suspicion_update / threat_update を SYSTEM_EVENT_VIEWS に持たず行ごと破棄。CLI renderer は [SUSPICION]/[THREAT] 表示可 |
+| yukkie/AgentVillage#434 | bug | 🔴 | 2 | Render suspicion/threat snapshots in SpectatorScreen | #451/#470 で追加された suspicion_snapshot / threat_snapshot を使い、観戦者モードで疑念・脅威をバー主体で表示。旧ログは content 表示へフォールバック |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |


### PR DESCRIPTION
## Summary
- Sync Ideas.md entry for issue #434 after revising the GitHub Issue body for the #451/#470 snapshot data contract.
- Update the local backlog summary from plain dropped event rows to snapshot-backed suspicion/threat meter rendering.

## Test plan
- [x] Pre-commit pytest passed during commit
- [x] Docs-only change reviewed