### PR TITLE
refactor: extend Avatar with label/layout/variant and add AvatarButton (#474)

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -428,7 +428,7 @@ stateDiagram-v2
 | `highlight` | `boolean?` | true でエージェント個人カラーのアウトラインを表示 |
 | `label` | `string?` | 渡すとエージェント名テキストを表示。`label` あり時は `<img alt="">` に変更（accessible name 重複を避ける） |
 | `layout` | `'vertical'｜'horizontal'` | `label` あり時のレイアウト。`vertical`: アイコン上・名前下、`horizontal`: アイコン左・名前右（デフォルト `'vertical'`） |
-| `variant` | `'plain'｜'muted'｜'selected'｜'dead'` | 外観状態（デフォルト `'plain'`）。`dead` はチップ全体の muted スタイル（`dead` prop のアイコン内オーバーレイとは別概念） |
+| `variant` | `'plain'｜'muted'｜'selected'｜'dead'｜'danger'` | 外観状態（デフォルト `'plain'`）。`dead` はチップ全体の muted スタイル（`dead` prop のアイコン内オーバーレイとは別概念）。`danger` はラベルテキストを `var(--danger)` 色で強調（処刑対象の投票グリッド等） |
 
 `label` あり時は identity wrapper 要素（新クラス）がアイコン frame（`.av`）を内包する構造になる。`.av` のスタイルは変更しないため、`label` なしの既存呼び出しは挙動変更なし。
 

--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -415,17 +415,42 @@ stateDiagram-v2
 
 ### 6.1 共通コンポーネント（`src/components/`）
 
-#### `Avatar`
+#### `Avatar`（default export）
+
+表示専用のエージェントアイデンティティコンポーネント。`label` なしではアイコン単体、`label` ありではアイコン＋名前テキストを表示する。
 
 | prop | 型 | 説明 |
 |---|---|---|
 | `name` | `string` | エージェント名。`/icons/{name}.png` を src に使用、失敗時は頭文字フォールバック |
 | `role` | `string?` | 役職キー（例: `"Werewolf"`）。spectator モードのみ渡す。渡すと役職刻印（日本語短縮名）を表示 |
-| `dead` | `boolean?` | true で「死亡」マークを表示 |
+| `dead` | `boolean?` | true でアイコン内に「死亡」オーバーレイを表示 |
 | `size` | `'md'｜'sm'｜'xs'` | アバターサイズ（デフォルト `'md'`） |
 | `highlight` | `boolean?` | true でエージェント個人カラーのアウトラインを表示 |
+| `label` | `string?` | 渡すとエージェント名テキストを表示。`label` あり時は `<img alt="">` に変更（accessible name 重複を避ける） |
+| `layout` | `'vertical'｜'horizontal'` | `label` あり時のレイアウト。`vertical`: アイコン上・名前下、`horizontal`: アイコン左・名前右（デフォルト `'vertical'`） |
+| `variant` | `'plain'｜'muted'｜'selected'｜'dead'` | 外観状態（デフォルト `'plain'`）。`dead` はチップ全体の muted スタイル（`dead` prop のアイコン内オーバーレイとは別概念） |
 
-データソース: `AGENT_PALETTE`（`lib/constants.js`）でエージェント名 → 個人カラーを解決。
+`label` あり時は identity wrapper 要素（新クラス）がアイコン frame（`.av`）を内包する構造になる。`.av` のスタイルは変更しないため、`label` なしの既存呼び出しは挙動変更なし。
+
+データソース: `AGENT_PALETTE`（`lib/constants.js`）でエージェント名 → 個人カラー（`--av-c`）を解決。
+
+#### `AvatarButton`（named export）
+
+インタラクティブ用途専用。`Avatar` を `<button type="button">` で包む。
+
+| prop | 型 | 説明 |
+|---|---|---|
+| `onClick` | `function` | クリックハンドラ（必須） |
+| `selected` | `boolean?` | true で `variant="selected"` を適用。個人カラー（`--av-c`）でボーダー＋シャドウを表示（持続的な選択済み状態） |
+| `...avatarProps` | — | `Avatar` の全 props をそのまま受け付ける |
+
+hover / focus スタイルは CSS `:hover` / `:focus-visible` で付与（`variant` prop には含まない）。
+将来の画面遷移対応は `AvatarLink`（`<a>` / React Router `<Link>` 版）として別途追加予定（#342）。
+
+**使い分け:**
+- icon-only（名前テキスト不要）→ bare `Avatar`（`label` なし）
+- 名前表示・display-only → `Avatar` with `label`
+- 名前表示・クリック可能 → `AvatarButton` with `label`
 
 #### `RoleTag`
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -27,7 +27,6 @@
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
 | yukkie/AgentVillage#464 | tech-debt | 🟡 | 1 | Define datetime policy for UI time elements | `<time>` 要素の `datetime` 付与方針を整理し、ゲーム内模擬時刻・実世界日時・ログ由来 timestamp の扱いを FrontendDesign.md に明記 |
-| yukkie/AgentVillage#474 | tech-debt | （なし） | — | Extend Avatar into reusable agent identity chip | Avatar を基盤に agent identity chip（avatar + name、vertical/horizontal、display/button、selected/muted/plain）へ拡張し、発言カードの大きい Avatar 以外の小型 identity 表示を順次置換 |
 | yukkie/AgentVillage#466 | tech-debt | （なし） | — | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |

--- a/frontend/src/components/Avatar.jsx
+++ b/frontend/src/components/Avatar.jsx
@@ -2,15 +2,7 @@ import { useState } from 'react';
 import { ROLES, AGENT_PALETTE } from '../lib/constants.js';
 import styles from './Avatar.module.css';
 
-/**
- * エージェントアバター。config/icons/{name}.png があれば画像表示、なければ頭文字フォールバック。
- * @param {string} name     - エージェント名（例: "Mira"）
- * @param {string} role     - 役職キー（例: "Werewolf"）。spectator のみ渡す
- * @param {boolean} dead    - 死亡フラグ
- * @param {'md'|'sm'|'xs'} size
- * @param {boolean} highlight - 個人カラーのアウトラインを表示するか
- */
-export default function Avatar({ name, role, dead, size = 'md', highlight }) {
+function AvatarIcon({ name, role, dead, size, highlight }) {
   const [imgLoaded, setImgLoaded] = useState(false);
   const color = AGENT_PALETTE[name] || '#888';
   const roleInfo = role && ROLES[role];
@@ -32,10 +24,75 @@ export default function Avatar({ name, role, dead, size = 'md', highlight }) {
         onLoad={() => setImgLoaded(true)}
         onError={(e) => { e.currentTarget.style.display = 'none'; }}
       />
-      {/* PNG 読み込み成功時は頭文字を非表示 */}
       {!imgLoaded && <div className={styles.mono}>{(name || '?').charAt(0)}</div>}
       {roleInfo && <div className={styles.roleTag}>{roleInfo.ja}</div>}
       {dead && <div className={styles.deadMark}>死亡</div>}
     </div>
+  );
+}
+
+function AvatarIconLabeled({ name, role, dead, size, highlight }) {
+  const [imgLoaded, setImgLoaded] = useState(false);
+  const color = AGENT_PALETTE[name] || '#888';
+  const roleInfo = role && ROLES[role];
+  const sizeClass = size === 'sm' ? styles.sm : size === 'xs' ? styles.xs : '';
+
+  return (
+    <div
+      className={`${styles.av} ${sizeClass}`}
+      style={{
+        '--av-c': color,
+        boxShadow: highlight ? `0 0 0 2px ${color}` : 'none',
+      }}
+    >
+      <div className={styles.grad} />
+      <img
+        src={`/icons/${name}.png`}
+        alt=""
+        className={styles.img}
+        onLoad={() => setImgLoaded(true)}
+        onError={(e) => { e.currentTarget.style.display = 'none'; }}
+      />
+      {!imgLoaded && <div className={styles.mono}>{(name || '?').charAt(0)}</div>}
+      {roleInfo && <div className={styles.roleTag}>{roleInfo.ja}</div>}
+      {dead && <div className={styles.deadMark}>死亡</div>}
+    </div>
+  );
+}
+
+/**
+ * エージェントアイデンティティコンポーネント。
+ * label なし: アイコン単体（bare Avatar）。label あり: アイコン＋名前テキスト。
+ */
+export default function Avatar({ name, role, dead, size = 'md', highlight, label, layout = 'vertical', variant = 'plain' }) {
+  if (!label) {
+    return <AvatarIcon name={name} role={role} dead={dead} size={size} highlight={highlight} />;
+  }
+
+  const layoutClass = layout === 'horizontal' ? styles.chipH : styles.chipV;
+  const variantClass = styles[`chip_${variant}`] || '';
+
+  return (
+    <span className={`${styles.chip} ${layoutClass} ${variantClass}`} data-layout={layout} data-variant={variant}>
+      <AvatarIconLabeled name={name} role={role} dead={dead} size={size} highlight={highlight} />
+      <span className={styles.chipLabel} data-testid="avatar-label">{label}</span>
+    </span>
+  );
+}
+
+/**
+ * インタラクティブ用途専用。Avatar を button で包む。
+ */
+export function AvatarButton({ onClick, selected, label, variant, ...avatarProps }) {
+  const resolvedVariant = selected ? 'selected' : (variant || 'plain');
+  return (
+    <button
+      type="button"
+      className={styles.avatarBtn}
+      onClick={onClick}
+      aria-label={label}
+    >
+      <Avatar {...avatarProps} label={label} variant={resolvedVariant} />
+    </button>
   );
 }

--- a/frontend/src/components/Avatar.module.css
+++ b/frontend/src/components/Avatar.module.css
@@ -91,3 +91,81 @@
 }
 .xs .mono { font-size: 10px; }
 .xs .roleTag { display: none; }
+
+/* === Identity wrapper（label あり時のみ） === */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--bd);
+  border-radius: var(--r1);
+  background: var(--bg-2);
+  padding: 6px 4px 5px;
+  transition: border-color 120ms, box-shadow 120ms, opacity 120ms;
+}
+
+.chipV {
+  flex-direction: column;
+}
+
+.chipH {
+  flex-direction: row;
+  padding: 3px 8px 3px 4px;
+}
+
+.chipLabel {
+  font-size: 10px;
+  font-family: var(--sans);
+  color: var(--tx-2);
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 60px;
+}
+
+.chipH .chipLabel {
+  font-size: 11px;
+  text-align: left;
+  max-width: none;
+}
+
+/* variant: plain (default) — no extra style */
+
+/* variant: muted */
+.chip_muted {
+  opacity: 0.4;
+}
+
+/* variant: selected — personal color border + shadow */
+.chip_selected {
+  opacity: 1;
+  border-color: var(--av-c, var(--acc));
+  box-shadow: 0 0 0 1px var(--av-c, var(--acc));
+}
+
+/* variant: dead — muted whole chip */
+.chip_dead {
+  opacity: 0.35;
+}
+
+/* variant: danger — execution target highlight */
+.chip_danger .chipLabel {
+  color: var(--danger);
+}
+
+/* === AvatarButton === */
+.avatarBtn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  border-radius: var(--r1);
+  display: inline-flex;
+}
+
+.avatarBtn .chip_plain { opacity: 0.35; }
+.avatarBtn:hover .chip_plain { opacity: 0.9; }
+.avatarBtn:hover .chip_selected { opacity: 1; }
+.avatarBtn:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }

