### PR TITLE
feat: extract AgentRosterRow shared component & replace SpectatorScreen roster

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -483,6 +483,24 @@ hover / focus スタイルは CSS `:hover` / `:focus-visible` で付与（`varia
 
 `--r-color` CSS Variable を inline style で設定し、子要素が `var(--r-color)` を参照できる。
 
+#### `AgentRosterRow`
+
+ロスター（SpectatorScreen 右ペイン）と参加者ピッカー（AgentDetailScreen 左ペイン）で共有する「エージェント行」コンポーネント（#521）。レイアウトは AgentDetail picker 式（**アイコン左・名前/役職情報を縦2行で右・statusDot 右端**）、表示情報は SpectatorScreen 式（役職タグ・CO バッジ・死因メタ）を採用する。行全体を `Link` で包んで AgentDetail へ遷移する。
+
+特定 screen の state（`useParams` 等）に依存しない props ベースのコンポーネントとし、遷移先パスや役職表示可否は呼び出し側で計算して渡す。
+
+| prop | 型 | 説明 |
+|---|---|---|
+| `name` | `string` | エージェント名（必須）。Avatar の `alt` と1行目テキストに使う |
+| `role` | `string?` | 真の役職キー（例: `"Seer"`）。`showRole` が true のとき RoleTag・Avatar 役職刻印に使う |
+| `to` | `string` | 遷移先パス（`Link to`）。`agentDetailPath` 等は**呼び出し側で組み立てて渡す**（画面非依存にするため） |
+| `showRole` | `boolean?` | true で役職タグ・Avatar 役職刻印を表示。呼び出し側が `viewerMode === 'spectator'` を計算して渡す（デフォルト `false`） |
+| `coRole` | `string?` | CO 済み役職キー。あれば CO バッジを表示 |
+| `dead` | `boolean?` | 死亡フラグ。Avatar 死亡オーバーレイ・行 muted・statusDot 色（`--tx-4`）に反映 |
+| `deathMeta` | `{day, content}?` | 死因メタ（`Day {day} · {content}`）。役職を露出しないため public でも表示する |
+
+> **役職出し分けは `showRole` boolean に集約**: 「死亡者は役職常時公開」という特例は持たない。生存・死亡とも `showRole`（＝呼び出し側の `viewerMode === 'spectator'`）に従う。死亡者の役職を public で露出すると消去法で生存者の役職が絞れてしまうため（#521 AC-3）。
+
 #### `Icon`
 
 | prop | 型 | 説明 |
@@ -549,7 +567,7 @@ Semantic HTML: `GameCard` は自己完結したゲーム項目として `<articl
 | `SystemRow` | GM通知・処刑・夜フェーズ移行など非発言イベント |
 | `FeedItem` | `event_type` でルーティングして各カードに振り分ける |
 | `LeftPane` | フェーズナビ（日 × フェーズ、クリックで中央フィードを切り替え） + エージェント/役職/表示フィルタ |
-| `RightPane` | ロスター（生存/死亡）/ COボード / 夜の行動タイムライン |
+| `RightPane` | ロスター（生存/死亡、共通 `AgentRosterRow` を使用）/ COボード / 夜の行動タイムライン |
 
 #### viewerMode トグル（#314）
 
@@ -565,7 +583,7 @@ SpectatorScreen から AgentDetailScreen への遷移、および AgentDetailScr
 |---|---|---|
 | `SpeechCard` 役職タグ・Avatar 役職刻印 | 真の役職を表示 | 非表示 |
 | `ThoughtDetails` / `WolfChatCard` 思考ログ | `<details>` で展開可 | `🔒 思考ログ` ロックバッジ（クリック不可） |
