### PR TITLE
feat: inject threat_scores into werewolf daytime discussion prompt

### DIFF
--- a/src/llm/prompt.py
+++ b/src/llm/prompt.py
@@ -175,6 +175,12 @@ def build_personal_info_prompt(actor: Actor) -> str:
             if belief.reason:
                 lines.append(f"    Reasons: {'; '.join(belief.reason)}")
 
+    if actor.state.threat_scores:
+        lines.append("\nYour current threat assessments (0.0=safe to ignore, 1.0=must eliminate soon):")
+        lines.append("Use these to guide your speech and deception strategy.")
+        for name, score in actor.state.threat_scores.items():
+            lines.append(f"  {name}: threat={score:.2f}")
+
     return "\n".join(lines)
 
 

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -185,3 +185,32 @@ class TestRoleNightChatPrompt:
         prompt = role.night_chat_prompt(actor, ["OtherWolf"], ["Alice", "Wolf", "OtherWolf"], log)
         assert "Wolf team conversation so far" in prompt
         assert "Let's attack Alice." in prompt
+
+
+def test_personal_info_prompt_shows_threat_scores_for_werewolf(make_test_actor):
+    """
+    SUT: build_personal_info_prompt
+    Mock: なし
+    Level: unit
+    Objective: Werewolf の actor.state.threat_scores が非空のとき脅威スコアとガイダンスが昼会話プロンプトに含まれること（AC: wolf's daytime discussion prompt includes threat_scores when non-empty）。
+    """
+    actor = make_test_actor("Wolf", "Werewolf")
+    actor.state.threat_scores = {"Seer": 0.9, "Knight": 0.6}
+    prompt = build_personal_info_prompt(actor)
+    assert "threat" in prompt.lower()
+    assert "Seer" in prompt
+    assert "0.90" in prompt
+    assert "Knight" in prompt
+    assert "0.60" in prompt
+
+
+def test_personal_info_prompt_omits_threat_section_for_villager(make_test_actor):
+    """
+    SUT: build_personal_info_prompt
+    Mock: なし
+    Level: unit
+    Objective: Villager（threat_scores が空）の場合は脅威スコアセクションが含まれないこと（AC: non-werewolf actors' discussion prompt unchanged）。
+    """
+    actor = make_test_actor("Alice", "Villager")
+    prompt = build_personal_info_prompt(actor)
+    assert "threat assessments" not in prompt


### PR DESCRIPTION
## Summary
- `build_personal_info_prompt` に Werewolf の `threat_scores` 注入を追加
- 昼の会話プロンプトで脅威モデルが参照可能になり、夜の行動・会話との一貫性が保たれる
- 非 Werewolf（`threat_scores` が空）のプロンプトは変わらない

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス（396 tests）
- [ ] wolf の daytime prompt に threat_scores が含まれることを unit test で検証
- [ ] villager の daytime prompt が unchanged であることを unit test で検証

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)