### PR TITLE
feat(frontend): make SpectatorScreen avatars navigable to AgentDetailScreen

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -156,7 +156,7 @@ stateDiagram-v2
     [*] --> GameList : 起動
     GameList --> Spectator : ゲームカードをクリック
     Spectator --> GameList : パンくず「r/agent-jinrou」クリック
-    Spectator --> AgentDetail : ロスターのエージェント名クリック（予定）
+    Spectator --> AgentDetail : ロスターのエージェント名クリック（#485 実装済み）
     AgentDetail --> Spectator : パンくず「第NN回 桜霞」クリック
     AgentDetail --> AgentDetail : 左ペインで別エージェント選択
     AgentDetail --> GameList : パンくず「r/agent-jinrou」クリック
@@ -463,7 +463,7 @@ stateDiagram-v2
 | `...avatarProps` | — | `Avatar` の全 props をそのまま受け付ける |
 
 hover / focus スタイルは CSS `:hover` / `:focus-visible` で付与（`variant` prop には含まない）。
-将来の画面遷移対応は `AvatarLink`（`<a>` / React Router `<Link>` 版）として別途追加予定（#342）。
+画面遷移用途では Avatar を React Router `<Link>` で直接包む方式を採用（#485）。`AvatarLink` コンポーネントの追加は不要と判断。
 
 **使い分け:**
 - icon-only（名前テキスト不要）→ bare `Avatar`（`label` なし）

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,7 +21,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| ❌ yukkie/AgentVillage#485 | enhancement | （なし） | — | Make agent avatars in SpectatorScreen navigable to AgentDetailScreen | SpectatorScreen 内の Avatar・名前表示をクリックして /game/:sessionId/agent/:agentName に遷移する |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#353 | enhancement | 🟡 | 1 | Emit role_assigned events at game start for each agent | init フェーズで全エージェント分の役職割り当てイベントを spectator_log に出力 |
 | yukkie/AgentVillage#347 | enhancement | 🟡 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { Link, useParams, useNavigate } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
 import RoleTag from '../components/RoleTag.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
