### PR TITLE
fix(frontend): make vote grid avatars navigable to AgentDetailScreen

### DIFF
--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -549,9 +549,13 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             <div className={styles.voteGrid}>
               {execResult.voteTable.map((v, i) => (
                 <div className={styles.voteCell} key={i}>
-                  <Avatar name={v.from} size="xs" label={v.from} layout="horizontal" />
+                  <Link to={`/game/${sessionId}/agent/${v.from}`} className={styles.agentLink}>
+                    <Avatar name={v.from} size="xs" label={v.from} layout="horizontal" />
+                  </Link>
                   <span className={styles.voteArrow}>▶</span>
-                  <Avatar name={v.to} size="xs" label={v.to} layout="horizontal" variant={v.to === execResult.target ? 'danger' : 'plain'} />
+                  <Link to={`/game/${sessionId}/agent/${v.to}`} className={styles.agentLink}>
+                    <Avatar name={v.to} size="xs" label={v.to} layout="horizontal" variant={v.to === execResult.target ? 'danger' : 'plain'} />
+                  </Link>
                 </div>
               ))}
             </div>

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -1274,6 +1274,36 @@ describe('avatar navigation links (#485)', () => {
     expect(container.querySelector(`a[href="/game/${sessionId}/agent/Bob"]`)).toBeTruthy();
   });
 
+  it('RightPane vote grid from/to avatars link to agent detail page', () => {
+    /*
+     * SUT: RightPane (vote grid)
+     * Mock: なし
+     * Level: unit
+     * Objective: 投票グリッドの from / to Avatar が AgentDetailScreen への Link を持つことを検証する。
+     */
+    const daySummary = {
+      1: {
+        nightActions: [],
+        execResult: { target: 'Bob', votes: 1, voteTable: [{ from: 'Alice', to: 'Bob' }] },
+        speechCount: 0,
+        nightDone: false,
+      },
+    };
+    const { container } = renderWithSession(
+      <RightPane
+        agents={baseAgents}
+        roleAssignment={{ Alice: 'Seer', Bob: 'Werewolf', Carol: 'Knight' }}
+        coStatus={{}}
+        daySummary={daySummary}
+        activeDay={1}
+        deadByDay={baseDeadByDay}
+        viewerMode="spectator"
+      />
+    );
+    expect(container.querySelector(`a[href="/game/${sessionId}/agent/Alice"]`)).toBeTruthy();
+    expect(container.querySelector(`a[href="/game/${sessionId}/agent/Bob"]`)).toBeTruthy();
+  });
+
   it('LeftPane filter chip does NOT link to agent detail (AC: 左ペインフィルターは対象外)', () => {
     /*
      * SUT: LeftPane


### PR DESCRIPTION
## Summary

- #485 の実装で投票グリッド（右ペイン・処刑結果）の `from` / `to` Avatar が Link 化されていなかった漏れを修正
- `v.from` / `v.to` の Avatar をそれぞれ `<Link to={/game/:sessionId/agent/:name}>` で包む

## Test plan

- [x] `npm test` 全 205 件パス
- [ ] ブラウザで右ペイン処刑結果の投票グリッド Avatar をクリックして AgentDetailScreen に遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)