### PR TITLE
Show role assigned events in eve feed

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -594,6 +594,7 @@ Semantic HTML: `SpeechCard` / `WolfChatCard` は独立した発言カードと�
 | `night_attack`（public） | `{content}`（SystemRow kind="death"、右に target アバター） |
 | `suspicion_update` | `suspicion_snapshot` があれば SystemRow 内で疑念メーターを表示（高いほど長いバー、green → yellow → red）。snapshot 欠如時は `{content}` にフォールバック |
 | `threat_update` | `threat_snapshot` があれば SystemRow 内で脅威メーターを表示（高いほど長いバー、赤系の濃淡）。snapshot 欠如時は `{content}` にフォールバック |
+| `role_assigned` | 前夜フィードに表示。summary row（`agent=null`, `is_public=true`）は public mode のみ SystemRow の役職構成として表示し、spectator mode では個別役職カードと重複するため表示しない。per-agent row（`agent={name}`, `is_public=false`）は spectator mode のみ AgentEpisodeCard で表示し、真役職 Avatar / RoleTag と本文を表示する。public mode では既存の `is_public=false` 非表示ルールでマウントしない |
 
 データソース: `stub/spectator.js`（`EVENTS`, `ROLE_ASSIGNMENT`, `NIGHT_RESULTS`, `EXEC_RESULTS`, `VOTE_TABLE_D1`, `ACTIONS_TIMELINE`）。
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -22,7 +22,6 @@
 | yukkie/AgentVillage#492 | enhancement | 🔴 | 5 | Connect AgentDetailScreen to real game data with viewerMode support | AgentDetailScreen のスタブ固定を実データ接続に。同時に viewerMode 対応で public 時に役職・推論ログ等を秘匿。規模次第で実データ接続/viewerMode に分割可 |
 | yukkie/AgentVillage#493 | enhancement | 🔴 | 3 | Lift viewerMode into routing/URL state | viewerMode を SpectatorScreen の useState から URL/横断 state へ引き上げ。直打ち・リロード・画面遷移で視点を保持 |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#501 | enhancement | ❌ | - | feat(frontend): show role_assigned events in eve feed | 前夜フィードに role_assigned イベントを表示。feedFilter + FeedItem に render case 追加。spectator は個別、public は summary のみ |
 | yukkie/AgentVillage#347 | enhancement | 🔴 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |

--- a/frontend/src/lib/feedFilter.js
+++ b/frontend/src/lib/feedFilter.js
@@ -43,7 +43,7 @@ export function filterFeedEvents(events, day, phase) {
     }
 
     if (phase === 'eve') {
-      return ev.event_type === 'game_start_narrative';
+      return ev.event_type === 'game_start_narrative' || ev.event_type === 'role_assigned';
     }
 
     return false;