-| `RightPane` 生存ロスター役職タグ・Avatar 役職刻印 | 真の役職を表示 | 非表示 |
+| `RightPane` ロスター（生存・**死亡とも**）役職タグ・Avatar 役職刻印 | 真の役職を表示 | 非表示（死亡者も伏せる。露出すると生存者の役職を絞れるため。死因メタは表示維持。#521） |
 | spectator 限定システムログ（`wolf_chat` / `inspection` / `guard` / `medium_result` および `is_public=false` のイベント） | 表示 | **完全非表示**（カード自体をマウントしない） |
 
 #### AgentDetailScreen の viewerMode 可視性（game-scoped mode）

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,7 +19,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#521 ❌ | enhancement | — | — | Unify SpectatorScreen roster & AgentDetail picker into shared components | #515 §8.3 D 派生（先行）。統一デザインのエージェント行（AgentRosterRow: アイコン左・名前/役職縦2行・statusDot）を components/ へ抽出し Spectator ロスターを置換。見た目が変わる。feed カード抽出は #526 に分割。#523 が依存 |
 | yukkie/AgentVillage#526 ❌ | enhancement | — | — | Extract SpectatorScreen feed cards into shared components | #521 から分割（案A）。feed カード（SpeechCard/WolfChatCard/SystemRow）と付随純粋関数・CSS を components/ へ昇格。表示・挙動は不変。#523（中央タイムライン）が依存 |
 | yukkie/AgentVillage#522 ❌ | enhancement | — | — | Implement AgentDetailScreen global profile mode | #515 §8.3 A。/agent/:name を game_stats.json で実データ化（勝率・過去戦績・横断名簿リンク集）。役職/推論/夜行動/マトリクスは出さない |
 | yukkie/AgentVillage#523 ❌ | enhancement | — | — | Implement AgentDetailScreen game-scoped mode | #515 §8.3 B/D。/game/:sessionId/agent/:name を spectator_log+agents/*.json で実データ化。中央を日付タブ統合・疑念マトリクス・viewerMode 出し分け。依存: #521, #526 |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,9 +19,10 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#521 ❌ | enhancement | — | — | Unify SpectatorScreen roster & AgentDetail picker into shared components | #515 §8.3 D 派生（先行）。feed カード（SpeechCard/WolfChatCard/SystemRow）と統一デザインのエージェント行（AgentRosterRow: アイコン左・名前/役職縦2行・statusDot）を components/ へ共通化。Spectator ロスター見た目が変わる。#523 が依存 |
+| yukkie/AgentVillage#521 ❌ | enhancement | — | — | Unify SpectatorScreen roster & AgentDetail picker into shared components | #515 §8.3 D 派生（先行）。統一デザインのエージェント行（AgentRosterRow: アイコン左・名前/役職縦2行・statusDot）を components/ へ抽出し Spectator ロスターを置換。見た目が変わる。feed カード抽出は #526 に分割。#523 が依存 |
+| yukkie/AgentVillage#526 ❌ | enhancement | — | — | Extract SpectatorScreen feed cards into shared components | #521 から分割（案A）。feed カード（SpeechCard/WolfChatCard/SystemRow）と付随純粋関数・CSS を components/ へ昇格。表示・挙動は不変。#523（中央タイムライン）が依存 |
 | yukkie/AgentVillage#522 ❌ | enhancement | — | — | Implement AgentDetailScreen global profile mode | #515 §8.3 A。/agent/:name を game_stats.json で実データ化（勝率・過去戦績・横断名簿リンク集）。役職/推論/夜行動/マトリクスは出さない |
