### PR TITLE
fix: render suspicion threat snapshots

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -526,7 +526,7 @@ Semantic HTML: `SpeechCard` / `WolfChatCard` は独立した発言カードと�
 
 | activePhase | 表示するイベント種別 |
 |---|---|
-| `'discuss'` | `speech`（public、`claimed_role` 付きは CO を兼ねる）, `phase_start`（TURN系）。旧ログの `co_announcement` 別行はフォールバックで表示 |
+| `'discuss'` | `speech`（public、`claimed_role` 付きは CO を兼ねる）, `suspicion_update`, `threat_update`, `phase_start`（TURN系）。旧ログの `co_announcement` 別行はフォールバックで表示 |
 | `'vote'` | `vote`, `elimination`, `medium_result`, `phase_start`（VOTE系） |
 | `'night'` | `wolf_chat`, `inspection`, `guard`, `guard_block`, `night_attack`, `phase_start`（NIGHT / NIGHT_WOLF_CHAT 系） |
 
@@ -544,6 +544,8 @@ Semantic HTML: `SpeechCard` / `WolfChatCard` は独立した発言カードと�
 | `guard_block`（public） | `{content}`（SystemRow kind="gm"） |
 | `night_attack`（private） | `{content}`（SystemRow kind="exec"、右に target アバター） |
 | `night_attack`（public） | `{content}`（SystemRow kind="death"、右に target アバター） |
+| `suspicion_update` | `suspicion_snapshot` があれば SystemRow 内で疑念メーターを表示（高いほど長いバー、green → yellow → red）。snapshot 欠如時は `{content}` にフォールバック |
+| `threat_update` | `threat_snapshot` があれば SystemRow 内で脅威メーターを表示（高いほど長いバー、赤系の濃淡）。snapshot 欠如時は `{content}` にフォールバック |
 
 データソース: `stub/spectator.js`（`EVENTS`, `ROLE_ASSIGNMENT`, `NIGHT_RESULTS`, `EXEC_RESULTS`, `VOTE_TABLE_D1`, `ACTIONS_TIMELINE`）。
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,7 +20,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#434 | bug | 🔴 | 2 | Render suspicion/threat snapshots in SpectatorScreen | #451/#470 で追加された suspicion_snapshot / threat_snapshot を使い、観戦者モードで疑念・脅威をバー主体で表示。旧ログは content 表示へフォールバック |
 | yukkie/AgentVillage#352 | enhancement | 🟡 | 1 | Show prologue message on game start in SpectatorScreen feed | GAME START 時にプロローグ固定文をフォールバック表示。将来の role_assigned イベント実装時に差し替え |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力。#352 のフォールバック差し替え用 |
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |

--- a/frontend/src/lib/feedFilter.js
+++ b/frontend/src/lib/feedFilter.js
@@ -2,6 +2,7 @@
 // separate co_announcement event. Keep co_announcement here so archived replays
 // continue to appear in the discuss feed.
 const DISCUSS_TYPES = new Set(['speech', 'co_announcement']);
+const DISCUSS_SPECTATOR_TYPES = new Set(['suspicion_update', 'threat_update']);
 const VOTE_TYPES = new Set(['vote', 'elimination', 'medium_result']);
 const NIGHT_TYPES = new Set(['wolf_chat', 'inspection', 'guard', 'guard_block', 'night_attack']);
 const NIGHT_PHASES = new Set(['night', 'night_wolf_chat']);
