### PR TITLE
docs: add issues #521-#524 to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,6 +19,10 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
+| yukkie/AgentVillage#521 ❌ | enhancement | — | — | Unify SpectatorScreen roster & AgentDetail picker into shared components | #515 §8.3 D 派生（先行）。feed カード（SpeechCard/WolfChatCard/SystemRow）と統一デザインのエージェント行（AgentRosterRow: アイコン左・名前/役職縦2行・statusDot）を components/ へ共通化。Spectator ロスター見た目が変わる。#523 が依存 |
+| yukkie/AgentVillage#522 ❌ | enhancement | — | — | Implement AgentDetailScreen global profile mode | #515 §8.3 A。/agent/:name を game_stats.json で実データ化（勝率・過去戦績・横断名簿リンク集）。役職/推論/夜行動/マトリクスは出さない |
+| yukkie/AgentVillage#523 ❌ | enhancement | — | — | Implement AgentDetailScreen game-scoped mode | #515 §8.3 B/D。/game/:sessionId/agent/:name を spectator_log+agents/*.json で実データ化。中央を日付タブ統合・疑念マトリクス・viewerMode 出し分け。依存: #521 |
+| yukkie/AgentVillage#524 ❌ | enhancement | — | — | Remove AgentDetailScreen stub-only UI and add viewerMode toggle | #515 §8.3 C。不要ボタン/並べ替え/応援/現在の目標/疑似時刻/疑い・信頼タブ/右ペイン夜行動を撤去し、game-scoped に viewerMode トグル追加 |
 | yukkie/AgentVillage#515 ❌ | documentation | 🔴 | — | Classify stub/agentDetail.js fields into 2-axis quadrants | #492 の Followup。stub/agentDetail.js 全項目を「遷移元（global profile / game-scoped）× 扱い（実データ置換 / 破棄）」の4象限に仕分け、FrontendDesign §8.3 に確定記載。実装 Issue 群の分割方針もここで決める |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |


### PR DESCRIPTION
## Summary
- `doc/Ideas.md` に #515 のスタブ仕分けから切り出した実装 Issue 4件を追記

## Background
#515（`doc/FrontendDesign.md` §8.3）の2軸4象限仕分けに基づく実装 Issue 群:
- #521 共通コンポーネント化（feed カード＋統一デザインのエージェント行。先行・#523 が依存）
- #522 global profile mode 実装
- #523 game-scoped mode 実装（#521 依存）
- #524 両モード共通の不要 UI 撤去＋viewerMode トグル追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)