-| yukkie/AgentVillage#523 ❌ | enhancement | — | — | Implement AgentDetailScreen game-scoped mode | #515 §8.3 B/D。/game/:sessionId/agent/:name を spectator_log+agents/*.json で実データ化。中央を日付タブ統合・疑念マトリクス・viewerMode 出し分け。依存: #521 |
+| yukkie/AgentVillage#523 ❌ | enhancement | — | — | Implement AgentDetailScreen game-scoped mode | #515 §8.3 B/D。/game/:sessionId/agent/:name を spectator_log+agents/*.json で実データ化。中央を日付タブ統合・疑念マトリクス・viewerMode 出し分け。依存: #521, #526 |
 | yukkie/AgentVillage#524 ❌ | enhancement | — | — | Remove AgentDetailScreen stub-only UI and add viewerMode toggle | #515 §8.3 C。不要ボタン/並べ替え/応援/現在の目標/疑似時刻/疑い・信頼タブ/右ペイン夜行動を撤去し、game-scoped に viewerMode トグル追加 |
 | yukkie/AgentVillage#519 ❌ | enhancement | — | — | Real-data blurb for AgentDetailScreen via config/agents.json | #515 の仕分け（§8.3 E 分割案5）から切り出し。AGENT_BLURB を config/agents.json の静的フィールド（まず英語）へ実データ化し、AgentDetailScreen 両モードで表示 |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |

--- a/frontend/src/components/AgentRosterRow.jsx
+++ b/frontend/src/components/AgentRosterRow.jsx
@@ -1,0 +1,39 @@
+import { Link } from 'react-router-dom';
+import Avatar from './Avatar.jsx';
+import RoleTag from './RoleTag.jsx';
+import { ROLES } from '../lib/constants.js';
+import styles from './AgentRosterRow.module.css';
+
+/**
+ * ロスター（SpectatorScreen 右ペイン）と参加者ピッカー（AgentDetailScreen 左ペイン）で
+ * 共有する統一エージェント行。レイアウトは AgentDetail picker 式（アイコン左・名前/役職を
+ * 縦2行で右・statusDot 右端）、表示情報は SpectatorScreen 式（役職タグ・CO バッジ・死因メタ）。
+ *
+ * 特定 screen の state（useParams 等）に依存しない props ベースのコンポーネント。
+ * 遷移先 `to` と役職表示可否 `showRole` は呼び出し側で計算して渡す。
+ */
+export default function AgentRosterRow({ name, role, to, showRole = false, coRole, dead = false, deathMeta }) {
+  const r = ROLES[role];
+  return (
+    <li className={`${styles.row} ${dead ? styles.dead : ''}`} style={{ '--r-color': r?.color }}>
+      <Link to={to} className={styles.link}>
+        <Avatar name={name} role={showRole ? role : undefined} size="sm" dead={dead} />
+        <div className={styles.who}>
+          <span className={styles.name}>{name}</span>
+          <span className={styles.meta}>
+            {showRole && <RoleTag role={role} />}
+            {coRole && (
+              <span className={styles.coBadge} style={{ '--co-color': ROLES[coRole]?.color }}>
+                ▶ {ROLES[coRole]?.ja || coRole} CO
+              </span>
+            )}
+            {deathMeta && (
+              <span className={styles.deathReason}>Day {deathMeta.day} · {deathMeta.content}</span>
+            )}
+          </span>
+        </div>
+        <span className={styles.statusDot} />
+      </Link>
+    </li>
+  );
+}