@@ -20,6 +21,7 @@ export function filterFeedEvents(events, day, phase) {
 
     if (phase === 'discuss') {
       if (DISCUSS_TYPES.has(ev.event_type)) return ev.is_public !== false;
+      if (DISCUSS_SPECTATOR_TYPES.has(ev.event_type)) return true;
       if (ev.event_type === 'phase_start') return !NIGHT_PHASES.has(ev.phase) && ev.phase !== 'day_vote';
       return false;
     }

--- a/frontend/src/lib/feedFilter.test.js
+++ b/frontend/src/lib/feedFilter.test.js
@@ -136,6 +136,22 @@ describe('filterFeedEvents', () => {
   SUT: filterFeedEvents
   Mock: なし
   Level: unit
+  Objective: spectator 専用の suspicion_update / threat_update は discuss フェーズの中央フィードに渡すことを検証する
+  */
+  it('discuss: suspicion_update / threat_update を返す', () => {
+    const events = [
+      ev({ event_type: 'suspicion_update', is_public: false, suspicion_snapshot: { Bob: 0.82 } }),
+      ev({ event_type: 'threat_update', is_public: false, threat_snapshot: { Alice: 0.74 } }),
+      ev({ event_type: 'speech', is_public: false, content: '[THINK] thinking...' }),
+    ];
+    const result = filterFeedEvents(events, 1, 'discuss');
+    expect(result.map(e => e.event_type)).toEqual(['suspicion_update', 'threat_update']);
+  });
+
+  /*
+  SUT: filterFeedEvents
+  Mock: なし
+  Level: unit
   Objective: GAME START phase_start が discuss フェーズで含まれることを検証する
   */
   it('discuss: GAME START phase_start を含む', () => {

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -108,6 +108,97 @@ function contentForViewer(ev, viewerMode) {
   return ev.content || MISSING_CONTENT;
 }
 
+function scoreEntries(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') return [];
+  return Object.entries(snapshot)
+    .filter(([, value]) => Number.isFinite(value))
+    .sort(([, a], [, b]) => b - a);
+}
+
+function scorePercent(value) {
+  return Math.round(Math.max(0, Math.min(1, value)) * 100);
+}
+
+function scoreSeverity(value) {
+  if (value >= 0.7) return 'high';
+  if (value >= 0.4) return 'medium';
+  return 'low';
+}
+
+function RelationshipMeterList({ snapshot, metric, roleAssignment = {} }) {
+  const entries = scoreEntries(snapshot);
+
+  return (
+    <ul className={`${styles.scoreList} ${styles[metric]}`} aria-label={`${metric} snapshot`}>
+      {entries.map(([name, value]) => {
+        const percent = scorePercent(value);
+        const severity = scoreSeverity(value);
+        return (
+          <li
+            key={name}
+            className={`${styles.scoreItem} ${styles[severity]}`}
+            aria-label={`${name} ${metric} ${percent}%`}
+            title={`${name}: ${value.toFixed(2)}`}
+          >
+            <span className={styles.scoreAgentChip}>
+              <Avatar name={name} role={roleAssignment[name]} size="xs" />
+              <span className={styles.scoreName}>{name}</span>
+            </span>
+            <span className={styles.scoreTrack} aria-hidden="true">
+              <span className={styles.scoreFill} style={{ width: `${percent}%` }} />
+            </span>
+            <span className={styles.scoreSeverity}>{severity}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function RelationshipUpdateRow({ ev, roleAssignment, viewerMode }) {
+  const isThreat = ev.event_type === 'threat_update';
+  const metric = isThreat ? 'threat' : 'suspicion';
+  const snapshot = isThreat ? ev.threat_snapshot : ev.suspicion_snapshot;
+  const label = isThreat ? '脅威' : '疑念';
+  const entries = scoreEntries(snapshot);
+
+  if (entries.length === 0) {
+    return (
+      <SystemRow
+        kind={isThreat ? 'exec' : 'gm'}
+        icon={isThreat ? '!' : '?'}
+        label={label}
+        leftName={ev.agent}
+        roleAssignment={roleAssignment}
+        viewerMode={viewerMode}
+      >
+        {contentForViewer(ev, viewerMode)}
+      </SystemRow>
+    );
+  }
+
+  return (
+    <SystemRow
+      kind={isThreat ? 'exec' : 'gm'}
+      icon={isThreat ? '!' : '?'}
+      label={label}
+      leftName={ev.agent}
+      roleAssignment={roleAssignment}
+      viewerMode={viewerMode}
+    >
+      <div className={styles.scoreSnapshot}>
+        <RelationshipMeterList snapshot={snapshot} metric={metric} roleAssignment={roleAssignment} />
+        {ev.content && (
+          <details className={styles.deltaTrace}>
+            <summary>delta trace</summary>
+            <div>{ev.content}</div>
+          </details>
+        )}
+      </div>
+    </SystemRow>
+  );
+}
+
 const SYSTEM_EVENT_VIEWS = {
   vote: {
     kind: 'exec',
@@ -231,6 +322,10 @@ export function FeedItem({ ev, prevById, roleAssignment, title, viewerMode = 'sp
   if (isPublic && !ev.is_public) return null;
 
   if (ev.event_type === 'wolf_chat') return <WolfChatCard ev={ev} viewerMode={viewerMode} />;
+
+  if (ev.event_type === 'suspicion_update' || ev.event_type === 'threat_update') {
+    return <RelationshipUpdateRow ev={ev} roleAssignment={roleAssignment} viewerMode={viewerMode} />;
+  }
 
   const configuredSystemEvent = renderConfiguredSystemEvent(ev, roleAssignment, viewerMode);
   if (configuredSystemEvent) return configuredSystemEvent;

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -167,6 +167,7 @@ function RelationshipUpdateRow({ ev, roleAssignment, viewerMode }) {
   const snapshot = isThreat ? ev.threat_snapshot : ev.suspicion_snapshot;
   const label = isThreat ? '脅威' : '疑念';
   const entries = scoreEntries(snapshot);
+  const displayContent = contentForViewer(ev, viewerMode);
 
   if (entries.length === 0) {
     return (
@@ -179,7 +180,7 @@ function RelationshipUpdateRow({ ev, roleAssignment, viewerMode }) {
       >
         <div className={styles.scoreFallback}>
           <ScoreOwnerChip name={ev.agent} role={roleAssignment[ev.agent]} />
-          <span>{contentForViewer(ev, viewerMode)}</span>
+          <span>{displayContent}</span>
         </div>
       </SystemRow>
     );
@@ -197,7 +198,7 @@ function RelationshipUpdateRow({ ev, roleAssignment, viewerMode }) {
         <ScoreOwnerChip name={ev.agent} role={roleAssignment[ev.agent]} />
         <div className={styles.scoreBody}>
           <RelationshipMeterList snapshot={snapshot} metric={metric} />
-          {ev.content && <div className={styles.deltaTrace}>{ev.content}</div>}
+          {ev.content && <div className={styles.deltaTrace}>{displayContent}</div>}
         </div>
       </div>
     </SystemRow>

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -194,17 +194,11 @@ function RelationshipUpdateRow({ ev, roleAssignment, viewerMode }) {
       viewerMode={viewerMode}
     >
       <div className={styles.scoreSnapshot}>
-        <div className={styles.scoreHeader}>
-          <ScoreOwnerChip name={ev.agent} role={roleAssignment[ev.agent]} />
-          <span className={styles.scoreHeaderText}>{label}メーター</span>
+        <ScoreOwnerChip name={ev.agent} role={roleAssignment[ev.agent]} />
+        <div className={styles.scoreBody}>
+          <RelationshipMeterList snapshot={snapshot} metric={metric} />
+          {ev.content && <div className={styles.deltaTrace}>{ev.content}</div>}
         </div>
-        <RelationshipMeterList snapshot={snapshot} metric={metric} />
-        {ev.content && (
-          <details className={styles.deltaTrace}>
-            <summary>delta trace</summary>
-            <div>{ev.content}</div>
-          </details>
-        )}
       </div>
     </SystemRow>
   );

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -125,7 +125,7 @@ function scoreSeverity(value) {
   return 'low';
 }
 
-function RelationshipMeterList({ snapshot, metric, roleAssignment = {} }) {
+function RelationshipMeterList({ snapshot, metric }) {
   const entries = scoreEntries(snapshot);
 
   return (
@@ -140,10 +140,7 @@ function RelationshipMeterList({ snapshot, metric, roleAssignment = {} }) {
             aria-label={`${name} ${metric} ${percent}%`}
             title={`${name}: ${value.toFixed(2)}`}
           >
-            <span className={styles.scoreAgentChip}>
-              <Avatar name={name} role={roleAssignment[name]} size="xs" />
-              <span className={styles.scoreName}>{name}</span>
-            </span>
+            <span className={styles.scoreName}>{name}</span>
             <span className={styles.scoreTrack} aria-hidden="true">
               <span className={styles.scoreFill} style={{ width: `${percent}%` }} />
             </span>
@@ -152,6 +149,15 @@ function RelationshipMeterList({ snapshot, metric, roleAssignment = {} }) {
         );
       })}
     </ul>
+  );
+}
+
+function ScoreOwnerChip({ name, role }) {
+  return (
+    <span className={styles.scoreOwnerChip}>
+      <Avatar name={name} role={role} size="xs" />
+      <span className={styles.scoreOwnerName}>{name}</span>
+    </span>
   );
 }
 
@@ -168,11 +174,13 @@ function RelationshipUpdateRow({ ev, roleAssignment, viewerMode }) {
         kind={isThreat ? 'exec' : 'gm'}
         icon={isThreat ? '!' : '?'}
         label={label}
-        leftName={ev.agent}
         roleAssignment={roleAssignment}
         viewerMode={viewerMode}
       >
-        {contentForViewer(ev, viewerMode)}
+        <div className={styles.scoreFallback}>
+          <ScoreOwnerChip name={ev.agent} role={roleAssignment[ev.agent]} />
+          <span>{contentForViewer(ev, viewerMode)}</span>
+        </div>
       </SystemRow>
     );
   }
@@ -182,12 +190,15 @@ function RelationshipUpdateRow({ ev, roleAssignment, viewerMode }) {
       kind={isThreat ? 'exec' : 'gm'}
       icon={isThreat ? '!' : '?'}
       label={label}
-      leftName={ev.agent}
       roleAssignment={roleAssignment}
       viewerMode={viewerMode}
     >
       <div className={styles.scoreSnapshot}>
-        <RelationshipMeterList snapshot={snapshot} metric={metric} roleAssignment={roleAssignment} />
+        <div className={styles.scoreHeader}>
+          <ScoreOwnerChip name={ev.agent} role={roleAssignment[ev.agent]} />
+          <span className={styles.scoreHeaderText}>{label}メーター</span>
+        </div>
+        <RelationshipMeterList snapshot={snapshot} metric={metric} />
         {ev.content && (
           <details className={styles.deltaTrace}>
             <summary>delta trace</summary>

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -303,23 +303,16 @@
 .scoreSnapshot {
   width: 100%;
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
 }
 
-.scoreHeader,
 .scoreFallback {
   display: flex;
   align-items: center;
   gap: 10px;
   min-width: 0;
-}
-
-.scoreHeaderText {
-  color: var(--tx-3);
-  font-family: var(--serif);
-  font-size: 12px;
-  letter-spacing: 0.04em;
 }
 
 .scoreOwnerChip {
@@ -333,6 +326,14 @@
   border-radius: var(--r1);
   background: var(--bg-2);
   flex: 0 0 auto;
+}
+
+.scoreBody {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
 }
 
 .scoreOwnerName {
@@ -363,7 +364,7 @@
   flex-direction: column;
   justify-content: space-between;
   gap: 5px;
-  flex: 0 1 118px;
+  flex: 0 0 100px;
   min-height: 50px;
   padding: 6px 7px;
   border: 1px solid var(--bd);
@@ -419,15 +420,6 @@
   font-family: var(--mono);
   font-size: 10.5px;
   line-height: 1.5;
-}
-
-.deltaTrace summary {
-  cursor: pointer;
-  width: max-content;
-}
-
-.deltaTrace div {
-  margin-top: 3px;
   word-break: break-word;
 }
 
@@ -587,7 +579,7 @@
 /* sysrow inner */
 .sysIconCol { display: flex; flex-direction: column; align-items: center; gap: 3px; flex: 0 0 64px; width: 64px; }
 .sysLabel { font-family: var(--serif); font-size: 10px; color: var(--tx-3); letter-spacing: 0.08em; text-align: center; }
-.sysText { font-size: 13px; color: var(--tx); display: flex; align-items: center; gap: 4px; flex-wrap: wrap; }
+.sysText { font-size: 13px; color: var(--tx); display: flex; align-items: center; gap: 4px; flex-wrap: wrap; flex: 1; min-width: 0; }
 .sysTs { font-family: var(--mono); font-size: 10px; color: var(--tx-4); }
 .sysIcon {
   width: 28px; height: 28px; border-radius: 50%;

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -304,7 +304,47 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+}
+
+.scoreHeader,
+.scoreFallback {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.scoreHeaderText {
+  color: var(--tx-3);
+  font-family: var(--serif);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+
+.scoreOwnerChip {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 54px;
+  padding: 6px 4px 5px;
+  border: 1px solid var(--bd);
+  border-radius: var(--r1);
+  background: var(--bg-2);
+  flex: 0 0 auto;
+}
+
+.scoreOwnerName {
+  color: var(--tx-2);
+  font-family: var(--sans);
+  font-size: 10px;
+  line-height: 1;
+  text-align: center;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .scoreList {
@@ -323,8 +363,8 @@
   flex-direction: column;
   justify-content: space-between;
   gap: 5px;
-  flex: 0 1 112px;
-  min-height: 76px;
+  flex: 0 1 118px;
+  min-height: 50px;
   padding: 6px 7px;
   border: 1px solid var(--bd);
   border-radius: var(--r1);
@@ -332,20 +372,12 @@
   min-width: 0;
 }
 
-.scoreAgentChip {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  min-width: 0;
-}
-
 .scoreName {
-  color: var(--tx-2);
-  font-family: var(--sans);
-  font-size: 10px;
-  line-height: 1;
-  text-align: center;
+  color: var(--tx);
+  font-family: var(--serif);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -300,6 +300,105 @@
 .sysrow.phase .icon { background: rgba(125,108,255,0.18); color: #b6abff; }
 .sysrow .sysText strong { font-family: var(--serif); font-weight: 600; }
 
+.scoreSnapshot {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.scoreList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 8px;
+  width: 100%;
+}
+
+.scoreItem {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 5px;
+  flex: 0 1 112px;
+  min-height: 76px;
+  padding: 6px 7px;
+  border: 1px solid var(--bd);
+  border-radius: var(--r1);
+  background: var(--bg-2);
+  min-width: 0;
+}
+
+.scoreAgentChip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.scoreName {
+  color: var(--tx-2);
+  font-family: var(--sans);
+  font-size: 10px;
+  line-height: 1;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.scoreTrack {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--bg-3);
+  overflow: hidden;
+  min-width: 0;
+}
+
+.scoreFill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.scoreSeverity {
+  color: var(--tx-4);
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.scoreItem.low .scoreFill { background: #5fbd7a; }
+.scoreItem.medium .scoreFill { background: var(--acc); }
+.scoreItem.high .scoreFill { background: var(--danger); }
+.scoreList.threat .scoreItem.low .scoreFill { background: rgba(226,107,107,0.45); }
+.scoreList.threat .scoreItem.medium .scoreFill { background: rgba(226,107,107,0.72); }
+.scoreList.threat .scoreItem.high .scoreFill { background: var(--danger); }
+
+.deltaTrace {
+  color: var(--tx-3);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  line-height: 1.5;
+}
+
+.deltaTrace summary {
+  cursor: pointer;
+  width: max-content;
+}
+
+.deltaTrace div {
+  margin-top: 3px;
+  word-break: break-word;
+}
+
 /* Vote breakdown */
 .voteDetail {
   padding: 14px 24px 16px;

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -22,7 +22,7 @@ afterEach(() => {
   cleanup();
 });
 
-function renderFeedItem(overrides) {
+function renderFeedItem(overrides, options = {}) {
   const ev = {
     day: 1,
     event_type: 'vote',
@@ -39,6 +39,7 @@ function renderFeedItem(overrides) {
       prevById={{}}
       roleAssignment={roleAssignment}
       title="Test Village"
+      viewerMode={options.viewerMode}
     />
   );
 }
@@ -161,6 +162,95 @@ describe('FeedItem event routing', () => {
 
     expect(screen.getByText('[missing content]')).toBeTruthy();
     expect(screen.queryByText(/Alice senses|Bob was|村人陣営|人狼陣営/)).toBeNull();
+  });
+
+  it('renders suspicion_update snapshots as spectator meter rows', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: component
+     * Objective: suspicion_snapshot を持つ suspicion_update が、content 文字列主体ではなく
+     *            バー主体の疑念メーターとして表示されることを検証する。
+     */
+    const { container } = renderFeedItem({
+      event_type: 'suspicion_update',
+      agent: 'Alice',
+      content: 'Alice suspicion update: Bob=0.82, Carol=0.45, Dave=0.31',
+      is_public: false,
+      suspicion_snapshot: { Bob: 0.82, Carol: 0.45, Dave: 0.31 },
+    });
+
+    expect(screen.getByText('疑念')).toBeTruthy();
+    expect(screen.getByText('Bob')).toBeTruthy();
+    expect(screen.getByText('Carol')).toBeTruthy();
+    expect(screen.getByText('Dave')).toBeTruthy();
+    expect(screen.getByAltText('Bob')).toBeTruthy();
+    expect(screen.getByAltText('Carol')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Bob suspicion 82%"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Carol suspicion 45%"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Dave suspicion 31%"]')).toBeTruthy();
+    expect(screen.getByText('delta trace')).toBeTruthy();
+    expect(screen.getByText('Alice suspicion update: Bob=0.82, Carol=0.45, Dave=0.31')).toBeTruthy();
+  });
+
+  it('renders threat_update snapshots as spectator meter rows', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: component
+     * Objective: threat_snapshot を持つ threat_update が、脅威メーターとして表示されることを検証する。
+     */
+    const { container } = renderFeedItem({
+      event_type: 'threat_update',
+      agent: 'Bob',
+      content: 'Bob threat update: Alice=0.74, Carol=0.25',
+      is_public: false,
+      threat_snapshot: { Alice: 0.74, Carol: 0.25 },
+    });
+
+    expect(screen.getByText('脅威')).toBeTruthy();
+    expect(screen.getByText('Alice')).toBeTruthy();
+    expect(screen.getByText('Carol')).toBeTruthy();
+    expect(screen.getByAltText('Alice')).toBeTruthy();
+    expect(screen.getByAltText('Carol')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Alice threat 74%"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Carol threat 25%"]')).toBeTruthy();
+  });
+
+  it('falls back to content when suspicion/threat snapshots are missing', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし（旧アーカイブ相当の LogEvent plain object を入力）
+     * Level: component
+     * Objective: snapshot が欠如した旧ログでも suspicion_update を破棄せず content を表示することを検証する。
+     */
+    renderFeedItem({
+      event_type: 'suspicion_update',
+      agent: 'Alice',
+      content: 'Alice suspicion update: Bob=0.82',
+      is_public: false,
+      suspicion_snapshot: null,
+    });
+
+    expect(screen.getByText('Alice suspicion update: Bob=0.82')).toBeTruthy();
+  });
+
+  it('hides suspicion/threat updates in public mode', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: component
+     * Objective: is_public=false の suspicion_update が public モードではマウントされないことを検証する。
+     */
+    const { container } = renderFeedItem({
+      event_type: 'suspicion_update',
+      agent: 'Alice',
+      content: 'Alice suspicion update: Bob=0.82',
+      is_public: false,
+      suspicion_snapshot: { Bob: 0.82 },
+    }, { viewerMode: 'public' });
+
+    expect(container.firstChild).toBeNull();
   });
 
   it('renders the only actor avatar on the right side for single-actor system logs', () => {

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -217,6 +217,26 @@ describe('FeedItem event routing', () => {
     expect(container.querySelector('[aria-label="Carol threat 25%"]')).toBeTruthy();
   });
 
+  it('uses spectator_content for suspicion/threat trace text in spectator mode', () => {
+    /**
+     * SUT: FeedItem → RelationshipUpdateRow
+     * Mock: なし（LogEvent 形状の plain object を入力）
+     * Level: component
+     * Objective: snapshot 分岐の trace 表示も contentForViewer 経由で spectator_content を優先することを検証する。
+     */
+    renderFeedItem({
+      event_type: 'suspicion_update',
+      agent: 'Alice',
+      content: 'public trace should not be used',
+      spectator_content: 'Alice suspicion update: Bob=0.82',
+      is_public: false,
+      suspicion_snapshot: { Bob: 0.82 },
+    });
+
+    expect(screen.getByText('Alice suspicion update: Bob=0.82')).toBeTruthy();
+    expect(screen.queryByText('public trace should not be used')).toBeNull();
+  });
+
   it('falls back to content when suspicion/threat snapshots are missing', () => {
     /**
      * SUT: FeedItem

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -185,11 +185,11 @@ describe('FeedItem event routing', () => {
     expect(screen.getByText('Carol')).toBeTruthy();
     expect(screen.getByText('Dave')).toBeTruthy();
     expect(screen.getByAltText('Alice')).toBeTruthy();
-    expect(screen.getByText('疑念メーター')).toBeTruthy();
+    expect(screen.queryByText('疑念メーター')).toBeNull();
     expect(container.querySelector('[aria-label="Bob suspicion 82%"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Carol suspicion 45%"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Dave suspicion 31%"]')).toBeTruthy();
-    expect(screen.getByText('delta trace')).toBeTruthy();
+    expect(screen.queryByText('delta trace')).toBeNull();
     expect(screen.getByText('Alice suspicion update: Bob=0.82, Carol=0.45, Dave=0.31')).toBeTruthy();
   });
 
@@ -212,7 +212,7 @@ describe('FeedItem event routing', () => {
     expect(screen.getByText('Alice')).toBeTruthy();
     expect(screen.getByText('Carol')).toBeTruthy();
     expect(screen.getByAltText('Bob')).toBeTruthy();
-    expect(screen.getByText('脅威メーター')).toBeTruthy();
+    expect(screen.queryByText('脅威メーター')).toBeNull();
     expect(container.querySelector('[aria-label="Alice threat 74%"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Carol threat 25%"]')).toBeTruthy();
   });

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -184,8 +184,8 @@ describe('FeedItem event routing', () => {
     expect(screen.getByText('Bob')).toBeTruthy();
     expect(screen.getByText('Carol')).toBeTruthy();
     expect(screen.getByText('Dave')).toBeTruthy();
-    expect(screen.getByAltText('Bob')).toBeTruthy();
-    expect(screen.getByAltText('Carol')).toBeTruthy();
+    expect(screen.getByAltText('Alice')).toBeTruthy();
+    expect(screen.getByText('疑念メーター')).toBeTruthy();
     expect(container.querySelector('[aria-label="Bob suspicion 82%"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Carol suspicion 45%"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Dave suspicion 31%"]')).toBeTruthy();
@@ -211,8 +211,8 @@ describe('FeedItem event routing', () => {
     expect(screen.getByText('脅威')).toBeTruthy();
     expect(screen.getByText('Alice')).toBeTruthy();
     expect(screen.getByText('Carol')).toBeTruthy();
-    expect(screen.getByAltText('Alice')).toBeTruthy();
-    expect(screen.getByAltText('Carol')).toBeTruthy();
+    expect(screen.getByAltText('Bob')).toBeTruthy();
+    expect(screen.getByText('脅威メーター')).toBeTruthy();
     expect(container.querySelector('[aria-label="Alice threat 74%"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Carol threat 25%"]')).toBeTruthy();
   });


### PR DESCRIPTION
## Summary
- Render suspicion_update and threat_update events in SpectatorScreen spectator mode.
- Use suspicion_snapshot / threat_snapshot for bar-first meter rows, with content as delta trace and old-log fallback.
- Keep public mode hiding for is_public=false events and document the frontend display contract.
- Remove the completed #434 entry from Ideas.md.

## Test plan
- [x] npm.cmd run test -- SpectatorScreen.test.jsx feedFilter.test.js
- [x] npm.cmd run test
- [x] npm.cmd run test:coverage
- [x] npm.cmd run build
- [x] uv run ruff check .
- [x] uv run pytest
- [x] Playwright/browser verification skipped per user request; Claude will handle it separately

Closes #434

🤖 Generated with [Codex](https://Codex.com/Codex)