### PR TITLE
feat: introduce React Router for game and agent deep links

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -25,7 +25,7 @@
 | ビルドツール | Vite 6 | 高速 HMR、設定が軽量 |
 | UI ライブラリ | React 18 | `design/proposal/` の JSX プロトタイプを低コストで移植できる |
 | スタイリング | CSS Modules | `design/proposal/prototypes/styles.css` の CSS Variables をそのまま流用可能 |
-| ルーティング | （未導入）useState 切り替え | Milestone 2 で react-router を導入する |
+| ルーティング | React Router v7（`react-router-dom`） | URL ベース遷移・ブラウザ履歴対応（#342） |
 | 将来移行先 | Next.js | React 資産を保持したまま SSR / API Routes を追加可能 |
 
 ---
@@ -77,15 +77,23 @@ frontend/
 | 観戦メイン | `SpectatorScreen` | 特定ゲームの発言フィードを 3 ペインで表示 |
 | エージェント詳細 | `AgentDetailScreen` | 特定エージェントのプロフィール・推論ログ・疑い度マトリクス |
 
-### 4.2 現状の遷移実装（Milestone 1）
+### 4.2 現状の遷移実装（#342 完了後）
 
-`App.jsx` が `useState('list')` で現在の画面キーを管理し、`SCREENS` マップからコンポーネントを選択する。画面間のデータ受け渡し（どのゲーム・どのエージェントを見るか）は **未実装**（スタブデータがハードコード）。
+React Router v7 を導入済み。`App.jsx` は `Routes`/`Route` でルートを定義し、`useState` による画面切り替えは廃止。
 
 ```js
-// App.jsx（現状）
-const SCREENS = { list: GameListScreen, spectator: SpectatorScreen, agent: AgentDetailScreen };
-const [screen, setScreen] = useState('list');
+// App.jsx
+<Routes>
+  <Route path="/"                               element={<GameListScreen />} />
+  <Route path="/agent/:agentName"               element={<AgentDetailScreen />} />
+  <Route path="/game/:sessionId"                element={<SpectatorScreen />} />
+  <Route path="/game/:sessionId/agent/:agentName" element={<AgentDetailScreen />} />
+</Routes>
 ```
+
+`AgentDetailScreen` は `useParams()` の `sessionId` の有無でモードを切り替える:
+- **game-scoped mode** (`sessionId` あり): 特定ゲームの推論ログ・疑念マトリクス等を表示
+- **global profile mode** (`sessionId` なし): エージェントのグローバルプロフィール・過去戦績を表示（スタブ、#318 対応待ち）
 
 ### 4.2.1 Replay viewer（#318）
 
@@ -119,17 +127,27 @@ const [screen, setScreen] = useState('list');
 
 `daySummary` は `SpectatorScreen` の左右ペインで共有する日別データ名とする。`nightActions` や `execResult` のような行動系フィールドも `daySummary` 配下に置き、左ペインと右ペインが別々の集計結果を参照して表示ずれを起こさないようにする。
 
-### 4.3 ルーティング方針（Milestone 2）
+### 4.3 ルーティング（#342 実装済み）
 
-react-router を導入し、URL ベースの遷移に移行する。
+React Router v7 を導入。URL ベースの遷移に移行済み。
 
 ```
-/                          → GameListScreen
-/game/:sessionId           → SpectatorScreen（ゲームID 指定）
-/game/:sessionId/agent/:name → AgentDetailScreen（エージェント指定）
+/                              → GameListScreen
+/agent/:agentName              → AgentDetailScreen（global profile mode）
+/game/:sessionId               → SpectatorScreen（ゲームID 指定）
+/game/:sessionId/agent/:agentName → AgentDetailScreen（game-scoped mode）
 ```
 
-画面間のナビゲーションは `TopBar` のパンくず（`crumbs` prop）を `<Link>` に差し替えることで対応する。
+画面間のナビゲーションは `TopBar` のパンくず（`crumbs` prop に `to` を渡す）と各画面内の `<Link>` で対応する。
+
+#### SPA フォールバックと静的ファイルの境界
+
+SPA ルート（`/game/...`、`/agent/...` 等）はすべて `index.html` にフォールバックする必要がある。静的アーカイブファイルのパス（`/state_archive/...`）は SPA ルートとは別扱いにする。
+
+| 環境 | 対応 |
+|---|---|
+| ローカル Vite dev | `vite.config.js` の `server.historyApiFallback: true`（または同等設定）で対応済み |
+| production/static hosting（nginx / GitHub Pages 等） | すべての未マッチリクエストを `index.html` に rewrite するよう設定が必要。ただし `/state_archive/` プレフィックスのリクエストは静的ファイルとして先に serve し、フォールバックさせない |
 
 ### 4.4 状態遷移図
 