--- a/frontend/src/components/Avatar.test.jsx
+++ b/frontend/src/components/Avatar.test.jsx
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Avatar, { AvatarButton } from './Avatar.jsx';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Avatar label layouts', () => {
+  it('renders agent name label in vertical layout', () => {
+    /*
+    SUT: Avatar
+    Mock: なし
+    Level: unit
+    Objective: label prop を渡すと名前テキストが表示され、vertical layout クラスが付くことを検証する。
+    */
+    render(<Avatar name="Nox" label="Nox" layout="vertical" />);
+    expect(screen.getByText('Nox')).toBeTruthy();
+  });
+
+  it('renders agent name label in horizontal layout', () => {
+    /*
+    SUT: Avatar
+    Mock: なし
+    Level: unit
+    Objective: horizontal layout が適用されることを検証する。
+    */
+    const { container } = render(<Avatar name="Nox" label="Nox" layout="horizontal" />);
+    expect(container.firstChild.dataset.layout).toBe('horizontal');
+  });
+
+  it('renders without label as bare icon (no label text)', () => {
+    /*
+    SUT: Avatar
+    Mock: なし
+    Level: unit
+    Objective: label なしでは名前テキストが表示されず、既存の bare Avatar 挙動が維持されることを検証する。
+    */
+    render(<Avatar name="Nox" />);
+    expect(screen.queryByTestId('avatar-label')).toBeNull();
+  });
+});
+
+describe('Avatar variants', () => {
+  it('applies selected variant', () => {
+    /*
+    SUT: Avatar
+    Mock: なし
+    Level: unit
+    Objective: variant="selected" が identity wrapper の data-variant に反映されることを検証する。
+    */
+    const { container } = render(<Avatar name="Nox" label="Nox" variant="selected" />);
+    expect(container.firstChild.dataset.variant).toBe('selected');
+  });
+
+  it('applies muted variant', () => {
+    /*
+    SUT: Avatar
+    Mock: なし
+    Level: unit
+    Objective: variant="muted" が data-variant に反映されることを検証する。
+    */
+    const { container } = render(<Avatar name="Nox" label="Nox" variant="muted" />);
+    expect(container.firstChild.dataset.variant).toBe('muted');
+  });
+
+  it('applies dead variant', () => {
+    /*
+    SUT: Avatar
+    Mock: なし
+    Level: unit
+    Objective: variant="dead" が data-variant に反映されることを検証する（dead prop のアイコン内オーバーレイとは別）。
+    */
+    const { container } = render(<Avatar name="Nox" label="Nox" variant="dead" />);
+    expect(container.firstChild.dataset.variant).toBe('dead');
+  });
+});
+
+describe('Avatar accessibility', () => {
+  it('sets img alt to empty string when label is provided', () => {
+    /*
+    SUT: Avatar
+    Mock: なし
+    Level: unit
+    Objective: label あり時は img の alt="" になり、accessible name 重複を避けることを検証する。
+    */
+    const { container } = render(<Avatar name="Nox" label="Nox" />);
+    const img = container.querySelector('img');
+    expect(img.getAttribute('alt')).toBe('');
+  });
+
+  it('sets img alt to name when label is absent', () => {
+    /*
+    SUT: Avatar
+    Mock: なし
+    Level: unit
+    Objective: label なし時は img の alt=name で accessible name を提供することを検証する。
+    */
+    const { container } = render(<Avatar name="Nox" />);
+    const img = container.querySelector('img');
+    expect(img.getAttribute('alt')).toBe('Nox');
+  });
+});
+
+describe('AvatarButton', () => {
+  it('renders as a button element', () => {
+    /*
+    SUT: AvatarButton
+    Mock: vi.fn
+    Level: unit
+    Objective: AvatarButton が button role を持つ要素としてレンダリングされることを検証する。
+    */
+    render(<AvatarButton name="Nox" label="Nox" onClick={vi.fn()} />);
+    expect(screen.getByRole('button')).toBeTruthy();
+  });
+
+  it('fires onClick when clicked', async () => {
+    /*
+    SUT: AvatarButton
+    Mock: vi.fn（onClick の発火を観測）
+    Level: unit
+    Objective: クリックで onClick が1回発火することを検証する。
+    */
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<AvatarButton name="Nox" label="Nox" onClick={onClick} />);
+    await user.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('has aria-label equal to label prop', () => {
+    /*
+    SUT: AvatarButton
+    Mock: なし
+    Level: unit
+    Objective: AvatarButton の aria-label が label prop と一致し、accessible name が正しく設定されることを検証する。
+    */
+    render(<AvatarButton name="Nox" label="Nox" onClick={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Nox' })).toBeTruthy();
+  });
+
+  it('applies selected variant when selected prop is true', () => {
+    /*
+    SUT: AvatarButton
+    Mock: なし
+    Level: unit
+    Objective: selected={true} で内包する Avatar に selected variant が適用されることを検証する。
+    */
+    const { container } = render(<AvatarButton name="Nox" label="Nox" selected onClick={vi.fn()} />);
+    expect(container.querySelector('[data-variant="selected"]')).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/GameListScreen.jsx
+++ b/frontend/src/screens/GameListScreen.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import Avatar from '../components/Avatar.jsx';
+import Avatar, { AvatarButton } from '../components/Avatar.jsx';
 import TopBar, { TopBarBtn } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { TOP_AGENTS, COMMUNITY_POSTS, VILLAGE_NAME_PRESETS } from '../../stub/gameList.js';
@@ -76,22 +76,17 @@ function NewVillageForm() {
           </div>
 
           <div className={styles.agentGrid}>
-            {ALL_AGENTS.map(name => {
-              const isSelected = selected.has(name);
-              const color = AGENT_PALETTE[name];
-              return (
-                <button
-                  key={name}
-                  className={`${styles.agentChip} ${isSelected ? styles.agentChipOn : ''}`}
-                  style={{ '--chip-c': color }}
-                  onClick={() => toggleAgent(name)}
-                  title={name}
-                >
-                  <Avatar name={name} size="sm" />
-                  <span className={styles.chipName}>{name}</span>
-                </button>
-              );
-            })}
+            {ALL_AGENTS.map(name => (
+              <AvatarButton
+                key={name}
+                name={name}
+                size="sm"
+                label={name}
+                layout="vertical"
+                selected={selected.has(name)}
+                onClick={() => toggleAgent(name)}
+              />
+            ))}
           </div>
 
           <div className={styles.formFooter}>

--- a/frontend/src/screens/GameListScreen.module.css
+++ b/frontend/src/screens/GameListScreen.module.css
@@ -503,33 +503,6 @@
   margin-bottom: 16px;
 }
 
-.agentChip {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 4px 5px;
-  border: 1px solid var(--bd);
-  border-radius: var(--r1);
-  background: var(--bg-2);
-  cursor: pointer;
-  opacity: 0.35;
-  transition: opacity 120ms, border-color 120ms, box-shadow 120ms;
-}
-.agentChip:hover { opacity: 0.65; }
-.agentChipOn {
-  opacity: 1;
-  border-color: var(--chip-c);
-  box-shadow: 0 0 0 1px var(--chip-c);
-}
-
-.chipName {
-  font-size: 10px;
-  color: var(--tx-2);
-  font-family: var(--sans);
-  text-align: center;
-  line-height: 1;
-}
 
 .formFooter {
   display: flex;

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -153,12 +153,7 @@ function RelationshipMeterList({ snapshot, metric }) {
 }
 
 function ScoreOwnerChip({ name, role }) {
-  return (
-    <span className={styles.scoreOwnerChip}>
-      <Avatar name={name} role={role} size="xs" />
-      <span className={styles.scoreOwnerName}>{name}</span>
-    </span>
-  );
+  return <Avatar name={name} role={role} size="xs" label={name} layout="vertical" />;
 }
 
 function RelationshipUpdateRow({ ev, roleAssignment, viewerMode }) {
@@ -526,10 +521,9 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             <div className={styles.voteGrid}>
               {execResult.voteTable.map((v, i) => (
                 <div className={styles.voteCell} key={i}>
-                  <Avatar name={v.from} size="xs" />
-                  <span className={styles.voteFrom}>{v.from}</span>
+                  <Avatar name={v.from} size="xs" label={v.from} layout="horizontal" />
                   <span className={styles.voteArrow}>▶</span>
-                  <span className={v.to === execResult.target ? styles.targetBad : styles.voteTo}>{v.to}</span>
+                  <Avatar name={v.to} size="xs" label={v.to} layout="horizontal" variant={v.to === execResult.target ? 'danger' : 'plain'} />
                 </div>
               ))}
             </div>
@@ -551,10 +545,9 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             const coRole = coStatus[n];
             return (
               <li key={n} className={styles.rosterRow} style={{ '--r-color': r?.color }}>
-                <Avatar name={n} role={viewerMode === 'spectator' ? role : undefined} size="sm" />
+                <Avatar name={n} role={viewerMode === 'spectator' ? role : undefined} size="sm" label={n} layout="vertical" />
                 <div className={styles.who}>
                   <span className={styles.rosterName}>
-                    {n}
                     {viewerMode === 'spectator' && <RoleTag role={role} />}
                     {coRole && (
                       <span className={styles.coBadge} style={{ '--co-color': ROLES[coRole]?.color }}>▶ {ROLES[coRole]?.ja || coRole} CO</span>
@@ -576,10 +569,9 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             const meta = activeDead.get(n);
             return (
               <li key={n} className={`${styles.rosterRow} ${styles.dead}`} style={{ '--r-color': r?.color }}>
-                <Avatar name={n} role={role} size="sm" dead />
+                <Avatar name={n} role={role} size="sm" dead label={n} layout="vertical" />
                 <div className={styles.whoMeta}>
                   <div className={styles.whoBlock}>
-                    <span className={styles.rosterName}>{n}</span>
                     <span className={styles.sub}>
                       <RoleTag role={role} />
                     </span>

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -315,37 +315,12 @@
   min-width: 0;
 }
 
-.scoreOwnerChip {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  width: 54px;
-  padding: 6px 4px 5px;
-  border: 1px solid var(--bd);
-  border-radius: var(--r1);
-  background: var(--bg-2);
-  flex: 0 0 auto;
-}
-
 .scoreBody {
   display: flex;
   flex-direction: column;
   gap: 8px;
   flex: 1;
   min-width: 0;
-}
-
-.scoreOwnerName {
-  color: var(--tx-2);
-  font-family: var(--sans);
-  font-size: 10px;
-  line-height: 1;
-  text-align: center;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .scoreList {
@@ -478,17 +453,18 @@
 
 .rosterRow {
   display: grid;
-  grid-template-columns: 32px 1fr;
-  gap: 10px;
+  grid-template-columns: auto 1fr;
+  gap: 8px;
   align-items: center;
-  padding: 7px 8px;
+  padding: 3px 8px;
   border-radius: var(--r1);
   border: 1px solid transparent;
   cursor: pointer;
   background: var(--bg-2);
-  margin-bottom: 4px;
+  margin-bottom: 2px;
 }
 .rosterRow:hover { border-color: var(--bd); }
+.rosterRow :global([data-layout="vertical"]) { padding: 2px 4px 2px; }
 .rosterRow.dead  { opacity: 0.6; }
 .rosterRow .who  { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .rosterRow .who .name {

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -184,7 +184,7 @@ describe('FeedItem event routing', () => {
     expect(screen.getByText('Bob')).toBeTruthy();
     expect(screen.getByText('Carol')).toBeTruthy();
     expect(screen.getByText('Dave')).toBeTruthy();
-    expect(screen.getByAltText('Alice')).toBeTruthy();
+    expect(screen.getByText('Alice')).toBeTruthy();
     expect(screen.queryByText('疑念メーター')).toBeNull();
     expect(container.querySelector('[aria-label="Bob suspicion 82%"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Carol suspicion 45%"]')).toBeTruthy();
@@ -211,7 +211,7 @@ describe('FeedItem event routing', () => {
     expect(screen.getByText('脅威')).toBeTruthy();
     expect(screen.getByText('Alice')).toBeTruthy();
     expect(screen.getByText('Carol')).toBeTruthy();
-    expect(screen.getByAltText('Bob')).toBeTruthy();
+    expect(screen.getByText('Bob')).toBeTruthy();
     expect(screen.queryByText('脅威メーター')).toBeNull();
     expect(container.querySelector('[aria-label="Alice threat 74%"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Carol threat 25%"]')).toBeTruthy();


### PR DESCRIPTION
## Summary

- `Avatar` に `label` / `layout` / `variant` props を追加。`label` あり時はアイコン＋名前テキストを identity wrapper で表示
- `AvatarButton` を named export として追加。インタラクティブ用途専用の `<button>` ラッパー
- 村作成チップ（`GameListScreen`）を `AvatarButton` に移行、不要な screen-local CSS を削除
- `SpectatorScreen` の `ScoreOwnerChip` を `Avatar label` に置き換え
- 生存・死亡ロスター行・投票グリッドの Avatar に `label` / `layout` を適用
- `variant="danger"` を追加（処刑対象の赤ハイライト）

## Implementation notes

- `label` なしの既存呼び出しは挙動変更なし（bare Avatar は `AvatarIcon` として内部分離）
- `label` あり時は `<img alt="">` に変更し accessible name 重複を回避。`AvatarButton` は `aria-label={label}` を明示
- `variant` は React state 由来の持続的状態のみ（hover/focus は CSS 擬似クラスで対応）
- `selected` の opacity 管理は `.avatarBtn .chip_plain` で行い、display-only `Avatar` は opacity 1 を維持
- 削除した screen-local CSS: `GameListScreen` の `.agentChip` / `.agentChipOn` / `.chipName`、`SpectatorScreen` の `.scoreOwnerChip` / `.scoreOwnerName`

## Test plan

- [x] `ruff check .` パス
- [x] `pytest` パス
- [x] `npm test`（184 tests）パス
- [x] `npm run test:coverage` パス（未カバー: `Avatar` の `onLoad`/`onError` — jsdom では画像イベント発火不可、承認済み）
- [x] Playwright ブラウザ確認: 村作成チップ selected 動作・ScoreOwnerChip 表示・ロスター行・suspicion_update カード

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
