### PR TITLE
docs: sync issue #492 in Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,7 +19,7 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#492 | enhancement | 🔴 | 5 | Connect AgentDetailScreen to real game data with viewerMode support | AgentDetailScreen のスタブ固定を実データ接続に。同時に viewerMode 対応で public 時に役職・推論ログ等を秘匿。規模次第で実データ接続/viewerMode に分割可 |
+| yukkie/AgentVillage#492 | documentation | 🔴 | 2 | Design AgentDetailScreen real-data + viewerMode (stats schema, two-mode spec) | AgentDetailScreen の実データ化・viewerMode 対応の設計書更新（Spec/DataSpec/FrontendDesign）。game_stats.json スキーマ契約と global profile / game-scoped 2モード仕様を確定。実コードは仕分け Followup → 実装 Issue 群で別途 |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |


### PR DESCRIPTION
## Summary
- Issue #492 を revise（実データ接続＋viewerMode のコード実装 → 設計書更新メイン）したことに伴い、`doc/Ideas.md` の該当行を同期する。
- ラベル `enhancement`→`documentation`、SP `5`→`2`、タイトル・要約を新スコープに更新。

実体（Spec / DataSpec / FrontendDesign の更新）は #492 本体の作業で別途行う。本 PR は Ideas.md の1行同期のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)