### PR TITLE
docs: add avatar identity chip issue to Ideas

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -28,6 +28,7 @@
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
 | yukkie/AgentVillage#464 | tech-debt | 🟡 | 1 | Define datetime policy for UI time elements | `<time>` 要素の `datetime` 付与方針を整理し、ゲーム内模擬時刻・実世界日時・ログ由来 timestamp の扱いを FrontendDesign.md に明記 |
+| yukkie/AgentVillage#474 | tech-debt | （なし） | — | Extend Avatar into reusable agent identity chip | Avatar を基盤に agent identity chip（avatar + name、vertical/horizontal、display/button、selected/muted/plain）へ拡張し、発言カードの大きい Avatar 以外の小型 identity 表示を順次置換 |
 | yukkie/AgentVillage#466 | tech-debt | （なし） | — | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |


### PR DESCRIPTION
## Summary
- Add the new Avatar identity chip follow-up task to Ideas.md.
- Keep the implementation issue tracked in the Milestone 2 backlog.

## Test plan
- [x] Pre-commit pytest passed during commit
- [x] Docs-only change reviewed

No auto-close keyword is included because this PR only updates Ideas.md.