### PR TITLE
docs: add datetime attribute policy for time elements

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -611,8 +611,19 @@ Semantic HTML: `AgentHero` は画面内のエージェント見出しとして `
 | `<ul>` / `<li>` | 順序を問わないリスト | ロスター・CO ボード・ランキング等（3 Screen 側で順次） |
 | `<article>` | 自己完結したカード | `GameCard`、将来 `SpeechCard` 等（3 Screen 側） |
 | `<h1>`〜`<h5>` | 見出し階層 | 各画面の見出し（適用済み多数） |
-| `<time>` | 日時 | タイムスタンプ（3 Screen 側で順次） |
+| `<time>` | 日時 | タイムスタンプ（`SpectatorScreen` / `AgentDetailScreen` 適用済み）。`datetime` 属性の付与方針は下記参照 |
 | `<strong>` / `<em>` | 強調・他要素との区別 | 本文中の強調語（適用済み多数） |
+
+#### `<time>` 要素の `datetime` 属性方針（#464）
+
+`datetime` 属性はブラウザ・スクリーンリーダー・検索エンジンが**機械可読な実日時**として解釈する。そのため、値の種類によって以下のように扱いを分ける。
+
+| 値の種類 | 例 | `datetime` 付与 |
+|---|---|---|
+| ゲーム内模擬時刻（`day` / `speechId` から計算した HH:MM 文字列） | `fmtTime(day, speechId)` の返り値 | **付けない** — 実日時ではないため機械処理に誤った意味を与える |
+| 実世界日時・ログ由来の UNIX timestamp | ゲームの開始時刻・完了時刻など | **付ける** — `datetime="YYYY-MM-DDTHH:MM:SSZ"` 形式で記述する |
+
+現行実装（`SpectatorScreen.jsx` / `AgentDetailScreen.jsx`）はゲーム内模擬時刻を表示しているため `datetime` なしが正しい。実世界日時が利用可能になった時点で、対象の `<time>` に `datetime` を追加する。
 
 #### 装飾として `<div>`/`<span>` を維持する箇所
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -26,7 +26,6 @@
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#319 | enhancement | 🟡 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（Milestone 2 後半） |
 | yukkie/AgentVillage#364 | enhancement | 🟡 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
-| yukkie/AgentVillage#464 | tech-debt | 🟡 | 1 | Define datetime policy for UI time elements | `<time>` 要素の `datetime` 付与方針を整理し、ゲーム内模擬時刻・実世界日時・ログ由来 timestamp の扱いを FrontendDesign.md に明記 |
 | yukkie/AgentVillage#466 | tech-debt | （なし） | — | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |


### PR DESCRIPTION
## Summary
- `doc/FrontendDesign.md` §6.3 に `<time>` 要素の `datetime` 属性方針を追記
- ゲーム内模擬時刻（`fmtTime` 等）には `datetime` を付けない理由を明文化
- 実世界日時・UNIX timestamp が利用可能になった場合の付与条件（`datetime="YYYY-MM-DDTHH:MM:SSZ"` 形式）を明記
- 現行実装（`SpectatorScreen.jsx` / `AgentDetailScreen.jsx`）は `datetime` なしが正しいことをドキュメントで確認

## Implementation notes
- 実装ファイルの変更なし（既存の `datetime` なし実装が正しい方針に整合している）

## Test plan
- [ ] ドキュメント変更のみのため、テスト追加・変更なし

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)