@@ -60,6 +60,7 @@ function ThoughtDetails({ reasoning, viewerMode = 'spectator' }) {
 
 // --- 発言カード ---
 function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) {
+  const { sessionId } = useParams();
   const role = roleAssignment[ev.agent];
   const r = ROLES[role];
   const replied = ev.reply_to ? prevById[`${ev.day}-${ev.reply_to}`] : null;
@@ -67,6 +68,7 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
   const isPublic = viewerMode === 'public';
   const coedRole = ev.claimed_role;
   const coColor = coedRole ? ROLES[coedRole]?.color : undefined;
+  const agentTo = `/game/${sessionId}/agent/${ev.agent}`;
 
   return (
     <article
@@ -74,11 +76,13 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
       style={{ '--r-color': r?.color }}
       aria-label={`${ev.agent} ${fmtTurn(ev.day, ev.speech_id || 0)} ${fmtTime(ev.day, ev.speech_id || 0)}`}
     >
-      <Avatar name={ev.agent} role={isPublic ? undefined : role} />
+      <Link to={agentTo} className={styles.agentLink}>
+        <Avatar name={ev.agent} role={isPublic ? undefined : role} />
+      </Link>
       <div className={styles.vert} />
       <div>
         <div className={styles.spHead}>
-          <span className={styles.name}>{ev.agent}</span>
+          <Link to={agentTo} className={styles.agentLink}><span className={styles.name}>{ev.agent}</span></Link>
           <span className={styles.turn}>{fmtTurn(ev.day, ev.speech_id || 0)}</span>
           {!isPublic && <RoleTag role={role} />}
           {coedRole && (
@@ -267,6 +271,7 @@ function renderConfiguredSystemEvent(ev, roleAssignment, viewerMode) {
 
 // --- システム行 ---
 function SystemRow({ kind, icon, label, children, strategy, reasoning, ts, leftName, rightName, roleAssignment = {}, viewerMode = 'spectator' }) {
+  const { sessionId } = useParams();
   const defaultIcon = { gm: '👁', death: '💀', exec: '⚑', phase: '☾' }[kind] || '⌘';
   return (
     <div className={`${styles.sysrow} ${styles[kind] || ''}`}>
@@ -277,12 +282,16 @@ function SystemRow({ kind, icon, label, children, strategy, reasoning, ts, leftN
       <div className={styles.sysContent}>
         <div className={styles.sysMain}>
           {leftName && (
-            <Avatar name={leftName} role={roleAssignment[leftName]} size="xs" />
+            <Link to={`/game/${sessionId}/agent/${leftName}`} className={styles.agentLink}>
+              <Avatar name={leftName} role={roleAssignment[leftName]} size="xs" />
+            </Link>
           )}
           <div className={styles.sysText}>{children}</div>
           {ts && <div className={styles.sysTs}>{ts}</div>}
           {rightName && (
-            <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
+            <Link to={`/game/${sessionId}/agent/${rightName}`} className={styles.agentLink}>
+              <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
+            </Link>
           )}
         </div>
         {strategy && viewerMode === 'spectator' && (
@@ -296,13 +305,17 @@ function SystemRow({ kind, icon, label, children, strategy, reasoning, ts, leftN
 
 // --- 人狼会話カード ---
 function WolfChatCard({ ev, viewerMode = 'spectator' }) {
+  const { sessionId } = useParams();
+  const agentTo = `/game/${sessionId}/agent/${ev.agent}`;
   return (
     <article className={`${styles.speech} ${styles.wolfChat}`} aria-label={`${ev.agent} wolf chat`}>
-      <Avatar name={ev.agent} />
+      <Link to={agentTo} className={styles.agentLink}>
+        <Avatar name={ev.agent} />
+      </Link>
       <div className={styles.vert} />
       <div>
         <div className={styles.spHead}>
-          <span className={styles.name}>{ev.agent}</span>
+          <Link to={agentTo} className={styles.agentLink}><span className={styles.name}>{ev.agent}</span></Link>
         </div>
         <div className={styles.spBody}>{ev.content}</div>
         <ThoughtDetails reasoning={ev.reasoning} viewerMode={viewerMode} />
@@ -475,6 +488,7 @@ const NIGHT_ACTION_LABEL = { inspection: '占い', guard: '護衛', night_attack
 
 // === 右ペイン ===
 export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = {}, activeDay, deadByDay = {}, viewerMode = 'spectator' }) {
+  const { sessionId } = useParams();
   const order = Object.keys(agents);
   const activeDead = deadByDay[activeDay] ?? new Map();
   const deadNames = order.filter(n => activeDead.has(n))
@@ -499,7 +513,9 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
               <li key={roleKey} className={styles.coRow} style={{ '--r-color': roleDef.color }}>
                 <span className={styles.coRole}>{roleDef.ja}</span>
                 <span className={styles.coName} style={{ color: coAgents.length ? 'var(--tx)' : 'var(--tx-3)' }}>
-                  {coAgents.length ? coAgents.join(', ') : '未CO'}
+                  {coAgents.length ? coAgents.map((name, i) => (
+                    <span key={name}>{i > 0 && ', '}<Link to={`/game/${sessionId}/agent/${name}`} className={styles.agentLink}>{name}</Link></span>
+                  )) : '未CO'}
                 </span>
               </li>
             );
@@ -512,8 +528,8 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
           <li key={i} className={`${styles.action} ${styles[a.event_type] || ''}`}>
             <div className={styles.actionIco}>{NIGHT_ACTION_ICON[a.event_type] || '・'}</div>
             <div className={styles.what}>
-              <strong>{a.agent}</strong>
-              {a.target && <> → <em style={{ '--r-color': ROLES[roleAssignment[a.target]]?.color }}>{a.target}</em></>}
+              <Link to={`/game/${sessionId}/agent/${a.agent}`} className={styles.agentLink}><strong>{a.agent}</strong></Link>
+              {a.target && <> → <Link to={`/game/${sessionId}/agent/${a.target}`} className={styles.agentLink}><em style={{ '--r-color': ROLES[roleAssignment[a.target]]?.color }}>{a.target}</em></Link></>}
               <span style={{ color: 'var(--tx-4)', marginLeft: 6 }}>{NIGHT_ACTION_LABEL[a.event_type]}</span>
             </div>
           </li>
@@ -557,7 +573,9 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             const coRole = coStatus[n];
             return (
               <li key={n} className={styles.rosterRow} style={{ '--r-color': r?.color }}>
-                <Avatar name={n} role={viewerMode === 'spectator' ? role : undefined} size="sm" label={n} layout="vertical" />
+                <Link to={`/game/${sessionId}/agent/${n}`} className={styles.agentLink}>
+                  <Avatar name={n} role={viewerMode === 'spectator' ? role : undefined} size="sm" label={n} layout="vertical" />
+                </Link>
                 <div className={styles.who}>
                   <span className={styles.rosterName}>
                     {viewerMode === 'spectator' && <RoleTag role={role} />}
@@ -581,7 +599,9 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             const meta = activeDead.get(n);
             return (
               <li key={n} className={`${styles.rosterRow} ${styles.dead}`} style={{ '--r-color': r?.color }}>
-                <Avatar name={n} role={role} size="sm" dead label={n} layout="vertical" />
+                <Link to={`/game/${sessionId}/agent/${n}`} className={styles.agentLink}>
+                  <Avatar name={n} role={role} size="sm" dead label={n} layout="vertical" />
+                </Link>
                 <div className={styles.whoMeta}>
                   <div className={styles.whoBlock}>
                     <span className={styles.sub}>

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -628,3 +628,12 @@
 .gameOverWolf    { color: var(--r-werewolf); }
 .gameOverVillage { color: var(--r-villager); }
 .gameOverUnknown { color: var(--tx); }
+
+/* agent navigation link wrapper */
+.agentLink {
+  text-decoration: none;
+  color: inherit;
+  display: contents;
+}
+.agentLink:hover { opacity: 0.75; }
+.agentLink:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; border-radius: var(--r1); }

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -51,13 +51,19 @@ function renderFeedItem(overrides, options = {}) {
   };
 
   return render(
-    <FeedItem
-      ev={ev}
-      prevById={{}}
-      roleAssignment={roleAssignment}
-      title="Test Village"
-      viewerMode={options.viewerMode}
-    />
+    <MemoryRouter initialEntries={['/game/test-session']}>
+      <Routes>
+        <Route path="/game/:sessionId" element={
+          <FeedItem
+            ev={ev}
+            prevById={{}}
+            roleAssignment={roleAssignment}
+            title="Test Village"
+            viewerMode={options.viewerMode}
+          />
+        } />
+      </Routes>
+    </MemoryRouter>
   );
 }
 
@@ -566,7 +572,13 @@ function renderRightPane(overrides = {}) {
     viewerMode: 'spectator',
     ...overrides,
   };
-  return render(<RightPane {...props} />);
+  return render(
+    <MemoryRouter initialEntries={['/game/test-session']}>
+      <Routes>
+        <Route path="/game/:sessionId" element={<RightPane {...props} />} />
+      </Routes>
+    </MemoryRouter>
+  );
 }
 
 describe('RightPane: death reason display (#391)', () => {
@@ -972,10 +984,16 @@ describe('FeedItem: public mode hides spectator-only events (AC3 / #314)', () =>
      * Objective: spectator モードでは inspection が表示されることを検証する（対比用）。
      */
     render(
-      <FeedItem
-        ev={{ event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf', is_public: false }}
-        prevById={{}} roleAssignment={roleAssignment} title="Test" viewerMode="spectator"
-      />
+      <MemoryRouter initialEntries={['/game/test-session']}>
+        <Routes>
+          <Route path="/game/:sessionId" element={
+            <FeedItem
+              ev={{ event_type: 'inspection', agent: 'Alice', target: 'Bob', content: 'Alice inspects Bob: Werewolf', is_public: false }}
+              prevById={{}} roleAssignment={roleAssignment} title="Test" viewerMode="spectator"
+            />
+          } />
+        </Routes>
+      </MemoryRouter>
     );
     expect(screen.getByText(/Alice inspects Bob: Werewolf/)).toBeTruthy();
   });
@@ -996,13 +1014,13 @@ describe('SpeechCard: viewerMode public (AC2 / #314)', () => {
       is_public: true,
     };
     return render(
-      <FeedItem
-        ev={ev}
-        prevById={{}}
-        roleAssignment={roleAssignment}
-        title="Test Village"
-        viewerMode={viewerMode}
-      />
+      <MemoryRouter initialEntries={['/game/test-session']}>
+        <Routes>
+          <Route path="/game/:sessionId" element={
+            <FeedItem ev={ev} prevById={{}} roleAssignment={roleAssignment} title="Test Village" viewerMode={viewerMode} />
+          } />
+        </Routes>
+      </MemoryRouter>
     );
   }
 
@@ -1047,7 +1065,13 @@ describe('SpeechCard: viewerMode public (AC2 / #314)', () => {
       is_public: true,
     };
     const { container } = render(
-      <FeedItem ev={ev} prevById={{}} roleAssignment={roleAssignment} title="Test" viewerMode={mode} />
+      <MemoryRouter initialEntries={['/game/test-session']}>
+        <Routes>
+          <Route path="/game/:sessionId" element={
+            <FeedItem ev={ev} prevById={{}} roleAssignment={roleAssignment} title="Test" viewerMode={mode} />
+          } />
+        </Routes>
+      </MemoryRouter>
     );
     const badge = container.querySelector('[class*="coBadge"]');
     expect(badge).toBeTruthy();
@@ -1069,13 +1093,13 @@ describe('ThoughtDetails: viewerMode public (AC4 / #314)', () => {
       is_public: true,
     };
     return render(
-      <FeedItem
-        ev={ev}
-        prevById={{}}
-        roleAssignment={roleAssignment}
-        title="Test Village"
-        viewerMode={viewerMode}
-      />
+      <MemoryRouter initialEntries={['/game/test-session']}>
+        <Routes>
+          <Route path="/game/:sessionId" element={
+            <FeedItem ev={ev} prevById={{}} roleAssignment={roleAssignment} title="Test Village" viewerMode={viewerMode} />
+          } />
+        </Routes>
+      </MemoryRouter>
     );
   }
 
@@ -1131,6 +1155,144 @@ describe('SpectatorScreen: back button', () => {
     await user.click(screen.getByText('← 一覧'));
     // MemoryRouter 上で / に遷移すると SpectatorScreen がアンマウントされる
     expect(screen.queryByText('← 一覧')).toBeNull();
+  });
+});
+
+describe('avatar navigation links (#485)', () => {
+  const sessionId = 'test-session-nav';
+
+  function renderWithSession(component) {
+    return render(
+      <MemoryRouter initialEntries={[`/game/${sessionId}`]}>
+        <Routes>
+          <Route path="/game/:sessionId" element={component} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('SpeechCard avatar links to agent detail page (AC: フィード発言カード Avatar)', () => {
+    /*
+     * SUT: FeedItem → SpeechCard
+     * Mock: なし
+     * Level: unit
+     * Objective: speech イベントの Avatar がゲーム内エージェント詳細ページへの Link を持つことを検証する（AC / #485）。
+     */
+    const ev = {
+      day: 1, event_type: 'speech', agent: 'Alice', content: 'hello',
+      speech_id: 1, reply_to: null, claimed_role: null, reasoning: null, is_public: true,
+    };
+    const { container } = renderWithSession(
+      <FeedItem ev={ev} prevById={{}} roleAssignment={roleAssignment} viewerMode="spectator" />
+    );
+    const link = container.querySelector(`a[href="/game/${sessionId}/agent/Alice"]`);
+    expect(link).toBeTruthy();
+  });
+
+  it('SystemRow leftName Avatar links to agent detail page (AC: フィード SystemRow leftName)', () => {
+    /*
+     * SUT: FeedItem → SystemRow
+     * Mock: なし
+     * Level: unit
+     * Objective: SystemRow の leftName Avatar がエージェント詳細ページへの Link を持つことを検証する（AC / #485）。
+     */
+    const ev = { day: 1, event_type: 'vote', agent: 'Alice', target: 'Bob', content: 'vote', is_public: true };
+    const { container } = renderWithSession(
+      <FeedItem ev={ev} prevById={{}} roleAssignment={roleAssignment} viewerMode="spectator" />
+    );
+    expect(container.querySelector(`a[href="/game/${sessionId}/agent/Alice"]`)).toBeTruthy();
+    expect(container.querySelector(`a[href="/game/${sessionId}/agent/Bob"]`)).toBeTruthy();
+  });
+
+  it('RightPane alive roster Avatar links to agent detail page (AC: 右ペイン生存エージェント)', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: 右ペイン生存ロスターの Avatar が AgentDetailScreen への Link を持つことを検証する（AC / #485）。
+     */
+    const { container } = renderWithSession(
+      <RightPane
+        agents={baseAgents}
+        roleAssignment={{ Alice: 'Seer', Bob: 'Werewolf', Carol: 'Knight' }}
+        coStatus={{}}
+        daySummary={{}}
+        activeDay={1}
+        deadByDay={baseDeadByDay}
+        viewerMode="spectator"
+      />
+    );
+    expect(container.querySelector(`a[href="/game/${sessionId}/agent/Alice"]`)).toBeTruthy();
+  });
+
+  it('RightPane CO board agent name links to agent detail page (AC: 右ペイン CO ボード)', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: CO ボードに表示されているエージェント名が Link を持つことを検証する（AC / #485）。
+     */
+    const { container } = renderWithSession(
+      <RightPane
+        agents={baseAgents}
+        roleAssignment={{ Alice: 'Seer', Bob: 'Werewolf', Carol: 'Knight' }}
+        coStatus={{ Alice: 'Seer' }}
+        daySummary={{}}
+        activeDay={1}
+        deadByDay={baseDeadByDay}
+        viewerMode="spectator"
+      />
+    );
+    expect(container.querySelector(`a[href="/game/${sessionId}/agent/Alice"]`)).toBeTruthy();
+  });
+
+  it('RightPane night action agent/target links to agent detail page (AC: 右ペイン夜の行動)', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: 夜の行動の agent / target 名が Link を持つことを検証する（AC / #485）。
+     */
+    const daySummary = {
+      1: {
+        nightActions: [{ event_type: 'inspection', agent: 'Alice', target: 'Bob', is_public: false }],
+        execResult: null, speechCount: 0, nightDone: false,
+      },
+    };
+    const { container } = renderWithSession(
+      <RightPane
+        agents={baseAgents}
+        roleAssignment={{ Alice: 'Seer', Bob: 'Werewolf', Carol: 'Knight' }}
+        coStatus={{}}
+        daySummary={daySummary}
+        activeDay={1}
+        deadByDay={baseDeadByDay}
+        viewerMode="spectator"
+      />
+    );
+    expect(container.querySelector(`a[href="/game/${sessionId}/agent/Alice"]`)).toBeTruthy();
+    expect(container.querySelector(`a[href="/game/${sessionId}/agent/Bob"]`)).toBeTruthy();
+  });
+
+  it('LeftPane filter chip does NOT link to agent detail (AC: 左ペインフィルターは対象外)', () => {
+    /*
+     * SUT: LeftPane
+     * Mock: なし
+     * Level: unit
+     * Objective: 左ペインの「参加者で絞る」フィルターチップが Link を持たないことを検証する（AC / #485）。
+     */
+    const { container } = renderWithSession(
+      <LeftPane
+        activeDay={1} activePhase="discuss" setDay={vi.fn()} setPhase={vi.fn()}
+        days={[1]} agentNames={['Alice', 'Bob']}
+        daySummary={{ 1: { execResult: null, nightDone: false, nightActions: [], speechCount: 0 } }}
+      />
+    );
+    const filterChips = container.querySelectorAll('[class*="filtRow"] button');
+    filterChips.forEach(chip => {
+      expect(chip.tagName).toBe('BUTTON');
+      expect(chip.closest('a')).toBeNull();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- `SpectatorScreen` 内の Avatar / 名前表示を React Router `<Link>` でラップし、`/game/:sessionId/agent/:agentName` へ遷移できるようにした
- 対象: フィード発言カード (Avatar・名前)、フィード SystemRow (leftName/rightName Avatar)、右ペイン生存・死亡ロスター Avatar、右ペイン CO ボードのエージェント名、右ペイン夜の行動の agent/target 名
- 左ペイン「参加者で絞る」フィルターチップは変更なし（フィルター操作用途のため）
- 各サブコンポーネント (`SpeechCard`, `WolfChatCard`, `SystemRow`, `RightPane`) で `useParams()` を直接呼ぶ方式を採用（prop threading 不要）

## Implementation notes

- `AvatarLink` コンポーネントは追加せず、`<Link className={styles.agentLink}>` で Avatar を直接ラップする方式を採用（`FrontendDesign.md` の「予定」記述を更新済み）
- `display: contents` でリンクラッパーをレイアウト透過にし、既存 flex/grid レイアウトへの影響をゼロに抑えた
- 既存テストが Router context なしで `FeedItem` / `RightPane` を render していたため、`renderFeedItem` / `renderRightPane` ヘルパーを `MemoryRouter` でラップするよう更新した

## Test plan

- [x] `npm test` 全 204 件パス
- [x] `npm run test:coverage` — 追加実装行はすべてカバー済み
- [ ] **Playwright ブラウザ動作確認（スキップ）** — 出先のため未実施。帰宅後に以下を手動確認してください:
  - `http://localhost:5173` でゲームを開き SpectatorScreen を表示する
  - フィード内の発言カード Avatar / 名前をクリックすると `/game/{id}/agent/{名前}` に遷移する
  - 右ペイン生存・死亡エージェント Avatar をクリックすると遷移する
  - 右ペイン CO ボードのエージェント名をクリックすると遷移する
  - 右ペイン夜の行動の agent / target 名をクリックすると遷移する
  - 左ペイン「参加者で絞る」チップをクリックしても遷移しない（フィルターのみ）

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)