### PR TITLE
feat: lift viewerMode into URL state

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -556,6 +556,10 @@ Semantic HTML: `GameCard` は自己完結したゲーム項目として `<articl
 Semantic HTML: `SpeechCard` / `WolfChatCard` は独立した発言カードとして `<article>`、発言時刻は `<time>`、ロスター・COボード・夜行動タイムラインは `<ul><li>` で表現する。`SystemRow` はシステム通知行であり、発言カードとは別扱いにする。
 
 ヘッダーの「観戦者モード / 参加者視点」トグルで `viewerMode: 'spectator' | 'public'` を切り替える。
+`viewerMode` は URL query を正本とし、`?view=public` のとき `public`、未指定または不正値では
+`spectator` として扱う（#493）。`spectator` は既存 URL 互換を保つため query なしを canonical とする。
+SpectatorScreen から AgentDetailScreen への遷移、および AgentDetailScreen から SpectatorScreen へ戻る
+パンくずでは `?view=public` を引き継ぐ。
 
 | 要素 | spectator | public |
 |---|---|---|

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,7 +20,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#492 | enhancement | 🔴 | 5 | Connect AgentDetailScreen to real game data with viewerMode support | AgentDetailScreen のスタブ固定を実データ接続に。同時に viewerMode 対応で public 時に役職・推論ログ等を秘匿。規模次第で実データ接続/viewerMode に分割可 |
-| yukkie/AgentVillage#493 | enhancement | 🔴 | 3 | Lift viewerMode into routing/URL state | viewerMode を SpectatorScreen の useState から URL/横断 state へ引き上げ。直打ち・リロード・画面遷移で視点を保持 |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#347 | enhancement | 🔴 | 3 | Implement feed filters in SpectatorScreen left pane (agent / role / event type) | 参加者・役職・表示種別フィルターチップを実際に動作させる。追加データ不要でクライアントサイドのみで実装可能 |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useSearchParams } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
@@ -13,10 +13,19 @@ import styles from './AgentDetailScreen.module.css';
 
 const TABS = ['概要', '推論ログ', '疑い・信頼', '夜の行動', '過去の戦績'];
 
+function viewerModeFromSearchParams(searchParams) {
+  return searchParams.get('view') === 'public' ? 'public' : 'spectator';
+}
+
+function searchForViewerMode(viewerMode) {
+  return viewerMode === 'public' ? '?view=public' : '';
+}
+
 // --- 左ペイン ---
-function LeftPane({ current, sessionId }) {
+function LeftPane({ current, sessionId, viewerMode = 'spectator' }) {
   const alive = ALL_AGENTS.filter(n => !DEAD_AGENTS.has(n));
   const dead  = ALL_AGENTS.filter(n =>  DEAD_AGENTS.has(n));
+  const viewerSearch = searchForViewerMode(viewerMode);
 
   return (
     <>
@@ -31,7 +40,7 @@ function LeftPane({ current, sessionId }) {
           const r     = ROLES[role];
           const isDead = DEAD_AGENTS.has(n);
           const to = sessionId
-            ? `/game/${sessionId}/agent/${encodeURIComponent(n)}`
+            ? `/game/${sessionId}/agent/${encodeURIComponent(n)}${viewerSearch}`
             : `/agent/${encodeURIComponent(n)}`;
           return (
             <li
@@ -307,6 +316,9 @@ function RightPane({ agent }) {
 // === メイン画面 ===
 export default function AgentDetailScreen() {
   const { sessionId, agentName } = useParams();
+  const [searchParams] = useSearchParams();
+  const viewerMode = viewerModeFromSearchParams(searchParams);
+  const viewerSearch = searchForViewerMode(viewerMode);
   const agent = agentName || 'Nox';
   const [tab, setTab] = useState(0);
 
@@ -322,7 +334,7 @@ export default function AgentDetailScreen() {
   ];
 
   const topCrumbs = sessionId
-    ? [{ label: 'r/agent-jinrou', to: '/' }, { label: sessionId, to: `/game/${sessionId}` }, { label: agent }]
+    ? [{ label: 'r/agent-jinrou', to: '/' }, { label: sessionId, to: `/game/${sessionId}${viewerSearch}` }, { label: agent }]
     : [{ label: 'r/agent-jinrou', to: '/' }, { label: agent }];
 
   return (
@@ -336,7 +348,7 @@ export default function AgentDetailScreen() {
       <ThreePaneLayout
         collapsibleLeft
         collapsibleRight
-        left={<LeftPane current={agent} sessionId={sessionId} />}
+        left={<LeftPane current={agent} sessionId={sessionId} viewerMode={viewerMode} />}
         right={<RightPane agent={agent} />}
       >
         <div className={styles.mainPane}>

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -8,10 +8,10 @@ afterEach(() => {
   cleanup();
 });
 
-function renderAgent({ sessionId, agentName = 'Nox' } = {}) {
+function renderAgent({ sessionId, agentName = 'Nox', search = '' } = {}) {
   const path = sessionId
-    ? `/game/${sessionId}/agent/${agentName}`
-    : `/agent/${agentName}`;
+    ? `/game/${sessionId}/agent/${agentName}${search}`
+    : `/agent/${agentName}${search}`;
   const routePath = sessionId
     ? '/game/:sessionId/agent/:agentName'
     : '/agent/:agentName';
@@ -67,6 +67,30 @@ describe('AgentDetailScreen semantic structure', () => {
     renderAgent({ sessionId: 'test-session-001', agentName: 'Nox' });
 
     expect(screen.getByText('test-session-001')).toBeTruthy();
+  });
+
+  it('preserves public viewerMode query in the game breadcrumb link', () => {
+    /*
+     * SUT: AgentDetailScreen TopBar crumbs
+     * Mock: なし
+     * Level: contract
+     * Objective: AgentDetailScreen からゲーム画面へ戻るパンくずが ?view=public を引き継ぐことを検証する。
+     */
+    renderAgent({ sessionId: 'test-session-001', agentName: 'Nox', search: '?view=public' });
+
+    expect(screen.getByRole('link', { name: 'test-session-001' }).getAttribute('href')).toBe('/game/test-session-001?view=public');
+  });
+
+  it('preserves public viewerMode query in game-scoped agent picker links', () => {
+    /*
+     * SUT: AgentDetailScreen LeftPane
+     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
+     * Level: contract
+     * Objective: game-scoped AgentDetailScreen の AgentPicker 内リンクが ?view=public を引き継ぐことを検証する。
+     */
+    renderAgent({ sessionId: 'test-session-001', agentName: 'Nox', search: '?view=public' });
+
+    expect(screen.getByRole('link', { name: /Mira/ }).getAttribute('href')).toBe('/game/test-session-001/agent/Mira?view=public');
   });
 
   it('renders global breadcrumbs when sessionId is absent', () => {

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
 import RoleTag from '../components/RoleTag.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
@@ -12,6 +12,18 @@ import { filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
 
 const MISSING_CONTENT = '[missing content]';
+
+function viewerModeFromSearchParams(searchParams) {
+  return searchParams.get('view') === 'public' ? 'public' : 'spectator';
+}
+
+function searchForViewerMode(viewerMode) {
+  return viewerMode === 'public' ? '?view=public' : '';
+}
+
+function agentDetailPath(sessionId, agentName, viewerMode) {
+  return `/game/${sessionId}/agent/${agentName}${searchForViewerMode(viewerMode)}`;
+}
 
 // --- ユーティリティ ---
 function fmtTurn(day, speechId) {
@@ -68,7 +80,7 @@ function SpeechCard({ ev, prevById, roleAssignment, viewerMode = 'spectator' }) 
   const isPublic = viewerMode === 'public';
   const coedRole = ev.claimed_role;
   const coColor = coedRole ? ROLES[coedRole]?.color : undefined;
-  const agentTo = `/game/${sessionId}/agent/${ev.agent}`;
+  const agentTo = agentDetailPath(sessionId, ev.agent, viewerMode);
 
   return (
     <article
@@ -112,7 +124,7 @@ function AgentEpisodeCard({ ev, roleAssignment, viewerMode = 'spectator', label 
   const role = roleAssignment[ev.agent];
   const r = ROLES[role];
   const isPublic = viewerMode === 'public';
-  const agentTo = `/game/${sessionId}/agent/${ev.agent}`;
+  const agentTo = agentDetailPath(sessionId, ev.agent, viewerMode);
 
   return (
     <article
@@ -313,14 +325,14 @@ function SystemRow({ kind, icon, label, children, strategy, reasoning, ts, leftN
       <div className={styles.sysContent}>
         <div className={styles.sysMain}>
           {leftName && (
-            <Link to={`/game/${sessionId}/agent/${leftName}`} className={styles.agentLink}>
+            <Link to={agentDetailPath(sessionId, leftName, viewerMode)} className={styles.agentLink}>
               <Avatar name={leftName} role={roleAssignment[leftName]} size="xs" />
             </Link>
           )}
           <div className={styles.sysText}>{children}</div>
           {ts && <div className={styles.sysTs}>{ts}</div>}
           {rightName && (
-            <Link to={`/game/${sessionId}/agent/${rightName}`} className={styles.agentLink}>
+            <Link to={agentDetailPath(sessionId, rightName, viewerMode)} className={styles.agentLink}>
               <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
             </Link>
           )}
@@ -337,7 +349,7 @@ function SystemRow({ kind, icon, label, children, strategy, reasoning, ts, leftN
 // --- 人狼会話カード ---
 function WolfChatCard({ ev, viewerMode = 'spectator' }) {
   const { sessionId } = useParams();
-  const agentTo = `/game/${sessionId}/agent/${ev.agent}`;
+  const agentTo = agentDetailPath(sessionId, ev.agent, viewerMode);
   return (
     <article className={`${styles.speech} ${styles.wolfChat}`} aria-label={`${ev.agent} wolf chat`}>
       <Link to={agentTo} className={styles.agentLink}>
@@ -553,7 +565,7 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
                 <span className={styles.coRole}>{roleDef.ja}</span>
                 <span className={styles.coName} style={{ color: coAgents.length ? 'var(--tx)' : 'var(--tx-3)' }}>
                   {coAgents.length ? coAgents.map((name, i) => (
-                    <span key={name}>{i > 0 && ', '}<Link to={`/game/${sessionId}/agent/${name}`} className={styles.agentLink}>{name}</Link></span>
+                    <span key={name}>{i > 0 && ', '}<Link to={agentDetailPath(sessionId, name, viewerMode)} className={styles.agentLink}>{name}</Link></span>
                   )) : '未CO'}
                 </span>
               </li>
@@ -567,8 +579,8 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
           <li key={i} className={`${styles.action} ${styles[a.event_type] || ''}`}>
             <div className={styles.actionIco}>{NIGHT_ACTION_ICON[a.event_type] || '・'}</div>
             <div className={styles.what}>
-              <Link to={`/game/${sessionId}/agent/${a.agent}`} className={styles.agentLink}><strong>{a.agent}</strong></Link>
-              {a.target && <> → <Link to={`/game/${sessionId}/agent/${a.target}`} className={styles.agentLink}><em style={{ '--r-color': ROLES[roleAssignment[a.target]]?.color }}>{a.target}</em></Link></>}
+              <Link to={agentDetailPath(sessionId, a.agent, viewerMode)} className={styles.agentLink}><strong>{a.agent}</strong></Link>
+              {a.target && <> → <Link to={agentDetailPath(sessionId, a.target, viewerMode)} className={styles.agentLink}><em style={{ '--r-color': ROLES[roleAssignment[a.target]]?.color }}>{a.target}</em></Link></>}
               <span style={{ color: 'var(--tx-4)', marginLeft: 6 }}>{NIGHT_ACTION_LABEL[a.event_type]}</span>
             </div>
           </li>
@@ -588,11 +600,11 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             <div className={styles.voteGrid}>
               {execResult.voteTable.map((v, i) => (
                 <div className={styles.voteCell} key={i}>
-                  <Link to={`/game/${sessionId}/agent/${v.from}`} className={styles.agentLink}>
+                  <Link to={agentDetailPath(sessionId, v.from, viewerMode)} className={styles.agentLink}>
                     <Avatar name={v.from} size="xs" label={v.from} layout="horizontal" />
                   </Link>
                   <span className={styles.voteArrow}>▶</span>
-                  <Link to={`/game/${sessionId}/agent/${v.to}`} className={styles.agentLink}>
+                  <Link to={agentDetailPath(sessionId, v.to, viewerMode)} className={styles.agentLink}>
                     <Avatar name={v.to} size="xs" label={v.to} layout="horizontal" variant={v.to === execResult.target ? 'danger' : 'plain'} />
                   </Link>
                 </div>
@@ -616,7 +628,7 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             const coRole = coStatus[n];
             return (
               <li key={n} className={styles.rosterRow} style={{ '--r-color': r?.color }}>
-                <Link to={`/game/${sessionId}/agent/${n}`} className={styles.agentLink}>
+                <Link to={agentDetailPath(sessionId, n, viewerMode)} className={styles.agentLink}>
                   <Avatar name={n} role={viewerMode === 'spectator' ? role : undefined} size="sm" label={n} layout="vertical" />
                 </Link>
                 <div className={styles.who}>
@@ -642,7 +654,7 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             const meta = activeDead.get(n);
             return (
               <li key={n} className={`${styles.rosterRow} ${styles.dead}`} style={{ '--r-color': r?.color }}>
-                <Link to={`/game/${sessionId}/agent/${n}`} className={styles.agentLink}>
+                <Link to={agentDetailPath(sessionId, n, viewerMode)} className={styles.agentLink}>
                   <Avatar name={n} role={role} size="sm" dead label={n} layout="vertical" />
                 </Link>
                 <div className={styles.whoMeta}>
@@ -669,6 +681,7 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
 export default function SpectatorScreen() {
   const { sessionId } = useParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [activeDay, setActiveDay] = useState(2);
   const [activePhase, setActivePhase] = useState('discuss');
   const [replayEvents, setReplayEvents] = useState(null);
@@ -680,7 +693,11 @@ export default function SpectatorScreen() {
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
   const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
   const [loadError, setLoadError] = useState(null);
-  const [viewerMode, setViewerMode] = useState('spectator');
+  const viewerMode = viewerModeFromSearchParams(searchParams);
+
+  const toggleViewerMode = () => {
+    setSearchParams(viewerMode === 'spectator' ? { view: 'public' } : {});
+  };
 
   useEffect(() => {
     if (!sessionId) return undefined;
@@ -759,7 +776,7 @@ export default function SpectatorScreen() {
         <TopBarBtn onClick={() => navigate('/')}>← 一覧</TopBarBtn>
         <TopBarBtn><span className={topBarStyles.liveDot} /> REPLAY</TopBarBtn>
         <TopBarBtn>同時観戦 142</TopBarBtn>
-        <TopBarBtn onClick={() => setViewerMode(v => v === 'spectator' ? 'public' : 'spectator')}>
+        <TopBarBtn onClick={toggleViewerMode}>
           {viewerMode === 'spectator' ? '🔍 観戦者モード' : '👤 参加者視点'}
         </TopBarBtn>
         <TopBarBtn>⤓ 全ログDL</TopBarBtn>

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen, within, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { FeedItem, LeftPane, RightPane } from './SpectatorScreen.jsx';
 import SpectatorScreen from './SpectatorScreen.jsx';
@@ -19,12 +19,18 @@ vi.mock('../lib/archiveLoader.js', () => ({
   fetchGameBySessionId: vi.fn(),
 }));
 
-function renderSpectator(sessionId) {
+function LocationProbe() {
+  const location = useLocation();
+  return <output aria-label="current-location">{location.pathname}{location.search}</output>;
+}
+
+function renderSpectator(sessionId, search = '') {
   return render(
-    <MemoryRouter initialEntries={[`/game/${sessionId}`]}>
+    <MemoryRouter initialEntries={[`/game/${sessionId}${search}`]}>
       <Routes>
         <Route path="/game/:sessionId" element={<SpectatorScreen />} />
       </Routes>
+      <LocationProbe />
     </MemoryRouter>
   );
 }
@@ -1290,6 +1296,30 @@ describe('avatar navigation links (#485)', () => {
     expect(link).toBeTruthy();
   });
 
+  it('SpeechCard avatar preserves public viewerMode query in agent detail link', () => {
+    /*
+     * SUT: FeedItem → SpeechCard
+     * Mock: なし
+     * Level: contract
+     * Objective: public viewerMode の URL query が発言カード Avatar から AgentDetailScreen への Link に引き継がれることを検証する。
+     */
+    const ev = {
+      day: 1, event_type: 'speech', agent: 'Alice', content: 'hello',
+      speech_id: 1, reply_to: null, claimed_role: null, reasoning: null, is_public: true,
+    };
+    const { container } = render(
+      <MemoryRouter initialEntries={[`/game/${sessionId}?view=public`]}>
+        <Routes>
+          <Route path="/game/:sessionId" element={
+            <FeedItem ev={ev} prevById={{}} roleAssignment={roleAssignment} viewerMode="public" />
+          } />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(container.querySelector(`a[href="/game/${sessionId}/agent/Alice?view=public"]`)).toBeTruthy();
+  });
+
   it('SystemRow leftName Avatar links to agent detail page (AC: フィード SystemRow leftName)', () => {
     /*
      * SUT: FeedItem → SystemRow
@@ -1460,5 +1490,51 @@ describe('SpectatorScreen: viewerMode toggle (AC1 / #314)', () => {
     // Click again to switch back
     await user.click(screen.getByText(/参加者視点/));
     expect(screen.getByText(/観戦者モード/)).toBeTruthy();
+  });
+
+  it('initializes public mode from ?view=public after reload', async () => {
+    /*
+     * SUT: SpectatorScreen viewerMode URL state
+     * Mock: fetchGameBySessionId / fetchReplayLog / fetchReplayAgents を vi.fn()
+     * Level: contract
+     * Objective: URL 直打ち/リロード相当の初期表示で ?view=public が public viewerMode として反映されることを検証する。
+     */
+    archiveLoader.fetchGameBySessionId.mockResolvedValue({ cast: [] });
+    replayLoader.fetchReplayLog.mockResolvedValue('');
+    replayLoader.fetchReplayAgents.mockResolvedValue({});
+
+    renderSpectator('test-session-001', '?view=public');
+
+    await waitFor(() => {
+      expect(screen.queryByText(/読み込み中/)).toBeNull();
+    }, { timeout: 3000 });
+
+    expect(screen.getByText(/参加者視点/)).toBeTruthy();
+    expect(screen.getByLabelText('current-location').textContent).toBe('/game/test-session-001?view=public');
+  });
+
+  it('writes viewerMode toggle changes to the URL query', async () => {
+    /*
+     * SUT: SpectatorScreen viewerMode toggle
+     * Mock: fetchGameBySessionId / fetchReplayLog / fetchReplayAgents を vi.fn()
+     * Level: contract
+     * Objective: viewerMode トグル操作が ?view=public の付与/削除として URL に反映されることを検証する。
+     */
+    archiveLoader.fetchGameBySessionId.mockResolvedValue({ cast: [] });
+    replayLoader.fetchReplayLog.mockResolvedValue('');
+    replayLoader.fetchReplayAgents.mockResolvedValue({});
+    const user = userEvent.setup();
+
+    renderSpectator('test-session-001');
+
+    await waitFor(() => {
+      expect(screen.queryByText(/読み込み中/)).toBeNull();
+    }, { timeout: 3000 });
+
+    await user.click(screen.getByText(/観戦者モード/));
+    expect(screen.getByLabelText('current-location').textContent).toBe('/game/test-session-001?view=public');
+
+    await user.click(screen.getByText(/参加者視点/));
+    expect(screen.getByLabelText('current-location').textContent).toBe('/game/test-session-001');
   });
 });


### PR DESCRIPTION
## Summary
- Move SpectatorScreen viewerMode from local state to `?view=public` URL query state
- Preserve public viewerMode across SpectatorScreen ⇄ AgentDetailScreen navigation links
- Document the viewerMode URL contract and remove #493 from Ideas.md

## Implementation notes
- `spectator` remains the canonical/default mode with no query string.
- `?view=public` is the only URL value treated as public mode; missing/invalid values fall back to spectator.
- AgentDetailScreen only preserves the viewerMode query for navigation. Its actual public/spectator data hiding remains in #492.
- Playwright MCP browser automation was blocked by an existing profile lock, so browser verification could not be automated in this session.

## Test plan
- [x] `npm.cmd test`
- [x] `npm.cmd run test:coverage`
- [x] `npm.cmd run build`
- [x] `uv run ruff check .`
- [x] `uv run pytest`

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)