--- a/frontend/src/components/AgentRosterRow.module.css
+++ b/frontend/src/components/AgentRosterRow.module.css
@@ -1,0 +1,74 @@
+/* 統一エージェント行（#521）: アイコン左・名前/役職を縦2行で右・statusDot 右端 */
+.row {
+  list-style: none;
+  margin-bottom: 2px;
+}
+
+.link {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: var(--r1);
+  border: 1px solid transparent;
+  background: var(--bg-2);
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+}
+.link:hover { border-color: var(--bd); }
+.row.dead .link { opacity: 0.6; }
+
+.who {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.name {
+  font-family: var(--serif);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--tx);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.meta {
+  font-size: 10px;
+  color: var(--tx-3);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* CO バッジ（SpeechCard と同等スタイル。共通化は #526 で feed カード移動時に整理） */
+.coBadge {
+  font-family: var(--serif);
+  font-size: 10px;
+  background: color-mix(in oklab, var(--co-color, var(--acc)) 18%, transparent);
+  border: 1px solid color-mix(in oklab, var(--co-color, var(--acc)) 50%, transparent);
+  color: var(--co-color, var(--acc));
+  padding: 1px 5px;
+  border-radius: 2px;
+  letter-spacing: 0.04em;
+}
+
+.deathReason {
+  font-size: 11px;
+  color: var(--tx);
+  word-break: break-word;
+  min-width: 0;
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--alive);
+  align-self: center;
+}
+.row.dead .statusDot { background: var(--tx-4); }

--- a/frontend/src/components/AgentRosterRow.test.jsx
+++ b/frontend/src/components/AgentRosterRow.test.jsx
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AgentRosterRow from './AgentRosterRow.jsx';
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderRow(props = {}) {
+  return render(
+    <MemoryRouter>
+      <ul>
+        <AgentRosterRow name="Alice" to="/game/s1/agent/Alice" {...props} />
+      </ul>
+    </MemoryRouter>
+  );
+}
+
+describe('AgentRosterRow', () => {
+  it('統合: AgentRosterRow: name を表示し to へリンクする', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: name テキストを表示し、行全体が props.to の href を持つ Link としてレンダリングされることを検証する。
+     */
+    renderRow({ to: '/game/s1/agent/Alice' });
+
+    expect(screen.getByText('Alice')).toBeTruthy();
+    expect(screen.getByRole('link').getAttribute('href')).toBe('/game/s1/agent/Alice');
+  });
+
+  it('統合: AgentRosterRow: showRole=true で役職タグと Avatar 役職刻印を表示する', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: showRole=true のとき真役職（RoleTag・Avatar 役職刻印）が表示されることを検証する。
+     */
+    const { container } = renderRow({ role: 'Seer', showRole: true });
+
+    expect(screen.getAllByText('占い師').length).toBeGreaterThan(0);
+    expect(container.querySelector('[class*="roleTag"]')).toBeTruthy();
+  });
+
+  it('統合: AgentRosterRow: showRole=false で役職タグを表示しない', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: showRole=false のとき RoleTag・Avatar 役職刻印を一切表示しないことを検証する（public 役職リーク防止）。
+     */
+    const { container } = renderRow({ role: 'Seer', showRole: false });
+
+    expect(screen.queryByText('占い師')).toBeNull();
+    expect(container.querySelector('[class*="roleTag"]')).toBeNull();
+  });
+
+  it('統合: AgentRosterRow: coRole があれば CO バッジを表示する', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: coRole が渡されたとき CO 役職バッジ（▶ … CO）を表示することを検証する。
+     */
+    renderRow({ coRole: 'Seer' });
+
+    expect(screen.getByText(/▶.*占い師.*CO/)).toBeTruthy();
+  });
+
+  it('統合: AgentRosterRow: ROLES にない coRole は生キーを CO バッジに表示する', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: ROLES に未登録の coRole でも CO バッジを欠落させず生キー文字列を表示することを検証する（防御フォールバック）。
+     */
+    renderRow({ coRole: 'UnknownRole' });
+
+    expect(screen.getByText(/▶.*UnknownRole.*CO/)).toBeTruthy();
+  });
+
+  it('統合: AgentRosterRow: deathMeta があれば Day N · content を表示する', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: deathMeta が渡されたとき死因メタ（Day N · content）を表示することを検証する。
+     */
+    renderRow({ dead: true, deathMeta: { day: 1, content: 'Bob was executed.' } });
+
+    expect(screen.getByText(/Day 1 · Bob was executed\./)).toBeTruthy();
+  });
+
+  it('統合: AgentRosterRow: showRole=false でも deathMeta は表示する', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: public 相当（showRole=false）でも死因メタは役職を露出しないため表示維持されることを検証する（#521 AC-3 組み合わせ境界）。
+     */
+    const { container } = renderRow({
+      role: 'Werewolf',
+      showRole: false,
+      dead: true,
+      deathMeta: { day: 1, content: 'Werewolves attacked Bob.' },
+    });
+
+    expect(screen.getByText(/Day 1 · Werewolves attacked Bob\./)).toBeTruthy();
+    expect(screen.queryByText('人狼')).toBeNull();
+    expect(container.querySelector('[class*="roleTag"]')).toBeNull();
+  });
+
+  it('統合: AgentRosterRow: アイコン左・statusDot 右端の DOM 順で描画する', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: 行 Link 内が「アイコン（img を含む）→ … → statusDot」の順で並び、statusDot が右端要素であることを検証する。
+     */
+    const { container } = renderRow({ role: 'Seer', showRole: true });
+
+    const link = container.querySelector('a');
+    expect(link.firstElementChild.querySelector('img')).toBeTruthy();
+    expect(link.lastElementChild.className).toMatch(/statusDot/);
+  });
+});

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import Avatar, { AvatarButton } from '../components/Avatar.jsx';
 import RoleTag from '../components/RoleTag.jsx';
