### PR TITLE
refactor(frontend): remove hardcoded stub fallbacks in SpectatorScreen

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -17,8 +17,6 @@
 
 ### Milestone 2（実データ観戦）— 現 Sprint
 
-❌ #483 fix(frontend): remove hardcoded stub fallbacks in SpectatorScreen（tech-debt）
-
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -716,7 +716,7 @@ export default function SpectatorScreen() {
 
   return (
     <div className={styles.frame}>
-      <TopBar crumbs={[{ label: 'r/agent-jinrou', to: '/' }, { label: sessionId || '第13回 桜霞村' }, { label: activePhase === 'game_over' ? '勝敗結果' : activePhase === 'eve' ? '前夜 プロローグ' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}` }]}>
+      <TopBar crumbs={[{ label: 'r/agent-jinrou', to: '/' }, { label: sessionId }, { label: activePhase === 'game_over' ? '勝敗結果' : activePhase === 'eve' ? '前夜 プロローグ' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}` }]}>
         <TopBarBtn onClick={() => navigate('/')}>← 一覧</TopBarBtn>
         <TopBarBtn><span className={topBarStyles.liveDot} /> REPLAY</TopBarBtn>
         <TopBarBtn>同時観戦 142</TopBarBtn>
@@ -734,7 +734,7 @@ export default function SpectatorScreen() {
         right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} daySummary={daySummary} activeDay={activeDay} deadByDay={replayDeadByDay} viewerMode={viewerMode} />}
       >
         <div className={styles.feedHead}>
-          <h2>{activePhase === 'game_over' ? '勝敗結果' : activePhase === 'eve' ? '前夜 プロローグ' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}`} <small>{sessionId || '3:47 経過 / 残り 4:13'}</small></h2>
+          <h2>{activePhase === 'game_over' ? '勝敗結果' : activePhase === 'eve' ? '前夜 プロローグ' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}`} <small>{sessionId}</small></h2>
           <span className={styles.stat}>発言 <strong>{speechCount}</strong></span>
           <span className={styles.stat}>CO <strong>{coCount}</strong></span>
           <span className={styles.spacer} />


### PR DESCRIPTION
## Summary
- `{ label: sessionId || '第13回 桜霞村' }` → `{ label: sessionId }`（パンくず）
- `<small>{sessionId || '3:47 経過 / 残り 4:13'}</small>` → `<small>{sessionId}</small>`（feedHead）

SpectatorScreen は #342 以降 `/game/:sessionId` ルート経由でのみ到達でき、`useParams().sessionId` は常に取得できる。そのため `|| 'リテラル'` のフォールバックは到達不能な dead code（`tests/TestStrategy.md` §7-A「到達不能ガード節」）になっており、削除した。

## Implementation notes
- 表示文字列の削除のみ。`sessionId` は常に truthy のため実挙動の変化はなし。
- 退行テストは追加していない: 削除した分岐は valid sessionId 下で到達不能で、アサートレベルの RED を作れる退行テストが書けない（false-RED にしかならない）。§7-A の原則どおり削除でカバレッジ問題ごと解消している。残った `{ label: sessionId }` / `<small>{sessionId}</small>` の表示経路は既存の sessionId integration テストが行使している。
- Playwright で `/game/20260607_191119` を表示し、両リテラルが DOM に現れないこと・sessionId が両箇所に表示されることを確認済み。

## Test plan
- [x] `npm test` パス（205 passed）
- [x] Playwright: `'第13回 桜霞村'` / `'3:47 経過 / 残り 4:13'` が DOM に出ない、feedHead `<small>` に sessionId が出る
- [x] Python `ruff` / `pytest` は frontend のみの変更のため非影響

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)