### PR TITLE
docs: sync dev tool issues in Ideas.md after revise

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -60,8 +60,9 @@
 | yukkie/AgentVillage#315 | enhancement | 🟢 | 8 | FastAPI + WebSocket backend | リアルタイムストリーミング（Milestone 2 完了後） |
 | yukkie/AgentVillage#316 | enhancement | 🟢 | 13 | Mobile app (React Native) | iOS/Android 対応（#315 完了後） |
 | yukkie/AgentVillage#30 | enhancement | 🟢 | 13 | State management DB migration | JSON → DB 移行 |
-| yukkie/AgentVillage#424 | enhancement | 🟢 | 5 | Dev tool (1/2): AST-based relationship extraction for a central data type | 中心データ型を起点に producer/consumer/transform を AST で全列挙し隣接リスト出力。idd 事前調査から参照。汎用ツール（LogEvent は検証例） |
-| yukkie/AgentVillage#425 | enhancement | 🟢 | 3 | Dev tool (2/2): smell evaluation over the extracted relationship graph | 抽出グラフ上で transform スメルを定義基準で分類・淀み度集計。依存: #424 |
+| yukkie/AgentVillage#424 | enhancement | 🟢 | 5 | Dev tool (1/3): AST-based relationship extraction for a central data type | 中心データ型の producer/consumer/transform を Python AST で全列挙し隣接リスト出力（consumer×field read マトリクス含む）。#466 の設計比較の入力。JS 抽出は #508 に分割 |
+| yukkie/AgentVillage#508 | enhancement | 🟢 | — | Dev tool (2/3): JS field-access extraction | JS consumer のフィールド read をヒューリスティック抽出し #424 の隣接リストに統合（source: js / confidence: heuristic）。#379 導入後は型起点へ強化。依存: #424 |
+| yukkie/AgentVillage#425 | enhancement | 🟢 | 3 | Dev tool (3/3): smell evaluation skill over the extracted relationship graph | #424 のグラフに判定基準を適用する AI 評価スキル（判定コードは書かない）。淀み度集計＋4評価軸。依存: #424。SP 再見積もり対象 |
 
 ---
 


### PR DESCRIPTION
## Summary
- Dev tool シリーズの revise を Ideas.md に同期（(1/2)(2/2) → (1/3)(2/3)(3/3) の3部構成へ）
- Python AST 抽出ツールから JS フィールドアクセス抽出を分割し、新しい行を追加
- スメル評価を「機械判定ツール」から「AI 評価スキル」へ再スコープした内容を反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)