+import AgentRosterRow from '../components/AgentRosterRow.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
@@ -675,54 +676,33 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
       <section className={styles.rosterSection} aria-labelledby="roster-alive-heading">
         <h4 id="roster-alive-heading">生存 <span className={styles.count}>{alive.length}</span></h4>
         <ul className={styles.rosterList} aria-label="生存エージェント">
-          {alive.map(n => {
-            const role = roleAssignment[n];
-            const r = ROLES[role];
-            const coRole = coStatus[n];
-            return (
-              <li key={n} className={styles.rosterRow} style={{ '--r-color': r?.color }}>
-                <Link to={agentDetailPath(sessionId, n, viewerMode)} className={styles.agentLink}>
-                  <Avatar name={n} role={viewerMode === 'spectator' ? role : undefined} size="sm" label={n} layout="vertical" />
-                </Link>
-                <div className={styles.who}>
-                  <span className={styles.rosterName}>
-                    {viewerMode === 'spectator' && <RoleTag role={role} />}
-                    {coRole && (
-                      <span className={styles.coBadge} style={{ '--co-color': ROLES[coRole]?.color }}>▶ {ROLES[coRole]?.ja || coRole} CO</span>
-                    )}
-                  </span>
-                </div>
-              </li>
-            );
-          })}
+          {alive.map(n => (
+            <AgentRosterRow
+              key={n}
+              name={n}
+              role={roleAssignment[n]}
+              to={agentDetailPath(sessionId, n, viewerMode)}
+              showRole={viewerMode === 'spectator'}
+              coRole={coStatus[n]}
+            />
+          ))}
         </ul>
       </section>
 
       <section className={styles.rosterSection} aria-labelledby="roster-dead-heading">
         <h4 id="roster-dead-heading">死亡者 <span className={styles.count}>{deadNames.length}</span></h4>
         <ul className={styles.rosterList} aria-label="死亡者">
-          {deadNames.map(n => {
-            const role = roleAssignment[n];
-            const r = ROLES[role];
-            const meta = activeDead.get(n);
-            return (
-              <li key={n} className={`${styles.rosterRow} ${styles.dead}`} style={{ '--r-color': r?.color }}>
-                <Link to={agentDetailPath(sessionId, n, viewerMode)} className={styles.agentLink}>
-                  <Avatar name={n} role={role} size="sm" dead label={n} layout="vertical" />
-                </Link>
-                <div className={styles.whoMeta}>
-                  <div className={styles.whoBlock}>
-                    <span className={styles.sub}>
-                      <RoleTag role={role} />
-                    </span>
-                  </div>
-                  {meta && (
-                    <span className={styles.deathReason}>Day {meta.day} · {meta.content}</span>
-                  )}
-                </div>
-              </li>
-            );
-          })}
+          {deadNames.map(n => (
+            <AgentRosterRow
+              key={n}
+              name={n}
+              role={roleAssignment[n]}
+              to={agentDetailPath(sessionId, n, viewerMode)}
+              showRole={viewerMode === 'spectator'}
+              dead
+              deathMeta={activeDead.get(n)}
+            />
+          ))}
         </ul>
       </section>
     </div>

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -471,37 +471,7 @@
 }
 .rosterSection h4 .count { font-family: var(--mono); font-size: 10px; color: var(--tx-4); letter-spacing: 0; }
 