@@ -643,7 +661,14 @@ Semantic HTML: `AgentHero` は画面内のエージェント見出しとして `
 
 #### パンくずの呼び出し契約（`TopBar`）
 
-`crumbs` 配列の各要素は `{ label, onClick? }`。`onClick` を持つ要素のみ `<a href="#">`（link role）としてレンダリングされ、持たない中間要素は非リンクの `<span>` になる（dead link を作らない）。クリック可能にしたい中間 crumb には呼び出し側で `onClick` を渡すこと。
+`crumbs` 配列の各要素は `{ label, to?, onClick? }`。レンダリングルールは以下の通り:
+
+| 条件 | レンダリング |
+|---|---|
+| 最後の要素（現在地） | `<span aria-current="page">`（`to`/`onClick` があってもリンク化しない） |
+| `to` あり | `<Link to={c.to}>`（`onClick` より優先） |
+| `onClick` あり | `<a href="#" onClick>`（後方互換） |
+| どちらもなし | `<span>` |
 
 ---
 
@@ -721,7 +746,7 @@ fetch('../state_archive/20260510_102927/spectator_log.jsonl')
 
 `state_archive/index.json`（`tools/generate_archive_index.py` で事前生成）を fetch して `GameListScreen` に渡す。`stub/gameList.js` の `GAMES` 配列を削除済み。
 
-- `src/lib/archiveLoader.js` — `fetchGameList()` / `parseIndexToGameList()` でデータ取得・変換
+- `src/lib/archiveLoader.js` — `fetchGameList()` / `parseIndexToGameList()` / `fetchGameBySessionId(sessionId)` でデータ取得・変換
 - `src/legacy/normalizeAgentJson.js` — pre-#52 flat 形式エージェント JSON を正規化（Legacy-Adapter）
 - fetch 先 URL は `archiveLoader.js` に集約。#315 FastAPI 導入時は URL 差し替えのみで対応可能
 - `votes` / `desc` 等ログにないフィールドのギャップは `doc/GameData.md` に記録済み

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -28,7 +28,6 @@
 | yukkie/AgentVillage#466 | tech-debt | （なし） | — | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
-| yukkie/AgentVillage#342 | enhancement | 🟢 | 3 | Introduce React Router for game and agent detail navigation | React Router 導入。AgentDetailScreen 依存 |
 | yukkie/AgentVillage#403 | enhancement | 🟢 | 2 | Add avatars to CO status and night action sections | CO状況・夜の行動セクションにアバターアイコンを追加しコンポーネント化 |
 | yukkie/AgentVillage#379 | enhancement | 🟢 | 3 | Add static type checking to frontend JS (JSDoc or TypeScript) | フィールド名ミスをエディタ/CIで検出できるようにする。スタブ撤廃（#318）以降に検討 |
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,13 +9,14 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.17.0"
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.3.4",
-        "@vitest/coverage-v8": "^4.1.6",
+        "@vitest/coverage-v8": "^4.1.8",
         "jsdom": "^29.1.1",
         "vite": "^6.3.5",
         "vitest": "^4.1.6"
@@ -1603,14 +1604,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.8",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1624,8 +1625,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.6",
-        "vitest": "4.1.6"
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1634,16 +1635,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1652,13 +1653,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.6",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1679,9 +1680,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1692,13 +1693,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1706,14 +1707,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1722,9 +1723,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1732,13 +1733,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
+        "@vitest/pretty-format": "4.1.8",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1905,6 +1906,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -2552,6 +2566,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.17.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2638,6 +2690,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -2897,19 +2955,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2937,12 +2995,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,13 +12,14 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.17.0"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "^4.1.6",
+    "@vitest/coverage-v8": "^4.1.8",
     "jsdom": "^29.1.1",
     "vite": "^6.3.5",
     "vitest": "^4.1.6"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,40 +1,15 @@
-import { useState } from 'react';
+import { Routes, Route } from 'react-router-dom';
 import SpectatorScreen from './screens/SpectatorScreen.jsx';
 import GameListScreen from './screens/GameListScreen.jsx';
 import AgentDetailScreen from './screens/AgentDetailScreen.jsx';
 
-const SCREENS = {
-  list: GameListScreen,
-  spectator: SpectatorScreen,
-  agent: AgentDetailScreen,
-};
-
 export default function App() {
-  const [screen, setScreen] = useState('list');
-  const [selectedGame, setSelectedGame] = useState(null);
-  const Screen = SCREENS[screen];
-
-  if (screen === 'list') {
-    return (
-      <GameListScreen
-        onOpenGame={(game) => {
-          setSelectedGame(game);
-          setScreen('spectator');
-        }}
-      />
-    );
-  }
-
-  if (screen === 'spectator') {
-    return (
-      <SpectatorScreen
-        sessionId={selectedGame?.id}
-        cast={selectedGame?.cast ?? []}
-        title={selectedGame?.title}
-        onBack={() => setScreen('list')}
-      />
-    );
-  }
-
-  return <Screen />;
+  return (
+    <Routes>
+      <Route path="/" element={<GameListScreen />} />
+      <Route path="/agent/:agentName" element={<AgentDetailScreen />} />
+      <Route path="/game/:sessionId" element={<SpectatorScreen />} />
+      <Route path="/game/:sessionId/agent/:agentName" element={<AgentDetailScreen />} />
+    </Routes>
+  );
 }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from './App.jsx';
+import * as archiveLoader from './lib/archiveLoader.js';
+import * as replayLoader from './lib/replayLoader.js';
+
+vi.mock('./lib/archiveLoader.js', () => ({
+  fetchGameList: vi.fn().mockResolvedValue([]),
+  fetchGameBySessionId: vi.fn(),
+}));
+
+vi.mock('./lib/replayLoader.js', () => ({
+  fetchReplayLog: vi.fn(),
+  fetchReplayAgents: vi.fn(),
+  fetchReplayGame: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderAt(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>
+  );
+}
+
+describe('App routing contract', () => {
+  it('renders GameListScreen at /', async () => {
+    /*
+     * SUT: App (Routes)
+     * Mock: fetchGameList
+     * Level: integration
+     * Objective: "/" が GameListScreen をレンダリングすることを検証する。
+     */
+    archiveLoader.fetchGameList.mockResolvedValue([]);
+
+    renderAt('/');
+
+    expect(screen.getByText(/新しい村を作る/)).toBeTruthy();
+  });
+
+  it('renders SpectatorScreen at /game/:sessionId', async () => {
+    /*
+     * SUT: App (Routes)
+     * Mock: fetchGameBySessionId / fetchReplayLog / fetchReplayAgents
+     * Level: integration
+     * Objective: "/game/:sessionId" が SpectatorScreen をレンダリングすることを検証する。
+     */
+    archiveLoader.fetchGameBySessionId.mockResolvedValue({ cast: [] });
+    replayLoader.fetchReplayLog.mockResolvedValue('');
+    replayLoader.fetchReplayAgents.mockResolvedValue({});
+
+    renderAt('/game/test-session-001');
+
+    expect(screen.getByRole('navigation', { name: 'パンくず' })).toBeTruthy();
+    expect(screen.queryByRole('heading', { name: /新しい村を作る/ })).toBeNull();
+  });
+
+  it('renders AgentDetailScreen (game-scoped) at /game/:sessionId/agent/:agentName', () => {
+    /*
+     * SUT: App (Routes)
+     * Mock: なし（AgentDetailScreen はスタブデータ）
+     * Level: integration
+     * Objective: "/game/:sessionId/agent/:agentName" が AgentDetailScreen を game-scoped mode でレンダリングすることを検証する。
+     */
+    renderAt('/game/test-session-001/agent/Nox');
+
+    // パンくずに sessionId が含まれていれば game-scoped mode
+    expect(screen.getByText('test-session-001')).toBeTruthy();
+  });
+
+  it('renders AgentDetailScreen (global mode) at /agent/:agentName', () => {
+    /*
+     * SUT: App (Routes)
+     * Mock: なし（AgentDetailScreen はスタブデータ）
+     * Level: integration
+     * Objective: "/agent/:agentName" が AgentDetailScreen を global profile mode でレンダリングすることを検証する。
+     */
+    renderAt('/agent/Nox');
+
+    // global mode ではパンくずに sessionId がない
+    expect(screen.queryByText('test-session-001')).toBeNull();
+    expect(screen.getAllByText('Nox').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import styles from './TopBar.module.css';
 
 /**
@@ -22,9 +23,11 @@ export default function TopBar({ crumbs = [], children }) {
                 {i > 0 && <span className={styles.sep} aria-hidden="true">/</span>}
                 {isCurrent
                   ? <span className={styles.now} aria-current="page">{c.label}</span>
-                  : c.onClick
-                    ? <a href="#" onClick={(e) => { e.preventDefault(); c.onClick(); }}>{c.label}</a>
-                    : <span>{c.label}</span>
+                  : c.to
+                    ? <Link to={c.to}>{c.label}</Link>
+                    : c.onClick
+                      ? <a href="#" onClick={(e) => { e.preventDefault(); c.onClick(); }}>{c.label}</a>
+                      : <span>{c.label}</span>
                 }
               </li>
             );

--- a/frontend/src/components/TopBar.test.jsx
+++ b/frontend/src/components/TopBar.test.jsx
@@ -1,7 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import TopBar from './TopBar.jsx';
+
+function renderTopBar(crumbs, children) {
+  return render(
+    <MemoryRouter>
+      <TopBar crumbs={crumbs}>{children}</TopBar>
+    </MemoryRouter>
+  );
+}
 
 afterEach(() => {
   cleanup();
@@ -15,7 +24,7 @@ describe('TopBar breadcrumb semantics', () => {
     Level: component
     Objective: パンくず領域が aria-label 付き navigation landmark として特定できることを検証する。
     */
-    render(<TopBar crumbs={[{ label: 'r/agent-jinrou', onClick: () => {} }, { label: 'Day 2' }]} />);
+    renderTopBar([{ label: 'r/agent-jinrou', onClick: () => {} }, { label: 'Day 2' }]);
 
     expect(screen.getByRole('navigation', { name: 'パンくず' })).toBeTruthy();
   });
@@ -29,7 +38,7 @@ describe('TopBar breadcrumb semantics', () => {
     */
     const onClick = vi.fn();
     const user = userEvent.setup();
-    render(<TopBar crumbs={[{ label: 'r/agent-jinrou', onClick }, { label: 'Day 2' }]} />);
+    renderTopBar([{ label: 'r/agent-jinrou', onClick }, { label: 'Day 2' }]);
 
     const link = screen.getByRole('link', { name: 'r/agent-jinrou' });
     await user.click(link);
@@ -44,7 +53,7 @@ describe('TopBar breadcrumb semantics', () => {
     Level: component
     Objective: onClick を持たない中間 crumb が link role を持たない（dead link を作らない）ことを検証する退行防止テスト。
     */
-    render(<TopBar crumbs={[{ label: '観戦' }, { label: 'Day 2' }]} />);
+    renderTopBar([{ label: '観戦' }, { label: 'Day 2' }]);
 
     expect(screen.queryByRole('link', { name: '観戦' })).toBeNull();
     expect(screen.getByText('観戦')).toBeTruthy();
@@ -57,9 +66,49 @@ describe('TopBar breadcrumb semantics', () => {
     Level: component
     Objective: 最後の crumb（現在地）に aria-current="page" が付くことを検証する。
     */
-    render(<TopBar crumbs={[{ label: 'r/agent-jinrou', onClick: () => {} }, { label: 'Day 2' }]} />);
+    renderTopBar([{ label: 'r/agent-jinrou', onClick: () => {} }, { label: 'Day 2' }]);
 
     const current = screen.getByText('Day 2');
     expect(current.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('renders a to-crumb as a router Link', () => {
+    /*
+    SUT: TopBar
+    Mock: なし
+    Level: component
+    Objective: to を持つ中間 crumb が link role でレンダリングされることを検証する。
+    */
+    renderTopBar([{ label: 'r/agent-jinrou', to: '/' }, { label: 'Day 2' }]);
+
+    const link = screen.getByRole('link', { name: 'r/agent-jinrou' });
+    expect(link.getAttribute('href')).toBe('/');
+  });
+
+  it('prefers to over onClick when both are provided', () => {
+    /*
+    SUT: TopBar
+    Mock: なし
+    Level: component
+    Objective: to と onClick が両方ある場合、to が優先されて Link としてレンダリングされることを検証する。
+    */
+    const onClick = vi.fn();
+    renderTopBar([{ label: 'home', to: '/', onClick }, { label: 'current' }]);
+
+    const link = screen.getByRole('link', { name: 'home' });
+    expect(link.getAttribute('href')).toBe('/');
+  });
+
+  it('does not linkify the last crumb even when to is provided', () => {
+    /*
+    SUT: TopBar
+    Mock: なし
+    Level: component
+    Objective: 最後の crumb（現在地）は to が渡っていてもリンク化されないことを検証する。
+    */
+    renderTopBar([{ label: 'home', to: '/' }, { label: 'current', to: '/current' }]);
+
+    expect(screen.queryByRole('link', { name: 'current' })).toBeNull();
+    expect(screen.getByText('current').getAttribute('aria-current')).toBe('page');
   });
 });

--- a/frontend/src/lib/archiveLoader.js
+++ b/frontend/src/lib/archiveLoader.js
@@ -71,3 +71,20 @@ export async function fetchGameList() {
   const index = await res.json();
   return parseIndexToGameList(index);
 }
+
+/**
+ * Fetch a single game entry by sessionId from state_archive/index.json.
+ * Returns the raw index entry (including cast) for use by SpectatorScreen.
+ * Throws if the session is not found.
+ *
+ * @param {string} sessionId
+ * @returns {Promise<object>}
+ */
+export async function fetchGameBySessionId(sessionId) {
+  const res = await fetch(INDEX_URL);
+  if (!res.ok) throw new Error(`Failed to fetch game list: ${res.status}`);
+  const index = await res.json();
+  const entry = index.find(e => e.session_id === sessionId);
+  if (!entry) throw new Error(`Session not found: ${sessionId}`);
+  return entry;
+}

--- a/frontend/src/lib/archiveLoader.test.js
+++ b/frontend/src/lib/archiveLoader.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { parseIndexToGameList, parseEntryToGame } from './archiveLoader.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseIndexToGameList, parseEntryToGame, fetchGameBySessionId } from './archiveLoader.js';
 import { normalizeAgentJson } from '../legacy/normalizeAgentJson.js';
 
 // --- fixture data ---
@@ -131,6 +131,46 @@ describe('parseIndexToGameList', () => {
     Objective: 空の index に対して空配列を返すことを検証する
     */
     expect(parseIndexToGameList([])).toEqual([]);
+  });
+});
+
+// --- fetchGameBySessionId ---
+
+describe('fetchGameBySessionId', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the matching index entry by sessionId', async () => {
+    /*
+     * SUT: fetchGameBySessionId
+     * Mock: global fetch（index.json のレスポンスを固定）
+     * Level: unit
+     * Objective: sessionId に一致する index エントリが返ることを検証する。
+     */
+    const index = [ENTRY_WOLF, ENTRY_VILLAGE];
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(index),
+    }));
+
+    const result = await fetchGameBySessionId('20260510_102927');
+    expect(result).toBe(index[0]);
+  });
+
+  it('throws when sessionId is not found', async () => {
+    /*
+     * SUT: fetchGameBySessionId
+     * Mock: global fetch（index.json のレスポンスを固定）
+     * Level: unit
+     * Objective: sessionId に一致するエントリがない場合に Error をスローすることを検証する。
+     */
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([ENTRY_WOLF]),
+    }));
+
+    await expect(fetchGameBySessionId('not-exist')).rejects.toThrow('Session not found: not-exist');
   });
 });
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import './tokens.css';
 import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
@@ -13,7 +14,7 @@ import styles from './AgentDetailScreen.module.css';
 const TABS = ['概要', '推論ログ', '疑い・信頼', '夜の行動', '過去の戦績'];
 
 // --- 左ペイン ---
-function LeftPane({ current, onPick }) {
+function LeftPane({ current, sessionId }) {
   const alive = ALL_AGENTS.filter(n => !DEAD_AGENTS.has(n));
   const dead  = ALL_AGENTS.filter(n =>  DEAD_AGENTS.has(n));
 
@@ -29,19 +30,23 @@ function LeftPane({ current, onPick }) {
           const role  = ROLE_ASSIGNMENT[n];
           const r     = ROLES[role];
           const isDead = DEAD_AGENTS.has(n);
+          const to = sessionId
+            ? `/game/${sessionId}/agent/${encodeURIComponent(n)}`
+            : `/agent/${encodeURIComponent(n)}`;
           return (
             <li
               key={n}
               className={`${styles.pick} ${current === n ? styles.pickOn : ''} ${isDead ? styles.pickDead : ''}`}
               style={{ '--r-color': r?.color }}
-              onClick={() => onPick(n)}
             >
-              <Avatar name={n} role={role} size="sm" dead={isDead} />
-              <div className={styles.who}>
-                <span className={styles.pickName}>{n}</span>
-                <span className={styles.pickRole}>{r?.ja}</span>
-              </div>
-              <span className={styles.statusDot} />
+              <Link to={to} className={styles.pickLink}>
+                <Avatar name={n} role={role} size="sm" dead={isDead} />
+                <div className={styles.who}>
+                  <span className={styles.pickName}>{n}</span>
+                  <span className={styles.pickRole}>{r?.ja}</span>
+                </div>
+                <span className={styles.statusDot} />
+              </Link>
             </li>
           );
         })}
@@ -301,8 +306,9 @@ function RightPane({ agent }) {
 
 // === メイン画面 ===
 export default function AgentDetailScreen() {
-  const [agent, setAgent] = useState('Nox');
-  const [tab, setTab]     = useState(0);
+  const { sessionId, agentName } = useParams();
+  const agent = agentName || 'Nox';
+  const [tab, setTab] = useState(0);
 
   const role = ROLE_ASSIGNMENT[agent];
   const r    = ROLES[role];
@@ -315,13 +321,13 @@ export default function AgentDetailScreen() {
     <TabHistory      agent={agent} />,
   ];
 
+  const topCrumbs = sessionId
+    ? [{ label: 'r/agent-jinrou', to: '/' }, { label: sessionId, to: `/game/${sessionId}` }, { label: agent }]
+    : [{ label: 'r/agent-jinrou', to: '/' }, { label: agent }];
+
   return (
     <div className={styles.frame}>
-      <TopBar crumbs={[
-        { label: 'r/agent-jinrou' },
-        { label: '第13回 桜霞' },
-        { label: agent },
-      ]}>
+      <TopBar crumbs={topCrumbs}>
         <TopBarBtn><span className={topBarStyles.liveDot} /> LIVE観戦中</TopBarBtn>
         <TopBarBtn>⤓ プロファイルJSON</TopBarBtn>
         <TopBarBtn primary>★ ウォッチ</TopBarBtn>
@@ -330,7 +336,7 @@ export default function AgentDetailScreen() {
       <ThreePaneLayout
         collapsibleLeft
         collapsibleRight
-        left={<LeftPane current={agent} onPick={setAgent} />}
+        left={<LeftPane current={agent} sessionId={sessionId} />}
         right={<RightPane agent={agent} />}
       >
         <div className={styles.mainPane}>

--- a/frontend/src/screens/AgentDetailScreen.module.css
+++ b/frontend/src/screens/AgentDetailScreen.module.css
@@ -63,6 +63,12 @@
 .pickOn { background: var(--bg-2); border-left-color: var(--acc); }
 .pickDead { opacity: 0.55; }
 
+.pickLink {
+  display: contents;
+  color: inherit;
+  text-decoration: none;
+}
+
 .who {
   display: flex;
   flex-direction: column;

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -1,11 +1,28 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import AgentDetailScreen from './AgentDetailScreen.jsx';
 
 afterEach(() => {
   cleanup();
 });
+
+function renderAgent({ sessionId, agentName = 'Nox' } = {}) {
+  const path = sessionId
+    ? `/game/${sessionId}/agent/${agentName}`
+    : `/agent/${agentName}`;
+  const routePath = sessionId
+    ? '/game/:sessionId/agent/:agentName'
+    : '/agent/:agentName';
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path={routePath} element={<AgentDetailScreen />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
 
 describe('AgentDetailScreen semantic structure', () => {
   it('exposes the agent hero as a banner-like header and picker as a list', () => {
@@ -15,7 +32,7 @@ describe('AgentDetailScreen semantic structure', () => {
      * Level: component
      * Objective: AgentHero が header、AgentPicker が list/listitem role で特定できることを検証する。
      */
-    render(<AgentDetailScreen />);
+    renderAgent();
 
     expect(document.querySelector('header')?.textContent).toContain('Nox');
     expect(within(screen.getByRole('list', { name: 'エージェント一覧' })).getAllByRole('listitem').length).toBeGreaterThan(0);
@@ -29,7 +46,7 @@ describe('AgentDetailScreen semantic structure', () => {
      * Objective: 推論ログ・疑い度マトリクス・夜行動・過去戦績が list/listitem role で特定できることを検証する。
      */
     const user = userEvent.setup();
-    render(<AgentDetailScreen />);
+    renderAgent();
 
     expect(within(screen.getByRole('list', { name: '直近の推論' })).getAllByRole('listitem').length).toBeGreaterThan(0);
     expect(within(screen.getByRole('list', { name: '疑い度マトリクス' })).getAllByRole('listitem')).toHaveLength(8);
@@ -38,5 +55,30 @@ describe('AgentDetailScreen semantic structure', () => {
     await user.click(screen.getByRole('button', { name: '過去の戦績' }));
 
     expect(within(screen.getByRole('list', { name: '過去の戦績' })).getAllByRole('listitem')).toHaveLength(5);
+  });
+
+  it('renders game-scoped breadcrumbs when sessionId is present', () => {
+    /*
+     * SUT: AgentDetailScreen TopBar crumbs
+     * Mock: なし
+     * Level: component
+     * Objective: /game/:sessionId/agent/:agentName では sessionId が含まれるパンくずが表示されることを検証する。
+     */
+    renderAgent({ sessionId: 'test-session-001', agentName: 'Nox' });
+
+    expect(screen.getByText('test-session-001')).toBeTruthy();
+  });
+
+  it('renders global breadcrumbs when sessionId is absent', () => {
+    /*
+     * SUT: AgentDetailScreen TopBar crumbs
+     * Mock: なし
+     * Level: component
+     * Objective: /agent/:agentName では sessionId なしのパンくずが表示されることを検証する。
+     */
+    renderAgent({ agentName: 'Nox' });
+
+    expect(screen.queryByText('test-session-001')).toBeNull();
+    expect(screen.getAllByText('Nox').length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/screens/GameListScreen.jsx
+++ b/frontend/src/screens/GameListScreen.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import Avatar, { AvatarButton } from '../components/Avatar.jsx';
 import TopBar, { TopBarBtn } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
@@ -117,7 +118,7 @@ function winnerClass(winner) {
   return '';
 }
 
-function GameCard({ g, onOpen }) {
+function GameCard({ g }) {
   return (
     <article
       className={`${styles.gcard} ${g.hot ? styles.featured : ''}`}
@@ -128,10 +129,9 @@ function GameCard({ g, onOpen }) {
         <span className={styles.voteNum}>{g.votes}</span>
         <button>▼</button>
       </div>
-      <button
-        type="button"
+      <Link
+        to={`/game/${g.id}`}
         className={styles.cardBody}
-        onClick={() => onOpen(g)}
       >
         <div className={styles.gmeta}>
           {g.live
@@ -175,7 +175,7 @@ function GameCard({ g, onOpen }) {
           <span>★ 保存</span>
           <span>↗ 共有</span>
         </div>
-      </button>
+      </Link>
     </article>
   );
 }
@@ -223,13 +223,13 @@ function LeftPane() {
         <ul>
           {TOP_AGENTS.map(({ name, winRate }) => (
             <li key={name}>
-              <a>
+              <Link to={`/agent/${encodeURIComponent(name)}`} className={styles.agentLink}>
                 <Avatar name={name} size="xs" />
                 {name}
                 <span style={{ marginLeft: 'auto', color: 'var(--tx-3)', fontSize: 11, fontFamily: 'var(--mono)' }}>
                   勝率 {winRate}%
                 </span>
-              </a>
+              </Link>
             </li>
           ))}
         </ul>
@@ -254,10 +254,12 @@ function RightPane() {
         <ul className={styles.sideList} aria-label="今週の勝率トップ">
           {TOP_AGENTS.map(({ name, winRate }, i) => (
             <li className={styles.rankRow} key={name}>
-              <span className={styles.rank}>{i + 1}</span>
-              <Avatar name={name} size="xs" />
-              <span className={styles.rankName}>{name}</span>
-              <span className={styles.rankNum}>{winRate}%</span>
+              <Link to={`/agent/${encodeURIComponent(name)}`} className={styles.rankLink}>
+                <span className={styles.rank}>{i + 1}</span>
+                <Avatar name={name} size="xs" />
+                <span className={styles.rankName}>{name}</span>
+                <span className={styles.rankNum}>{winRate}%</span>
+              </Link>
             </li>
           ))}
         </ul>
@@ -279,7 +281,7 @@ function RightPane() {
 }
 
 // === メインゲーム一覧画面 ===
-export default function GameListScreen({ onOpenGame = () => {} }) {
+export default function GameListScreen() {
   const [activeTab, setActiveTab] = useState('完了');
   const [games, setGames] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -350,7 +352,7 @@ export default function GameListScreen({ onOpenGame = () => {} }) {
             </div>
           )}
 
-          {visibleGames.map(g => <GameCard key={g.id} g={g} onOpen={onOpenGame} />)}
+          {visibleGames.map(g => <GameCard key={g.id} g={g} />)}
         </div>
       </ThreePaneLayout>
     </div>

--- a/frontend/src/screens/GameListScreen.module.css
+++ b/frontend/src/screens/GameListScreen.module.css
@@ -203,6 +203,7 @@
   display: block;
   font: inherit;
   text-align: left;
+  text-decoration: none;
 }
 .cardBody:focus-visible {
   outline: 2px solid var(--acc);
@@ -527,3 +528,25 @@
   cursor: default;
 }
 .createBtn:not(:disabled):hover { opacity: 0.85; }
+
+.agentLink {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: inherit;
+  text-decoration: none;
+  width: 100%;
+  padding: 4px 6px;
+  border-radius: var(--r1);
+}
+.agentLink:hover { background: var(--bg-2); color: var(--tx); }
+
+.rankLink {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+.rankLink:hover { background: var(--bg-2); border-radius: var(--r1); }

--- a/frontend/src/screens/GameListScreen.test.jsx
+++ b/frontend/src/screens/GameListScreen.test.jsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import GameListScreen from './GameListScreen.jsx';
 import * as archiveLoader from '../lib/archiveLoader.js';
@@ -34,6 +35,14 @@ function mockGameList(games = [game]) {
   archiveLoader.fetchGameList.mockResolvedValue(games);
 }
 
+function renderGameList() {
+  return render(
+    <MemoryRouter>
+      <GameListScreen />
+    </MemoryRouter>
+  );
+}
+
 describe('GameListScreen GameCard semantics', () => {
   it('exposes each game card as an article named by session id', async () => {
     /**
@@ -44,7 +53,7 @@ describe('GameListScreen GameCard semantics', () => {
      */
     mockGameList();
 
-    render(<GameListScreen />);
+    renderGameList();
 
     const card = await screen.findByRole('article', { name: '20260510_102927' });
 
@@ -52,24 +61,20 @@ describe('GameListScreen GameCard semantics', () => {
     expect(screen.getByRole('heading', { level: 3, name: game.title })).toBeTruthy();
   });
 
-  it('opens the selected game when the card body button is clicked', async () => {
+  it('renders a link to /game/:sessionId for each game card', async () => {
     /**
      * SUT: GameListScreen / GameCard
      * Mock: fetchGameList（state_archive index の取得を固定）
      * Level: component
-     * Objective: semantic button 化後もカード選択で onOpenGame に選択 game が渡ることを検証する。
+     * Objective: Router 化後、GameCard が /game/:id へのリンクを持つことを検証する。
      */
-    const onOpenGame = vi.fn();
-    const user = userEvent.setup();
     mockGameList();
 
-    render(<GameListScreen onOpenGame={onOpenGame} />);
+    renderGameList();
 
-    await user.click(await screen.findByRole('button', { name: new RegExp(game.title) }));
-
-    await waitFor(() => {
-      expect(onOpenGame).toHaveBeenCalledWith(game);
-    });
+    await screen.findByRole('article', { name: '20260510_102927' });
+    const link = screen.getByRole('link', { name: new RegExp(game.title) });
+    expect(link.getAttribute('href')).toBe('/game/20260510_102927');
   });
 });
 
@@ -83,7 +88,7 @@ describe('GameListScreen list semantics', () => {
      */
     mockGameList();
 
-    render(<GameListScreen />);
+    renderGameList();
     await screen.findByRole('article', { name: '20260510_102927' });
 
     const sideNav = screen.getByRole('navigation', { name: 'ゲーム一覧サイドナビ' });
@@ -95,5 +100,23 @@ describe('GameListScreen list semantics', () => {
 
     const posts = screen.getByRole('list', { name: '観戦コミュニティ' });
     expect(within(posts).getAllByRole('listitem').length).toBeGreaterThan(0);
+  });
+
+  it('renders agent links to /agent/:agentName in top agents and ranking', async () => {
+    /*
+     * SUT: GameListScreen / LeftPane / RightPane
+     * Mock: fetchGameList
+     * Level: component
+     * Objective: 左ペイン「注目エージェント」と右ペイン「勝率トップ」が /agent/:name へのリンクを持つことを検証する。
+     */
+    mockGameList();
+
+    renderGameList();
+    await screen.findByRole('article', { name: '20260510_102927' });
+
+    const agentLinks = screen.getAllByRole('link').filter(
+      l => l.getAttribute('href')?.startsWith('/agent/')
+    );
+    expect(agentLinks.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
 import RoleTag from '../components/RoleTag.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
+import { fetchGameBySessionId } from '../lib/archiveLoader.js';
 import { parseGameData, aggregateCoStatus, computeDeadByDay } from '../lib/parseGameData.js';
 import { filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
@@ -601,7 +603,9 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
 
 // === メイン観戦画面 ===
 // TODO(#314): viewerMode の切り替えUI（spectator/public トグル）を追加する
-export default function SpectatorScreen({ sessionId, cast = [], title, onBack }) {
+export default function SpectatorScreen() {
+  const { sessionId } = useParams();
+  const navigate = useNavigate();
   const [activeDay, setActiveDay] = useState(2);
   const [activePhase, setActivePhase] = useState('discuss');
   const [replayEvents, setReplayEvents] = useState(null);
@@ -629,7 +633,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     setLoadingAgents(true);
     setLoadError(null);
 
-    fetchReplayAgents({ sessionId, cast })
+    fetchGameBySessionId(sessionId)
+      .then(entry => fetchReplayAgents({ sessionId, cast: entry.cast ?? [] }))
       .then(agentJsonByName => {
         if (cancelled) return;
         setReplayAgents(parseGameData('', agentJsonByName).agents);
@@ -664,7 +669,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
     return () => {
       cancelled = true;
     };
-  }, [sessionId, cast]);
+  }, [sessionId]);
 
   const events = replayEvents ?? [];
   const agents = replayAgents;
@@ -687,8 +692,8 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
 
   return (
     <div className={styles.frame}>
-      <TopBar crumbs={[{ label: '観戦' }, { label: title || sessionId || '第13回 桜霞村' }, { label: activePhase === 'game_over' ? '勝敗結果' : activePhase === 'eve' ? '前夜 プロローグ' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}` }]}>
-        {onBack && <TopBarBtn onClick={onBack}>← 一覧</TopBarBtn>}
+      <TopBar crumbs={[{ label: 'r/agent-jinrou', to: '/' }, { label: sessionId || '第13回 桜霞村' }, { label: activePhase === 'game_over' ? '勝敗結果' : activePhase === 'eve' ? '前夜 プロローグ' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}` }]}>
+        <TopBarBtn onClick={() => navigate('/')}>← 一覧</TopBarBtn>
         <TopBarBtn><span className={topBarStyles.liveDot} /> REPLAY</TopBarBtn>
         <TopBarBtn>同時観戦 142</TopBarBtn>
         <TopBarBtn onClick={() => setViewerMode(v => v === 'spectator' ? 'public' : 'spectator')}>
@@ -705,7 +710,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
         right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} daySummary={daySummary} activeDay={activeDay} deadByDay={replayDeadByDay} viewerMode={viewerMode} />}
       >
         <div className={styles.feedHead}>
-          <h2>{activePhase === 'game_over' ? '勝敗結果' : activePhase === 'eve' ? '前夜 プロローグ' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}`} <small>{sessionId ? sessionId : '3:47 経過 / 残り 4:13'}</small></h2>
+          <h2>{activePhase === 'game_over' ? '勝敗結果' : activePhase === 'eve' ? '前夜 プロローグ' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}`} <small>{sessionId || '3:47 経過 / 残り 4:13'}</small></h2>
           <span className={styles.stat}>発言 <strong>{speechCount}</strong></span>
           <span className={styles.stat}>CO <strong>{coCount}</strong></span>
           <span className={styles.spacer} />
@@ -730,7 +735,7 @@ export default function SpectatorScreen({ sessionId, cast = [], title, onBack })
               ev={e}
               prevById={prevById}
               roleAssignment={roleAssignment}
-              title={title || sessionId}
+              title={sessionId}
               viewerMode={viewerMode}
             />
           ))}

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -1,16 +1,33 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen, within, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { FeedItem, LeftPane, RightPane } from './SpectatorScreen.jsx';
 import SpectatorScreen from './SpectatorScreen.jsx';
 import styles from './SpectatorScreen.module.css';
 import * as replayLoader from '../lib/replayLoader.js';
+import * as archiveLoader from '../lib/archiveLoader.js';
 
 vi.mock('../lib/replayLoader.js', () => ({
   fetchReplayLog: vi.fn(),
   fetchReplayAgents: vi.fn(),
   fetchReplayGame: vi.fn(),
 }));
+
+vi.mock('../lib/archiveLoader.js', () => ({
+  fetchGameList: vi.fn(),
+  fetchGameBySessionId: vi.fn(),
+}));
+
+function renderSpectator(sessionId) {
+  return render(
+    <MemoryRouter initialEntries={[`/game/${sessionId}`]}>
+      <Routes>
+        <Route path="/game/:sessionId" element={<SpectatorScreen />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
 
 const roleAssignment = {
   Alice: 'Seer',
@@ -864,8 +881,6 @@ describe('SpectatorScreen: sessionId integration', () => {
     vi.resetAllMocks();
   });
 
-  const CAST = [];
-
   async function waitForReplayLoadToSettle() {
     await waitFor(() => {
       expect(replayLoader.fetchReplayLog).toHaveBeenCalledOnce();
@@ -878,14 +893,15 @@ describe('SpectatorScreen: sessionId integration', () => {
   it('renders feed events from fetchReplayLog after load', async () => {
     /*
      * SUT: SpectatorScreen (default export)
-     * Mock: fetchReplayLog / fetchReplayAgents を vi.fn() でモック
+     * Mock: fetchGameBySessionId / fetchReplayLog / fetchReplayAgents を vi.fn() でモック
      * Level: integration
-     * Objective: sessionId が渡されると fetchReplayLog の結果がフィードに表示されることを検証する。
+     * Objective: sessionId が URL params で渡されると fetchReplayLog の結果がフィードに表示されることを検証する。
      */
+    archiveLoader.fetchGameBySessionId.mockResolvedValue({ cast: [] });
     replayLoader.fetchReplayLog.mockResolvedValue(MINIMAL_JSONL);
     replayLoader.fetchReplayAgents.mockResolvedValue(MINIMAL_AGENT_JSON);
 
-    render(<SpectatorScreen sessionId="test-session-001" cast={CAST} />);
+    renderSpectator('test-session-001');
 
     await waitFor(() => expect(screen.getByText('こんにちは')).toBeTruthy(), { timeout: 3000 });
     await waitForReplayLoadToSettle();
@@ -894,14 +910,15 @@ describe('SpectatorScreen: sessionId integration', () => {
   it('shows CO count from real log events', async () => {
     /*
      * SUT: SpectatorScreen (default export)
-     * Mock: fetchReplayLog / fetchReplayAgents を vi.fn() でモック
+     * Mock: fetchGameBySessionId / fetchReplayLog / fetchReplayAgents を vi.fn() でモック
      * Level: integration
      * Objective: co_announcement イベントの数が TopBar の CO 表示に反映されることを検証する。
      */
+    archiveLoader.fetchGameBySessionId.mockResolvedValue({ cast: [] });
     replayLoader.fetchReplayLog.mockResolvedValue(MINIMAL_JSONL);
     replayLoader.fetchReplayAgents.mockResolvedValue(MINIMAL_AGENT_JSON);
 
-    render(<SpectatorScreen sessionId="test-session-001" cast={CAST} />);
+    renderSpectator('test-session-001');
 
     await waitFor(() => {
       const coSpan = [...document.querySelectorAll('span')].find(el => el.textContent.includes('CO'));
@@ -913,36 +930,18 @@ describe('SpectatorScreen: sessionId integration', () => {
   it('shows load error when fetchReplayLog rejects', async () => {
     /*
      * SUT: SpectatorScreen (default export)
-     * Mock: fetchReplayLog を reject するモック
+     * Mock: fetchGameBySessionId / fetchReplayLog を reject するモック
      * Level: integration
      * Objective: fetch 失敗時にエラーメッセージが表示されることを検証する。
      */
+    archiveLoader.fetchGameBySessionId.mockResolvedValue({ cast: [] });
     replayLoader.fetchReplayLog.mockRejectedValue(new Error('network error'));
     replayLoader.fetchReplayAgents.mockResolvedValue({});
 
-    render(<SpectatorScreen sessionId="bad-session" cast={CAST} />);
+    renderSpectator('bad-session');
 
     await waitFor(() => expect(screen.getByText(/network error/)).toBeTruthy(), { timeout: 3000 });
     await waitForReplayLoadToSettle();
-  });
-
-  it('calls onBack when back button is clicked', async () => {
-    /*
-     * SUT: SpectatorScreen (default export)
-     * Mock: fetchReplayLog / fetchReplayAgents / onBack を vi.fn()
-     * Level: integration
-     * Objective: onBack prop が渡されていれば「← 一覧」ボタンが表示されクリックで呼ばれることを検証する。
-     */
-    replayLoader.fetchReplayLog.mockResolvedValue('');
-    replayLoader.fetchReplayAgents.mockResolvedValue({});
-    const onBack = vi.fn();
-
-    const user = userEvent.setup();
-    render(<SpectatorScreen sessionId="test-session-001" cast={CAST} onBack={onBack} />);
-
-    await waitForReplayLoadToSettle();
-    await user.click(screen.getByText('← 一覧'));
-    expect(onBack).toHaveBeenCalledOnce();
   });
 });
 
@@ -1105,6 +1104,36 @@ describe('ThoughtDetails: viewerMode public (AC4 / #314)', () => {
   });
 });
 
+describe('SpectatorScreen: back button', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders a back button that navigates to /', async () => {
+    /*
+     * SUT: SpectatorScreen (default export)
+     * Mock: fetchGameBySessionId / fetchReplayLog / fetchReplayAgents を vi.fn()
+     * Level: integration
+     * Objective: 「← 一覧」ボタンが存在し、クリックするとルートに戻ることを検証する。
+     */
+    archiveLoader.fetchGameBySessionId.mockResolvedValue({ cast: [] });
+    replayLoader.fetchReplayLog.mockResolvedValue('');
+    replayLoader.fetchReplayAgents.mockResolvedValue({});
+    const user = userEvent.setup();
+
+    renderSpectator('test-session-001');
+
+    await waitFor(() => {
+      expect(screen.queryByText(/読み込み中/)).toBeNull();
+    }, { timeout: 3000 });
+
+    expect(screen.getByText('← 一覧')).toBeTruthy();
+    await user.click(screen.getByText('← 一覧'));
+    // MemoryRouter 上で / に遷移すると SpectatorScreen がアンマウントされる
+    expect(screen.queryByText('← 一覧')).toBeNull();
+  });
+});
+
 describe('SpectatorScreen: viewerMode toggle (AC1 / #314)', () => {
   afterEach(() => {
     vi.resetAllMocks();
@@ -1117,11 +1146,12 @@ describe('SpectatorScreen: viewerMode toggle (AC1 / #314)', () => {
      * Level: integration
      * Objective: ヘッダーのトグルボタンクリックで spectator / public が切り替わることを検証する（AC1 / #314）。
      */
+    archiveLoader.fetchGameBySessionId.mockResolvedValue({ cast: [] });
     replayLoader.fetchReplayLog.mockResolvedValue('');
     replayLoader.fetchReplayAgents.mockResolvedValue({});
     const user = userEvent.setup();
 
-    render(<SpectatorScreen sessionId="test-session-001" cast={[]} />);
+    renderSpectator('test-session-001');
 
     await waitFor(() => {
       expect(screen.queryByText(/読み込み中/)).toBeNull();

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -29,5 +29,8 @@ export default defineConfig({
     fs: {
       allow: [path.resolve(__dirname, '..')],
     },
+    // SPA fallback: serve index.html for unknown routes so React Router handles them.
+    // /state_archive/ is served by the custom middleware above and never falls through.
+    historyApiFallback: true,
   },
 });


### PR DESCRIPTION
## Summary
- `useState` による画面切り替えを React Router v7 に置き換え
- ルート構成: `/` → GameListScreen、`/agent/:agentName` → AgentDetailScreen（global）、`/game/:sessionId` → SpectatorScreen、`/game/:sessionId/agent/:agentName` → AgentDetailScreen（game-scoped）
- AgentDetailScreen は `useParams()` の `sessionId` 有無でモードを切り替え
- GameListScreen の GameCard・注目エージェント・勝率トップを `<Link>` に変更
- TopBar crumbs に `to?` フィールドを追加し `<Link>` レンダリングに対応
- SpectatorScreen に「← 一覧」ボタンを追加（`useNavigate('/')`）
- `fetchGameBySessionId` を archiveLoader に追加（SpectatorScreen が Router 経由で cast を取得するため）
- Vite dev サーバーに `historyApiFallback: true` を設定

## Implementation notes
- `<button>` → `<Link>` 変更に伴う UA デフォルトスタイル差分を修正: `.cardBody` に `text-decoration: none` 追加、`.rankLink` クラスを新設（`display: flex` と `display: contents` の競合を解消）
- SpectatorScreen の `onBack` prop は削除し `useNavigate` に置き換え（TopBar パンくずでも `/` に戻れるが、明示的な「← 一覧」ボタンを残した）
- `archiveLoader.js` の fetch 境界（`fetchGameList`）は component テスト側でモックする方針（TestStrategy.md §7-B）

## Test plan
- [ ] `ruff check .` パス
- [ ] `pytest` パス
- [ ] `npx vitest run`（198件）パス
- [ ] ブラウザで `/`、`/game/:sessionId`、`/agent/:agentName`、`/game/:sessionId/agent/:agentName` を直接開いてルーティング確認
- [ ] SpectatorScreen で「← 一覧」ボタンが表示され、クリックで一覧に戻ることを確認
- [ ] GameCard クリックで SpectatorScreen に遷移し、テキストに下線がないことを確認

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)