--- a/frontend/src/lib/feedFilter.test.js
+++ b/frontend/src/lib/feedFilter.test.js
@@ -214,16 +214,17 @@ describe('filterFeedEvents', () => {
   SUT: filterFeedEvents
   Mock: なし
   Level: unit
-  Objective: eve フェーズで game_start_narrative イベントのみ返すことを検証する
+  Objective: eve フェーズで game_start_narrative / role_assigned イベントを返すことを検証する
   */
-  it('eve: game_start_narrative イベントのみ返す', () => {
+  it('eve: game_start_narrative / role_assigned イベントを返す', () => {
     const events = [
       ev({ day: 0, event_type: 'game_start_narrative', phase: 'init', is_public: true, content: 'A werewolf lurks...' }),
+      ev({ day: 0, event_type: 'role_assigned', phase: 'init', agent: null, is_public: true, content: 'This village has 3 Villagers · 1 Seer · 1 Werewolf' }),
+      ev({ day: 0, event_type: 'role_assigned', phase: 'init', agent: 'Alice', is_public: false, content: 'Alice came to realize they were the Seer.' }),
       ev({ day: 1, event_type: 'speech', phase: 'day_discussion' }),
     ];
     const result = filterFeedEvents(events, 0, 'eve');
-    expect(result).toHaveLength(1);
-    expect(result[0].event_type).toBe('game_start_narrative');
+    expect(result.map(e => e.event_type)).toEqual(['game_start_narrative', 'role_assigned', 'role_assigned']);
   });
 
   /*

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -107,6 +107,37 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
   );
 }
 
+function AgentEpisodeCard({ ev, roleAssignment, viewerMode = 'spectator', label = '役職割り当て' }) {
+  const { sessionId } = useParams();
+  const role = roleAssignment[ev.agent];
+  const r = ROLES[role];
+  const isPublic = viewerMode === 'public';
+  const agentTo = `/game/${sessionId}/agent/${ev.agent}`;
+
+  return (
+    <article
+      className={styles.agentEpisode}
+      style={{ '--r-color': r?.color }}
+      aria-label={`${ev.agent} ${label}`}
+    >
+      <Link to={agentTo} className={styles.agentLink}>
+        <Avatar name={ev.agent} role={isPublic ? undefined : role} />
+      </Link>
+      <div className={styles.vert} />
+      <div>
+        <div className={styles.spHead}>
+          <Link to={agentTo} className={styles.agentLink}><span className={styles.name}>{ev.agent}</span></Link>
+          <span className={styles.turn}>{label}</span>
+          {!isPublic && <RoleTag role={role} />}
+        </div>
+        <div className={styles.spBody}>
+          <Mentioned text={contentForViewer(ev, viewerMode)} />
+        </div>
+      </div>
+    </article>
+  );
+}
+
 // Unified viewerMode-aware content selector for all event types.
 // spectator mode uses spectator_content when available; public mode always uses content.
 function contentForViewer(ev, viewerMode) {
@@ -339,6 +370,14 @@ export function FeedItem({ ev, prevById, roleAssignment, title, viewerMode = 'sp
 
   if (ev.event_type === 'game_start_narrative') {
     return <SystemRow kind="gm" label="ゲームマスター">{ev.content}</SystemRow>;
+  }
+
+  if (ev.event_type === 'role_assigned') {
+    if (ev.agent) {
+      return <AgentEpisodeCard ev={ev} roleAssignment={roleAssignment} viewerMode={viewerMode} />;
+    }
+    if (!isPublic) return null;
+    return <SystemRow kind="gm" label="役職構成" viewerMode={viewerMode}>{contentForViewer(ev, viewerMode)}</SystemRow>;
   }
 
   if (ev.event_type === 'wolf_chat') return <WolfChatCard ev={ev} viewerMode={viewerMode} />;

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -138,6 +138,26 @@
 }
 .speech:hover { background: rgba(255,255,255,0.012); }
 .speechWolf { background: linear-gradient(90deg, rgba(226,107,107,0.04), transparent 60%); }
+.agentEpisode {
+  composes: speech;
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--r-color, var(--acc)) 16%, var(--bg-1)) 0%,
+      color-mix(in oklab, var(--r-color, var(--acc)) 7%, var(--bg)) 58%,
+      transparent 100%
+    );
+  border-left: 2px solid color-mix(in oklab, var(--r-color, var(--acc)) 42%, transparent);
+}
+.agentEpisode:hover {
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--r-color, var(--acc)) 24%, var(--bg-1)) 0%,
+      color-mix(in oklab, var(--r-color, var(--acc)) 12%, var(--bg)) 60%,
+      transparent 100%
+    );
+}
 .wolfChat {
   background: linear-gradient(90deg, rgba(180,40,40,0.10), transparent 70%);
   border-left: 2px solid rgba(200,60,60,0.5);

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -384,6 +384,107 @@ describe('FeedItem: phase_start visibility', () => {
     renderFeedItem({ event_type: 'game_start_narrative', phase: 'init', day: 0, content: 'A werewolf lurks among the villagers.' });
     expect(screen.getByText(/A werewolf lurks/)).toBeTruthy();
   });
+
+  it('renders role_assigned summary as a gm system row in public mode', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし
+     * Level: unit
+     * Objective: public mode の role_assigned summary row が前夜の役職構成テキストとして表示されることを検証する。
+     */
+    renderFeedItem({
+      event_type: 'role_assigned',
+      phase: 'init',
+      day: 0,
+      agent: null,
+      is_public: true,
+      content: 'This village has 3 Villagers · 1 Seer · 1 Werewolf',
+    }, { viewerMode: 'public' });
+
+    expect(screen.getByText('役職構成')).toBeTruthy();
+    expect(screen.getByText(/This village has 3 Villagers/)).toBeTruthy();
+  });
+
+  it('hides role_assigned summary row in spectator mode', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし
+     * Level: unit
+     * Objective: spectator mode では role_assigned summary row を非表示にし、個別役職カードだけを表示対象にすることを検証する。
+     */
+    const { container } = renderFeedItem({
+      event_type: 'role_assigned',
+      phase: 'init',
+      day: 0,
+      agent: null,
+      is_public: true,
+      content: 'This village has 3 Villagers · 1 Seer · 1 Werewolf',
+    }, { viewerMode: 'spectator' });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders role_assigned per-agent row as an agent episode card in spectator mode', () => {
+    /**
+     * SUT: FeedItem → AgentEpisodeCard
+     * Mock: なし
+     * Level: component
+     * Objective: spectator mode の role_assigned per-agent row が大きな Avatar と真役職タグ付きのエピソードカードとして表示されることを検証する。
+     */
+    const { container } = renderFeedItem({
+      event_type: 'role_assigned',
+      phase: 'init',
+      day: 0,
+      agent: 'Alice',
+      is_public: false,
+      content: 'Alice came to realize they were the Seer.',
+    }, { viewerMode: 'spectator' });
+
+    expect(screen.getByRole('article', { name: 'Alice 役職割り当て' })).toBeTruthy();
+    expect(screen.getByAltText('Alice')).toBeTruthy();
+    expect(screen.getByText('Alice')).toBeTruthy();
+    expect(screen.getByText('Alice came to realize they were the Seer.')).toBeTruthy();
+    expect(container.querySelector('[class*="agentEpisode"]')).toBeTruthy();
+    expect(container.querySelector('[class*="roleTag"]')).toBeTruthy();
+  });
+
+  it('hides role_assigned per-agent row in public mode', () => {
+    /**
+     * SUT: FeedItem
+     * Mock: なし
+     * Level: unit
+     * Objective: public mode では is_public=false の role_assigned per-agent row がマウントされないことを検証する。
+     */
+    const { container } = renderFeedItem({
+      event_type: 'role_assigned',
+      phase: 'init',
+      day: 0,
+      agent: 'Alice',
+      is_public: false,
+      content: 'Alice came to realize they were the Seer.',
+    }, { viewerMode: 'public' });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('falls back for archived role_assigned rows with missing content', () => {
+    /**
+     * SUT: FeedItem → AgentEpisodeCard
+     * Mock: なし
+     * Level: unit
+     * Objective: role_assigned を含まない/本文欠損に近い旧アーカイブ互換ケースでもカード表示が壊れず欠損マーカーを表示することを検証する。
+     */
+    renderFeedItem({
+      event_type: 'role_assigned',
+      phase: 'init',
+      day: 0,
+      agent: 'Alice',
+      is_public: false,
+      content: '',
+    }, { viewerMode: 'spectator' });
+
+    expect(screen.getByText('[missing content]')).toBeTruthy();
+  });
 });
 
 describe('FeedItem: vote card', () => {


### PR DESCRIPTION
## Summary
- Include `role_assigned` events in the eve feed filter.
- Render per-agent `role_assigned` rows as reusable `AgentEpisodeCard` entries in spectator mode.
- Render the role summary row only in public mode, avoiding duplicate role info in spectator mode.
- Document the frontend display contract and remove #501 from `doc/Ideas.md`.

## Implementation notes
- `AgentEpisodeCard` reuses the SpeechCard-like layout so future agent one-line episode rows can share the same presentation.
- The card background uses the agent role color mixed into a dark background, with a slightly brighter hover state.
- Public mode keeps individual role assignments hidden through the existing `is_public=false` guard.

## Test plan
- [x] `npm test` passed: 11 files / 213 tests
- [x] `npm run test:coverage` passed
- [x] Playwright desktop check passed:
  - spectator eve: per-agent cards visible, summary hidden
  - public eve: summary visible, per-agent cards hidden
  - hover CSS rule present and brighter than base
- [x] pre-commit passed on commits

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)