-.rosterRow {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 8px;
-  align-items: center;
-  padding: 3px 8px;
-  border-radius: var(--r1);
-  border: 1px solid transparent;
-  cursor: pointer;
-  background: var(--bg-2);
-  margin-bottom: 2px;
-}
-.rosterRow:hover { border-color: var(--bd); }
-.rosterRow :global([data-layout="vertical"]) { padding: 2px 4px 2px; }
-.rosterRow.dead  { opacity: 0.6; }
-.rosterRow .who  { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
-.rosterRow .who .name {
-  font-family: var(--serif);
-  font-size: 13px; font-weight: 600;
-  color: var(--tx);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  display: flex; align-items: center; gap: 4px;
-}
-.rosterRow .who .sub  { font-size: 10px; color: var(--tx-3); display: flex; gap: 6px; }
-.rosterRow .meter     { width: 64px; height: 22px; display: flex; flex-direction: column; gap: 2px; }
-.rosterRow .meter .bar { height: 4px; border-radius: 2px; background: var(--bg-3); overflow: hidden; }
-.rosterRow .meter .bar i { display: block; height: 100%; background: var(--danger); }
-.rosterRow .meter small {
-  font-size: 9px; color: var(--tx-4); font-family: var(--mono);
-  display: flex; justify-content: space-between;
-}
+/* roster rows are rendered by the shared AgentRosterRow component (#521) */
 
 /* CO board */
 .coBoard {
@@ -594,15 +564,6 @@
 .voteTo    { color: var(--tx); font-weight: 500; }
 
 /* roster inner */
-.who       { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
-.rosterName { font-family: var(--serif); font-size: 13px; font-weight: 600; color: var(--tx); display: flex; align-items: center; gap: 4px; }
-.sub       { font-size: 10px; color: var(--tx-3); display: flex; gap: 6px; }
-.whoMeta { display: flex; flex-direction: row; align-items: baseline; gap: 8px; min-width: 0; }
-.whoBlock { display: flex; flex-direction: column; gap: 1px; flex-shrink: 0; }
-.deathReason { font-size: 12px; color: var(--tx); word-break: break-word; flex: 1; min-width: 0; }
-.meter     { width: 64px; height: 22px; display: flex; flex-direction: column; gap: 2px; }
-.bar       { height: 4px; border-radius: 2px; background: var(--bg-3); overflow: hidden; }
-.bar i     { display: block; height: 100%; background: var(--danger); }
 .count     { font-family: var(--mono); font-size: 10px; color: var(--tx-4); letter-spacing: 0; }
 
 /* action inner */

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -805,7 +805,7 @@ describe('RightPane: role display in spectator mode', () => {
      * Mock: なし
      * Level: unit
      * Objective: publicモードで生存エージェントの真の役職タグが非表示になることを検証する（AC2 / #314）。
-     *            死亡者行（Bob）は常時役職公開のため対象外。
+     *            死亡者行は #521 AC-3 の別テストで検証する。
      */
     const { container } = renderRightPane({ viewerMode: 'public', coStatus: {} });
     // Find the alive section (first rosterSection) and check no roleTag inside it
@@ -827,6 +827,44 @@ describe('RightPane: role display in spectator mode', () => {
       coStatus: { Alice: 'Seer' },
     });
     expect(screen.getByText(/占い師.*CO|CO.*占い師|▶.*占い師/)).toBeTruthy();
+  });
+});
+
+describe('RightPane: dead role hidden in public mode (#521 AC-3)', () => {
+  it('hides dead agent role tag in public mode but keeps death reason', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: component
+     * Objective: 組み合わせ境界（死亡者行 × public モード）で真役職を非表示にしつつ、
+     *            役職を露出しない死因メタ（Day N · content）は表示維持されることを検証する（#521 AC-3）。
+     */
+    const { container } = renderRightPane({
+      viewerMode: 'public',
+      deadByDay: { 1: new Map([['Bob', { day: 1, content: 'Werewolves attacked Bob.' }]]) },
+      activeDay: 1,
+      coStatus: {},
+    });
+    const deadSection = container.querySelectorAll('[class*="rosterSection"]')[1];
+    expect(deadSection.querySelectorAll('[class*="roleTag"]').length).toBe(0);
+    expect(screen.getByText(/Day 1 · Werewolves attacked Bob\./)).toBeTruthy();
+  });
+
+  it('shows dead agent role tag in spectator mode', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: component
+     * Objective: spectator モードでは死亡者行に真役職タグが表示されることを検証する（AC-3 の対となる正常系）。
+     */
+    const { container } = renderRightPane({
+      viewerMode: 'spectator',
+      deadByDay: { 1: new Map([['Bob', { day: 1, content: 'Werewolves attacked Bob.' }]]) },
+      activeDay: 1,
+      coStatus: {},
+    });
+    const deadSection = container.querySelectorAll('[class*="rosterSection"]')[1];
+    expect(deadSection.querySelectorAll('[class*="roleTag"]').length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- `AgentRosterRow`（アイコン左・名前/役職を縦2行で右・statusDot 右端）を `src/components/` に新設。`Link`/`role`/`showRole`/`coRole`/`dead`/`deathMeta` を props で受け、特定 screen の state（`useParams` 等）に依存しない。
- SpectatorScreen 右ペインの生存/死亡ロスター行を `AgentRosterRow` に置換。**見た目が統一デザインに変わる（意図的）**が、表示情報（役職・CO・死因メタ・viewerMode 出し分け）は維持。
- 孤立した roster CSS（`.rosterRow` 系・`.who`/`.whoMeta` 等）を `SpectatorScreen.module.css` から除去。
- `doc/FrontendDesign.md` を更新（§6.1 `AgentRosterRow`、§6.2 viewerMode 表）。

## Implementation notes
- **挙動変更（バグ修正・AC-3）**: 従来は死亡者の真役職を viewerMode に関わらず常時公開していたが、これは消去法で生存者の役職を絞れてしまうバグ。生存・死亡とも `showRole = viewerMode === 'spectator'` に統一し、**public モードでは死亡者の役職も伏せる**。役職を露出しない死因メタ（`Day N · content`）は public でも表示維持。
- HTML 要素: ロスター行 Avatar が `label layout="vertical"`（アイコン上・名前下）から `label` なし icon + 別テキストに変更。`alt={name}` の accessible name は維持。行の `<Link>` 化は従来どおり。
- `.coBadge` 相当スタイルは `AgentRosterRow.module.css` に複製（SpeechCard との共通化は #526 で feed カード移動時に整理）。
- スコープ分割（案A）: feed カード（`SpeechCard`/`WolfChatCard`/`SystemRow`）の `components/` 昇格は #526 に分離。

## Test plan
- [x] `pytest` パス（Python 変更なし・pre-commit で実行）
- [x] `npm test` パス（255 tests）
- [x] AgentRosterRow contract テスト（name/Link・役職出し分け・CO バッジ・死因メタ・DOM 順）
- [x] AC-3 組み合わせ境界テスト（死亡者 × public で役職非表示・死因メタ維持）
- [x] Playwright 目視（spectator/public 両モードのロスター。public で生存・死亡とも役職非表示を確認）
- 注: frontend は ESLint 未設定のため lint ゲートなし

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)