### PR TITLE
feat: AgentDetailScreen global profile mode (real data) #522

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -498,6 +498,8 @@ hover / focus スタイルは CSS `:hover` / `:focus-visible` で付与（`varia
 | `coRole` | `string?` | CO 済み役職キー。あれば CO バッジを表示 |
 | `dead` | `boolean?` | 死亡フラグ。Avatar 死亡オーバーレイ・行 muted・statusDot 色（`--tx-4`）に反映 |
 | `deathMeta` | `{day, content}?` | 死因メタ（`Day {day} · {content}`）。役職を露出しないため public でも表示する |
+| `showStatusDot` | `boolean?` | 右端の生死 statusDot を表示するか（デフォルト `true`）。`false` で statusDot を描画せずグリッドを2カラム化する。生死概念のない `global profile mode` 左ペインで `false` を渡す |
+| `selected` | `boolean?` | 現在表示中の行を強調（左ボーダー `--acc` ＋ 背景）。`global profile mode` 左ペインで「今表示しているエージェント」をハイライトするのに使う（デフォルト `false`） |
 
 > **役職出し分けは `showRole` boolean に集約**: 「死亡者は役職常時公開」という特例は持たない。生存・死亡とも `showRole`（＝呼び出し側の `viewerMode === 'spectator'`）に従う。死亡者の役職を public で露出すると消去法で生存者の役職が絞れてしまうため（#521 AC-3）。
 
@@ -810,6 +812,15 @@ fetch('../state_archive/20260510_102927/spectator_log.jsonl')
 
 FastAPI + WebSocket でイベントをストリーミング配信する。`fetch` を WebSocket に切り替えるだけで対応できるよう、`SpectatorScreen` の props インターフェースは Phase A で統一しておく。
 
+**Phase D — global profile mode の実データ化（#522）**
+
+`AgentDetailScreen` の `global profile mode`（`/agent/:name`）を `state/stats/game_stats.json` 由来の横断戦績に差し替える（仕分けは §8.3 A）。
+
+- `src/lib/archiveLoader.js` に `fetchGameStats()` / `parseGameStats(gamesJson, agentName)` / `parseAllAgentNames(gamesJson)` を追加。`won` をそのまま使い、`winner` / `faction` の値域変換は consumer 側で再実装しない（`doc/DataSpec.md` §6）。
+- **dev 配信経路**: `game_stats.json` は `state/stats/` 配下にあり既存の `/state_archive` middleware では配信されない。`vite.config.js` に `/stats` プレフィックスの静的配信 middleware を追加し（`/state_archive` と同形）、fetch URL を `/stats/game_stats.json` とする。#315 FastAPI 導入時は URL 差し替えのみで対応する。
+- **非同期状態の扱い**: global mode は `fetchGameStats()` 前提のため非同期状態が発生する。fetch 中は loading 表示、失敗時は error 表示にする。`agentName` が `game_stats.json` に存在しない場合も、名前・アバターは表示し、勝率・通算成績は `0戦 / 0勝`、過去戦績一覧は空表示にフォールバックする。
+- viewerMode による出し分けは行わない（§6.2）。`?view=public` でも表示内容は変わらず、viewerMode トグル UI も出さない。
+
 ### 8.3 `AgentDetailScreen` スタブ項目の2軸4象限仕分け（#515）
 
 `stub/agentDetail.js` の全エクスポート項目と `AgentDetailScreen.jsx` 内ハードコードを、
@@ -829,8 +840,8 @@ FastAPI + WebSocket でイベントをストリーミング配信する。`fetch
 | 名前 ＋ アバター | ✅ | `game_stats.json` の `players[].name` / アイコンは `/icons/{name}.png` |
 | blurb（1行プロフィール、`AGENT_BLURB`） | ✅（別 Issue・重い） | `config/agents.json` に静的な新フィールド（例: `blurb`）を追加して fetch。両モード共通。実装は別 Issue（`persona_short` は未実装のため使わない） |
 | 勝率・通算成績（`AGENT_STATS` の `games` / `wins`） | ✅ | `game_stats.json` の各 `game.players[]` を `name` でフィルタし `won` / 出場数を集計（`doc/DataSpec.md` §6） |
-| 過去の戦績一覧（`TabHistory` の `records`） | ✅ | `game_stats.json` 各 `game` を `name` でフィルタ（`game_id` / `role` / `won`）。**村名列は `game_stats.json` に無いため `session_id`（`game_id`）を代わりに表示する** |
-| 左ペイン名簿（`ALL_AGENTS` / `DEAD_AGENTS`） | ✅（別物に差し替え） | `global` では「同ゲームの参加者ピッカー」は概念として存在しない。代わりに**全エージェント横断のプロフィール一覧リンク集**にする（`game_stats.json` の全 `name` 集合 → 各行 `/agent/{name}`） |
+| 過去の戦績一覧（`TabHistory` の `records`） | ✅ | `game_stats.json` 各 `game` を `name` でフィルタ（`game_id` / `role` / `won`）。**村名列は `game_stats.json` に無いため `session_id`（`game_id`）を代わりに表示する**。過去戦績テーブルの `role` 列は表示してよい（Hero / Avatar / 左ペインの役職タグ・役職刻印を出さない方針とは別物） |
+| 左ペイン名簿（`ALL_AGENTS` / `DEAD_AGENTS`） | ✅（別物に差し替え） | `global` では「同ゲームの参加者ピッカー」は概念として存在しない。代わりに**全エージェント横断のプロフィール一覧リンク集**にする（`game_stats.json` の全 `name` 集合 → 各行 `/agent/{encodeURIComponent(name)}`）。共通 `AgentRosterRow` を `showRole={false}`（役職を出さない・AC-4）・`showStatusDot={false}`（生死概念なし）・`selected={name === current}`（現在地ハイライト）で再利用する。行全体が `Link` のためクリック領域が行全域になる（独自 `display: contents` 行だと padding/gap が hit しない問題を回避） |
 
 #### B. `game-scoped mode` の項目（出所＝`spectator_log.jsonl` ＋ `agents/*.json`）
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,7 +19,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#522 ❌ | enhancement | — | — | Implement AgentDetailScreen global profile mode | #515 §8.3 A。/agent/:name を game_stats.json で実データ化（勝率・過去戦績・横断名簿リンク集）。役職/推論/夜行動/マトリクスは出さない |
 | yukkie/AgentVillage#523 ❌ | enhancement | — | — | Implement AgentDetailScreen game-scoped mode | #515 §8.3 B/D。/game/:sessionId/agent/:name を spectator_log+agents/*.json で実データ化。中央を日付タブ統合・疑念マトリクス・viewerMode 出し分け。依存: #521, #526 |
 | yukkie/AgentVillage#524 ❌ | enhancement | — | — | Remove AgentDetailScreen stub-only UI and add viewerMode toggle | #515 §8.3 C。不要ボタン/並べ替え/応援/現在の目標/疑似時刻/疑い・信頼タブ/右ペイン夜行動を撤去し、game-scoped に viewerMode トグル追加 |
 | yukkie/AgentVillage#519 ❌ | enhancement | — | — | Real-data blurb for AgentDetailScreen via config/agents.json | #515 の仕分け（§8.3 E 分割案5）から切り出し。AGENT_BLURB を config/agents.json の静的フィールド（まず英語）へ実データ化し、AgentDetailScreen 両モードで表示 |

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -5,9 +5,13 @@ import App from './App.jsx';
 import * as archiveLoader from './lib/archiveLoader.js';
 import * as replayLoader from './lib/replayLoader.js';
 
-vi.mock('./lib/archiveLoader.js', () => ({
+vi.mock('./lib/archiveLoader.js', async (importOriginal) => ({
+  // Keep the real pure functions (parseGameStats / parseAllAgentNames etc.),
+  // mock only the fetch-boundary functions.
+  ...(await importOriginal()),
   fetchGameList: vi.fn().mockResolvedValue([]),
   fetchGameBySessionId: vi.fn(),
+  fetchGameStats: vi.fn().mockResolvedValue({ games: [] }),
 }));
 
 vi.mock('./lib/replayLoader.js', () => ({

--- a/frontend/src/components/AgentRosterRow.jsx
+++ b/frontend/src/components/AgentRosterRow.jsx
@@ -12,10 +12,10 @@ import styles from './AgentRosterRow.module.css';
  * 特定 screen の state（useParams 等）に依存しない props ベースのコンポーネント。
  * 遷移先 `to` と役職表示可否 `showRole` は呼び出し側で計算して渡す。
  */
-export default function AgentRosterRow({ name, role, to, showRole = false, coRole, dead = false, deathMeta }) {
+export default function AgentRosterRow({ name, role, to, showRole = false, coRole, dead = false, deathMeta, showStatusDot = true, selected = false }) {
   const r = ROLES[role];
   return (
-    <li className={`${styles.row} ${dead ? styles.dead : ''}`} style={{ '--r-color': r?.color }}>
+    <li className={`${styles.row} ${dead ? styles.dead : ''} ${showStatusDot ? '' : styles.noDot} ${selected ? styles.selected : ''}`} style={{ '--r-color': r?.color }}>
       <Link to={to} className={styles.link}>
         <Avatar name={name} role={showRole ? role : undefined} size="sm" dead={dead} />
         <div className={styles.who}>
@@ -32,7 +32,7 @@ export default function AgentRosterRow({ name, role, to, showRole = false, coRol
             )}
           </span>
         </div>
-        <span className={styles.statusDot} />
+        {showStatusDot && <span className={styles.statusDot} />}
       </Link>
     </li>
   );

--- a/frontend/src/components/AgentRosterRow.module.css
+++ b/frontend/src/components/AgentRosterRow.module.css
@@ -20,6 +20,15 @@
 .link:hover { border-color: var(--bd); }
 .row.dead .link { opacity: 0.6; }
 
+/* statusDot を出さない場合（global profile mode 等）は 2 カラムにして右端の余白を作らない */
+.row.noDot .link { grid-template-columns: auto 1fr; }
+
+/* 現在表示中のエージェント行を強調（左ボーダー山吹色＋背景） */
+.row.selected .link {
+  border-left: 2px solid var(--acc);
+  background: var(--bg-3);
+}
+
 .who {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/AgentRosterRow.test.jsx
+++ b/frontend/src/components/AgentRosterRow.test.jsx
@@ -112,6 +112,42 @@ describe('AgentRosterRow', () => {
     expect(container.querySelector('[class*="roleTag"]')).toBeNull();
   });
 
+  it('統合: AgentRosterRow: selected=true で選択状態クラスを付与する', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: selected=true のとき行に選択状態クラス（selected）が付与されることを検証する（現在地ハイライト）。
+     */
+    const { container } = renderRow({ selected: true });
+
+    expect(container.querySelector('[class*="selected"]')).toBeTruthy();
+  });
+
+  it('統合: AgentRosterRow: selected 未指定では選択状態クラスを付与しない', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: selected を渡さないとき選択状態クラスが付与されないことを検証する（デフォルト非選択）。
+     */
+    const { container } = renderRow();
+
+    expect(container.querySelector('[class*="selected"]')).toBeNull();
+  });
+
+  it('統合: AgentRosterRow: showStatusDot=false で statusDot を描画しない', () => {
+    /*
+     * SUT: AgentRosterRow
+     * Mock: なし（plain props を入力）
+     * Level: component
+     * Objective: showStatusDot=false のとき statusDot 要素を一切描画しないことを検証する（global profile mode 用）。
+     */
+    const { container } = renderRow({ showStatusDot: false });
+
+    expect(container.querySelector('[class*="statusDot"]')).toBeNull();
+  });
+
   it('統合: AgentRosterRow: アイコン左・statusDot 右端の DOM 順で描画する', () => {
     /*
      * SUT: AgentRosterRow

--- a/frontend/src/lib/archiveLoader.js
+++ b/frontend/src/lib/archiveLoader.js
@@ -72,6 +72,63 @@ export async function fetchGameList() {
   return parseIndexToGameList(index);
 }
 
+// --- Game stats (#522 global profile mode) ---
+
+// game_stats.json lives at state/stats/, served by the /stats middleware in
+// vite.config.js (local dev only). Replace with a FastAPI endpoint in production (#315).
+const GAME_STATS_URL = '/stats/game_stats.json';
+
+/**
+ * Aggregate a single agent's cross-game record from game_stats.json (DataSpec §6).
+ * `won` is read as-is; no winner/faction value conversion (already done by collector).
+ *
+ * @param {{games: object[]}} gamesJson - Parsed game_stats.json
+ * @param {string} agentName
+ * @returns {{wins: number, total: number, records: {gameId: string, role: string, won: boolean}[]}}
+ *   records are ordered newest-game-first. Empty for an unknown agentName.
+ */
+export function parseGameStats(gamesJson, agentName) {
+  const records = [];
+  let wins = 0;
+  let total = 0;
+  for (const game of gamesJson.games) {
+    const player = game.players.find(p => p.name === agentName);
+    if (!player) continue;
+    total += 1;
+    if (player.won) wins += 1;
+    records.push({ gameId: game.game_id, role: player.role, won: player.won });
+  }
+  // Newest game first (games[] is appended in chronological order by collector).
+  records.reverse();
+  return { wins, total, records };
+}
+
+/**
+ * Collect the unique set of all agent names across every game, sorted.
+ * Used by the global-mode left pane's cross-agent profile link list (AC-3).
+ *
+ * @param {{games: object[]}} gamesJson - Parsed game_stats.json
+ * @returns {string[]}
+ */
+export function parseAllAgentNames(gamesJson) {
+  const names = new Set();
+  for (const game of gamesJson.games) {
+    for (const player of game.players) names.add(player.name);
+  }
+  return [...names].sort();
+}
+
+/**
+ * Fetch and parse game_stats.json. Throws if the fetch fails.
+ *
+ * @returns {Promise<{games: object[]}>}
+ */
+export async function fetchGameStats() {
+  const res = await fetch(GAME_STATS_URL);
+  if (!res.ok) throw new Error(`Failed to fetch game stats: ${res.status}`);
+  return res.json();
+}
+
 /**
  * Fetch a single game entry by sessionId from state_archive/index.json.
  * Returns the raw index entry (including cast) for use by SpectatorScreen.

--- a/frontend/src/lib/archiveLoader.test.js
+++ b/frontend/src/lib/archiveLoader.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { parseIndexToGameList, parseEntryToGame, fetchGameBySessionId } from './archiveLoader.js';
+import {
+  parseIndexToGameList, parseEntryToGame, fetchGameBySessionId,
+  parseGameStats, parseAllAgentNames, fetchGameStats,
+} from './archiveLoader.js';
 import { normalizeAgentJson } from '../legacy/normalizeAgentJson.js';
 
 // --- fixture data ---
@@ -171,6 +174,123 @@ describe('fetchGameBySessionId', () => {
     }));
 
     await expect(fetchGameBySessionId('not-exist')).rejects.toThrow('Session not found: not-exist');
+  });
+});
+
+// --- parseGameStats / parseAllAgentNames（#522 global profile mode） ---
+
+const STATS_FIXTURE = {
+  games: [
+    {
+      game_id: '2026-05-09T18:10:31',
+      winner: 'Villagers',
+      players: [
+        { name: 'Nox', role: 'Seer', faction: 'village', model: 'm', survived: true, won: true },
+        { name: 'Kai', role: 'Werewolf', faction: 'werewolf', model: 'm', survived: false, won: false },
+        { name: 'Mira', role: 'Villager', faction: 'village', model: 'm', survived: true, won: true },
+      ],
+    },
+    {
+      game_id: '2026-05-10T10:29:27',
+      winner: 'Werewolves',
+      players: [
+        { name: 'Nox', role: 'Villager', faction: 'village', model: 'm', survived: false, won: false },
+        { name: 'Kai', role: 'Werewolf', faction: 'werewolf', model: 'm', survived: true, won: true },
+      ],
+    },
+  ],
+};
+
+describe('parseGameStats', () => {
+  it('勝利数・出場数を name でフィルタして集計する', () => {
+    /*
+    SUT: parseGameStats
+    Mock: なし
+    Level: unit
+    Objective: agentName で全ゲームをフィルタし wins/total が正しく集計されることを検証する (AC-1)
+    */
+    const stats = parseGameStats(STATS_FIXTURE, 'Nox');
+    expect(stats.total).toBe(2);
+    expect(stats.wins).toBe(1);
+  });
+
+  it('過去戦績一覧は gameId と role と won を含む', () => {
+    /*
+    SUT: parseGameStats
+    Mock: なし
+    Level: unit
+    Objective: records が game_id(=session_id) / role / won を含み、ゲーム降順であることを検証する (AC-2)
+    */
+    const stats = parseGameStats(STATS_FIXTURE, 'Nox');
+    expect(stats.records).toEqual([
+      { gameId: '2026-05-10T10:29:27', role: 'Villager', won: false },
+      { gameId: '2026-05-09T18:10:31', role: 'Seer', won: true },
+    ]);
+  });
+
+  it('存在しない agent は wins:0 total:0 records:[] を返す', () => {
+    /*
+    SUT: parseGameStats
+    Mock: なし
+    Level: unit
+    Objective: game_stats.json に存在しない名前で空集計を返すことを検証する (AC-7 empty state)
+    */
+    const stats = parseGameStats(STATS_FIXTURE, 'Unknown');
+    expect(stats).toEqual({ wins: 0, total: 0, records: [] });
+  });
+});
+
+describe('fetchGameStats', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns parsed game_stats.json on success', async () => {
+    /*
+    SUT: fetchGameStats
+    Mock: global fetch（game_stats.json のレスポンスを固定）
+    Level: unit
+    Objective: fetch 成功時に game_stats.json をパースして返すことを検証する。
+    */
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(STATS_FIXTURE),
+    }));
+    const result = await fetchGameStats();
+    expect(result).toBe(STATS_FIXTURE);
+  });
+
+  it('throws when fetch fails', async () => {
+    /*
+    SUT: fetchGameStats
+    Mock: global fetch（ok:false）
+    Level: unit
+    Objective: fetch 失敗時に Error をスローすることを検証する (AC-7 error path)。
+    */
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    await expect(fetchGameStats()).rejects.toThrow('Failed to fetch game stats: 500');
+  });
+});
+
+describe('parseAllAgentNames', () => {
+  it('全ゲームの参加エージェント名のユニーク集合を返す', () => {
+    /*
+    SUT: parseAllAgentNames
+    Mock: なし
+    Level: unit
+    Objective: 全 game.players[].name を重複排除しソートして返すことを検証する (AC-3)
+    */
+    expect(parseAllAgentNames(STATS_FIXTURE)).toEqual(['Kai', 'Mira', 'Nox']);
+  });
+
+  it('空の games には空配列を返す', () => {
+    /*
+    SUT: parseAllAgentNames
+    Mock: なし
+    Level: unit
+    Objective: games が空のとき空配列を返すことを検証する
+    */
+    expect(parseAllAgentNames({ games: [] })).toEqual([]);
   });
 });
 

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, Link, useSearchParams } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
+import AgentRosterRow from '../components/AgentRosterRow.jsx';
 import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
+import { fetchGameStats, parseGameStats, parseAllAgentNames } from '../lib/archiveLoader.js';
 import {
   ALL_AGENTS, DEAD_AGENTS, ROLE_ASSIGNMENT,
   AGENT_BLURB, AGENT_STATS, THOUGHTS, NIGHT_ACTIONS,
@@ -313,6 +315,135 @@ function RightPane({ agent }) {
   );
 }
 
+// ============================================================================
+// global profile mode（#522）— 出所は state/stats/game_stats.json（DataSpec §6）
+// 横断戦績のみを表示する。役職タグ・推論・夜行動・疑念マトリクス・session ラベル・
+// 生死は出さない（AC-4）。viewerMode による出し分けも行わない（AC-5）。
+// ============================================================================
+
+// --- global 左ペイン: 全エージェント横断プロフィール一覧リンク集（AC-3） ---
+function GlobalLeftPane({ allNames, current }) {
+  return (
+    <>
+      <div className={styles.pickerHead}>
+        <span className={styles.pickerTitle}>エージェント一覧</span>
+        <span className={styles.pickerCount}>全{allNames.length}名</span>
+      </div>
+      <div className={styles.agentPicker}>
+        <ul className={styles.pickerList} aria-label="エージェント一覧">
+          {allNames.map(n => (
+            <AgentRosterRow
+              key={n}
+              name={n}
+              to={`/agent/${encodeURIComponent(n)}`}
+              showRole={false}
+              showStatusDot={false}
+              selected={n === current}
+            />
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}
+
+// --- global ヒーロー: 名前・アバター・勝率・通算成績（AC-1 / AC-6） ---
+// 役職タグ・生死・session ラベルは出さない（AC-4）。
+function GlobalHero({ agent, stats }) {
+  const winPct = stats.total ? Math.round(stats.wins / stats.total * 100) : 0;
+
+  return (
+    <header className={styles.agentHero}>
+      <Avatar name={agent} highlight />
+      <div className={styles.heroInfo}>
+        <h1>{agent}</h1>
+        <div className={styles.heroSub}>
+          <span>通算 {stats.total} 戦 {stats.wins} 勝</span>
+        </div>
+      </div>
+      <div className={styles.heroStats}>
+        <div className={styles.heroStat}>
+          <div className={styles.statNum}>{winPct}%</div>
+          <div className={styles.statLabel}>勝率 ({stats.total}戦)</div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// --- global 過去戦績一覧（AC-2）。村名列が無いため game_id を session_id として表示 ---
+// role 列は表示する（AC-2 で許可。AC-4 が禁じる Hero/Avatar/左ペインの役職タグとは別物）。
+function GlobalHistory({ stats }) {
+  return (
+    <div className={styles.panel}>
+      <h3>過去の戦績 <small>通算 {stats.total} 戦 {stats.wins} 勝</small></h3>
+      {stats.records.length === 0 ? (
+        <div style={{ color: 'var(--tx-4)', fontSize: 13 }}>戦績なし</div>
+      ) : (
+        <ul className={styles.recordList} aria-label="過去の戦績">
+          {stats.records.map((rec, i) => {
+            const r = ROLES[rec.role];
+            return (
+              <li key={i} className={styles.recordRow} style={{ '--r-color': r?.color }}>
+                <span className={styles.recordNum}>{rec.gameId}</span>
+                <span className={styles.recordRole}>{r?.ja || rec.role}</span>
+                <span className={`${styles.recordResult} ${rec.won ? styles.win : styles.lose}`}>
+                  {rec.won ? '勝利' : '敗北'}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// --- global profile mode 本体（非同期 fetch・loading/error/empty を扱う・AC-7） ---
+function GlobalProfile({ agent }) {
+  const [state, setState] = useState({ status: 'loading', games: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchGameStats()
+      .then(games => { if (!cancelled) setState({ status: 'ready', games }); })
+      .catch(() => { if (!cancelled) setState({ status: 'error', games: null }); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const topCrumbs = [{ label: 'r/agent-jinrou', to: '/' }, { label: agent }];
+
+  let body;
+  if (state.status === 'loading') {
+    body = <div className={styles.tabContent} style={{ color: 'var(--tx-4)' }}>読み込み中…</div>;
+  } else if (state.status === 'error') {
+    body = <div className={styles.tabContent} style={{ color: 'var(--danger)' }}>戦績を読み込めませんでした。</div>;
+  } else {
+    const stats = parseGameStats(state.games, agent);
+    const allNames = parseAllAgentNames(state.games);
+    body = (
+      <ThreePaneLayout
+        collapsibleLeft
+        left={<GlobalLeftPane allNames={allNames} current={agent} />}
+      >
+        <div className={styles.mainPane}>
+          <GlobalHero agent={agent} stats={stats} />
+          <div className={styles.tabContent}>
+            <GlobalHistory stats={stats} />
+          </div>
+        </div>
+      </ThreePaneLayout>
+    );
+  }
+
+  return (
+    <div className={styles.frame}>
+      <TopBar crumbs={topCrumbs} />
+      {body}
+    </div>
+  );
+}
+
 // === メイン画面 ===
 export default function AgentDetailScreen() {
   const { sessionId, agentName } = useParams();
@@ -322,6 +453,12 @@ export default function AgentDetailScreen() {
   const agent = agentName || 'Nox';
   const [tab, setTab] = useState(0);
 
+  // sessionId なし → global profile mode（横断戦績・実データ）
+  if (!sessionId) {
+    return <GlobalProfile agent={agent} />;
+  }
+
+  // sessionId あり → game-scoped mode（現状はスタブ。実データ化は別 Issue）
   const role = ROLE_ASSIGNMENT[agent];
   const r    = ROLES[role];
 
@@ -333,9 +470,11 @@ export default function AgentDetailScreen() {
     <TabHistory      agent={agent} />,
   ];
 
-  const topCrumbs = sessionId
-    ? [{ label: 'r/agent-jinrou', to: '/' }, { label: sessionId, to: `/game/${sessionId}${viewerSearch}` }, { label: agent }]
-    : [{ label: 'r/agent-jinrou', to: '/' }, { label: agent }];
+  const topCrumbs = [
+    { label: 'r/agent-jinrou', to: '/' },
+    { label: sessionId, to: `/game/${sessionId}${viewerSearch}` },
+    { label: agent },
+  ];
 
   return (
     <div className={styles.frame}>

--- a/frontend/src/screens/AgentDetailScreen.module.css
+++ b/frontend/src/screens/AgentDetailScreen.module.css
@@ -371,7 +371,8 @@
 }
 
 .recordRow:last-child { border-bottom: none; }
-.recordNum   { font-family: var(--mono); color: var(--tx-4); width: 28px; }
+/* game_id（ISO 文字列）を表示する列。折り返さず収める（global・game-scoped 実データ共通） */
+.recordNum   { font-family: var(--mono); color: var(--tx-4); font-size: 11px; white-space: nowrap; }
 .recordRole  { font-family: var(--serif); color: var(--r-color, var(--tx-3)); width: 60px; }
 .recordResult { font-family: var(--mono); font-size: 11px; }
 .win  { color: var(--alive); }

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -1,62 +1,65 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import userEvent from '@testing-library/user-event';
 import AgentDetailScreen from './AgentDetailScreen.jsx';
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
-function renderAgent({ sessionId, agentName = 'Nox', search = '' } = {}) {
-  const path = sessionId
-    ? `/game/${sessionId}/agent/${agentName}${search}`
-    : `/agent/${agentName}${search}`;
-  const routePath = sessionId
-    ? '/game/:sessionId/agent/:agentName'
-    : '/agent/:agentName';
+// --- fixture: game_stats.json 形状（DataSpec §6） ---
+const STATS_FIXTURE = {
+  games: [
+    {
+      game_id: '2026-05-09T18:10:31',
+      winner: 'Villagers',
+      players: [
+        { name: 'Nox', role: 'Seer', faction: 'village', model: 'm', survived: true, won: true },
+        { name: 'Kai', role: 'Werewolf', faction: 'werewolf', model: 'm', survived: false, won: false },
+      ],
+    },
+    {
+      game_id: '2026-05-10T10:29:27',
+      winner: 'Werewolves',
+      players: [
+        { name: 'Nox', role: 'Villager', faction: 'village', model: 'm', survived: false, won: false },
+        { name: 'Kai', role: 'Werewolf', faction: 'werewolf', model: 'm', survived: true, won: true },
+      ],
+    },
+  ],
+};
+
+function mockFetchOk(data) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  }));
+}
+
+function renderGameScoped({ sessionId = 'test-session-001', agentName = 'Nox', search = '' } = {}) {
   return render(
-    <MemoryRouter initialEntries={[path]}>
+    <MemoryRouter initialEntries={[`/game/${sessionId}/agent/${agentName}${search}`]}>
       <Routes>
-        <Route path={routePath} element={<AgentDetailScreen />} />
+        <Route path="/game/:sessionId/agent/:agentName" element={<AgentDetailScreen />} />
       </Routes>
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 }
 
-describe('AgentDetailScreen semantic structure', () => {
-  it('exposes the agent hero as a banner-like header and picker as a list', () => {
-    /*
-     * SUT: AgentDetailScreen / AgentHero / LeftPane
-     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
-     * Level: component
-     * Objective: AgentHero が header、AgentPicker が list/listitem role で特定できることを検証する。
-     */
-    renderAgent();
+function renderGlobal(url) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/agent/:agentName" element={<AgentDetailScreen />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
 
-    expect(document.querySelector('header')?.textContent).toContain('Nox');
-    expect(within(screen.getByRole('list', { name: 'エージェント一覧' })).getAllByRole('listitem').length).toBeGreaterThan(0);
-  });
+// --- game-scoped mode（スタブ非依存の配線テスト。実データ化は別 Issue） ---
 
-  it('exposes overview thoughts, suspicion matrix, night actions, and history as semantic lists', async () => {
-    /*
-     * SUT: AgentDetailScreen tab panels
-     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
-     * Level: component
-     * Objective: 推論ログ・疑い度マトリクス・夜行動・過去戦績が list/listitem role で特定できることを検証する。
-     */
-    const user = userEvent.setup();
-    renderAgent();
-
-    expect(within(screen.getByRole('list', { name: '直近の推論' })).getAllByRole('listitem').length).toBeGreaterThan(0);
-    expect(within(screen.getByRole('list', { name: '疑い度マトリクス' })).getAllByRole('listitem')).toHaveLength(8);
-    expect(within(screen.getByRole('list', { name: '夜の行動' })).getAllByRole('listitem').length).toBeGreaterThan(0);
-
-    await user.click(screen.getByRole('button', { name: '過去の戦績' }));
-
-    expect(within(screen.getByRole('list', { name: '過去の戦績' })).getAllByRole('listitem')).toHaveLength(5);
-  });
-
+describe('AgentDetailScreen game-scoped breadcrumbs', () => {
   it('renders game-scoped breadcrumbs when sessionId is present', () => {
     /*
      * SUT: AgentDetailScreen TopBar crumbs
@@ -64,7 +67,7 @@ describe('AgentDetailScreen semantic structure', () => {
      * Level: component
      * Objective: /game/:sessionId/agent/:agentName では sessionId が含まれるパンくずが表示されることを検証する。
      */
-    renderAgent({ sessionId: 'test-session-001', agentName: 'Nox' });
+    renderGameScoped({ sessionId: 'test-session-001', agentName: 'Nox' });
 
     expect(screen.getByText('test-session-001')).toBeTruthy();
   });
@@ -76,7 +79,7 @@ describe('AgentDetailScreen semantic structure', () => {
      * Level: contract
      * Objective: AgentDetailScreen からゲーム画面へ戻るパンくずが ?view=public を引き継ぐことを検証する。
      */
-    renderAgent({ sessionId: 'test-session-001', agentName: 'Nox', search: '?view=public' });
+    renderGameScoped({ sessionId: 'test-session-001', agentName: 'Nox', search: '?view=public' });
 
     expect(screen.getByRole('link', { name: 'test-session-001' }).getAttribute('href')).toBe('/game/test-session-001?view=public');
   });
@@ -88,21 +91,141 @@ describe('AgentDetailScreen semantic structure', () => {
      * Level: contract
      * Objective: game-scoped AgentDetailScreen の AgentPicker 内リンクが ?view=public を引き継ぐことを検証する。
      */
-    renderAgent({ sessionId: 'test-session-001', agentName: 'Nox', search: '?view=public' });
+    renderGameScoped({ sessionId: 'test-session-001', agentName: 'Nox', search: '?view=public' });
 
     expect(screen.getByRole('link', { name: /Mira/ }).getAttribute('href')).toBe('/game/test-session-001/agent/Mira?view=public');
   });
+});
 
-  it('renders global breadcrumbs when sessionId is absent', () => {
+// --- global profile mode（#522・実データ化） ---
+
+describe('AgentDetailScreen(global)', () => {
+  it('エージェント名と img[alt=name] が描画される', async () => {
     /*
-     * SUT: AgentDetailScreen TopBar crumbs
-     * Mock: なし
-     * Level: component
-     * Objective: /agent/:agentName では sessionId なしのパンくずが表示されることを検証する。
-     */
-    renderAgent({ agentName: 'Nox' });
+    SUT: AgentDetailScreen (global profile mode)
+    Mock: global fetch（game_stats.json を返す）
+    Level: integration
+    Objective: 名前見出しと alt=name の Avatar img が描画されることを検証する (AC-6)
+    */
+    mockFetchOk(STATS_FIXTURE);
+    renderGlobal('/agent/Nox');
 
-    expect(screen.queryByText('test-session-001')).toBeNull();
-    expect(screen.getAllByText('Nox').length).toBeGreaterThan(0);
+    expect(await screen.findByRole('heading', { name: 'Nox' })).toBeTruthy();
+    // Hero + 左ペインの双方に Avatar(alt=Nox) が出る。1つ以上あれば AC-6 を満たす。
+    expect(screen.getAllByAltText('Nox').length).toBeGreaterThan(0);
+  });
+
+  it('左ペインに全エージェントの /agent/{name} リンクが描画される', async () => {
+    /*
+    SUT: AgentDetailScreen (global profile mode)
+    Mock: global fetch（game_stats.json を返す）
+    Level: integration
+    Objective: 左ペインが全エージェント名の /agent/{encodeURIComponent(name)} リンク集になることを検証する (AC-3)
+    */
+    mockFetchOk(STATS_FIXTURE);
+    renderGlobal('/agent/Nox');
+
+    const list = await screen.findByRole('list', { name: 'エージェント一覧' });
+    const noxLink = within(list).getByRole('link', { name: /Nox/ });
+    expect(noxLink.getAttribute('href')).toBe('/agent/Nox');
+    const kaiLink = within(list).getByRole('link', { name: /Kai/ });
+    expect(kaiLink.getAttribute('href')).toBe('/agent/Kai');
+  });
+
+  it('game-scoped 固有の要素（session ラベル・疑念マトリクス・夜の行動・推論ログ）が存在しない', async () => {
+    /*
+    SUT: AgentDetailScreen (global profile mode)
+    Mock: global fetch（game_stats.json を返す）
+    Level: integration
+    Objective: global mode で1ゲーム固有 UI が描画されないことを検証する (AC-4)
+    */
+    mockFetchOk(STATS_FIXTURE);
+    renderGlobal('/agent/Nox');
+    await screen.findByRole('heading', { name: 'Nox' });
+
+    expect(screen.queryByText('疑い度マトリクス')).toBeNull();
+    expect(screen.queryByText('推論ログ', { exact: false })).toBeNull();
+    expect(screen.queryByText('夜の行動')).toBeNull();
+    expect(screen.queryByText(/桜霞村/)).toBeNull();
+    expect(screen.queryByText('生存中', { exact: false })).toBeNull();
+  });
+
+  it('?view=public でも表示内容が変わらず viewerMode トグルが出ない', async () => {
+    /*
+    SUT: AgentDetailScreen (global profile mode)
+    Mock: global fetch（game_stats.json を返す）
+    Level: integration
+    Objective: viewerMode による出し分けを行わない（public でも内容不変・トグル UI なし）ことを検証する (AC-5)
+    */
+    mockFetchOk(STATS_FIXTURE);
+    renderGlobal('/agent/Nox?view=public');
+    await screen.findByRole('heading', { name: 'Nox' });
+
+    expect(screen.queryByText('観戦者モード')).toBeNull();
+    expect(screen.queryByText('参加者視点')).toBeNull();
+    expect(screen.getByText('50%')).toBeTruthy();
+  });
+
+  it('勝率・通算成績が game_stats.json の集計値で表示される', async () => {
+    /*
+    SUT: AgentDetailScreen (global profile mode)
+    Mock: global fetch（game_stats.json を返す）
+    Level: integration
+    Objective: 勝率・通算成績が parseGameStats の集計結果で描画されることを検証する (AC-1)
+    */
+    mockFetchOk(STATS_FIXTURE);
+    renderGlobal('/agent/Nox');
+    await screen.findByRole('heading', { name: 'Nox' });
+
+    // Nox: 2戦1勝 → 勝率 50%
+    expect(screen.getByText('50%')).toBeTruthy();
+    expect(screen.getAllByText(/2\s*戦/).length).toBeGreaterThan(0);
+  });
+
+  it('過去戦績一覧に gameId・role 列・勝敗が表示される', async () => {
+    /*
+    SUT: AgentDetailScreen (global profile mode)
+    Mock: global fetch（game_stats.json を返す）
+    Level: integration
+    Objective: 過去戦績一覧に session_id(=game_id)・role 列・勝敗が表示されることを検証する (AC-2)
+    */
+    mockFetchOk(STATS_FIXTURE);
+    renderGlobal('/agent/Nox');
+    const history = await screen.findByRole('list', { name: '過去の戦績' });
+
+    expect(within(history).getByText('2026-05-10T10:29:27')).toBeTruthy();
+    expect(within(history).getByText('2026-05-09T18:10:31')).toBeTruthy();
+    // role 列（AC-2 で許可）— Seer の日本語名
+    expect(within(history).getByText('占い師')).toBeTruthy();
+  });
+
+  it('存在しない agent でも名前・アバターを表示し成績は 0 になる', async () => {
+    /*
+    SUT: AgentDetailScreen (global profile mode)
+    Mock: global fetch（game_stats.json を返す）
+    Level: integration
+    Objective: game_stats.json に無い名前でも名前・アバターを描画し成績 0 を表示することを検証する (AC-7)
+    */
+    mockFetchOk(STATS_FIXTURE);
+    renderGlobal('/agent/Unknown');
+
+    expect(await screen.findByRole('heading', { name: 'Unknown' })).toBeTruthy();
+    expect(screen.getByAltText('Unknown')).toBeTruthy();
+    expect(screen.getByText('0%')).toBeTruthy();
+  });
+
+  it('fetch 失敗時に error 表示を出す', async () => {
+    /*
+    SUT: AgentDetailScreen (global profile mode)
+    Mock: global fetch（ok:false）
+    Level: integration
+    Objective: fetch 失敗時に error 表示へフォールバックすることを検証する (AC-7)
+    */
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    renderGlobal('/agent/Nox');
+
+    await waitFor(() => {
+      expect(screen.getByText(/読み込め|エラー/)).toBeTruthy();
+    });
   });
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,7 @@ import path from 'path';
 import fs from 'fs';
 
 const ARCHIVE_DIR = path.resolve(__dirname, '../state_archive');
+const STATS_DIR = path.resolve(__dirname, '../state/stats');
 
 export default defineConfig({
   plugins: [
@@ -15,6 +16,22 @@ export default defineConfig({
       configureServer(server) {
         server.middlewares.use('/state_archive', (req, res, next) => {
           const filePath = path.join(ARCHIVE_DIR, req.url);
+          if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+            res.setHeader('Content-Type', 'application/json');
+            fs.createReadStream(filePath).pipe(res);
+          } else {
+            next();
+          }
+        });
+      },
+    },
+    // Serve state/stats/ as static files under /stats/ (local dev only).
+    // game_stats.json (#522 global profile mode). Replace with FastAPI in production (#315).
+    {
+      name: 'serve-state-stats',
+      configureServer(server) {
+        server.middlewares.use('/stats', (req, res, next) => {
+          const filePath = path.join(STATS_DIR, req.url);
           if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
             res.setHeader('Content-Type', 'application/json');
             fs.createReadStream(filePath).pipe(res);


### PR DESCRIPTION
## Summary
- `/agent/:name`（global profile mode）を `state/stats/game_stats.json` 由来の横断戦績へ実データ化（#515 §8.3 A）
- 勝率・通算成績、過去戦績一覧（`game_id`/`role`/`won`）、全エージェント横断のプロフィール一覧リンク集を表示
- `archiveLoader.js` に純粋関数 `parseGameStats` / `parseAllAgentNames` と fetch 境界 `fetchGameStats` を追加
- `vite.config.js` に `/stats` middleware を追加し `state/stats/` を dev 配信（production は #315 FastAPI で差し替え）

## Implementation notes
- **共通化**: global 左ペインを独自マークアップから共通 `AgentRosterRow` へ統一。`showStatusDot`（生死概念のない global で false）・`selected`（現在地ハイライト）prop を追加
- **クリック領域バグ修正**: 当初の独自行は `display: contents` のリンクで padding/gap がクリック不能だった（行内37px が dead 域）。`AgentRosterRow` は行全体が `<Link>` のため行全域がクリック可（dead 1px のみ）に改善。Playwright で計測検証済み
- **AC-4/AC-5**: 役職タグ・推論・夜行動・疑念マトリクス・session ラベル・生死を出さず、viewerMode 出し分けも行わない
- **AC-7**: loading / error / empty（存在しない agent でも名前・アバター・0戦0勝）を処理
- `recordNum` 列を `game_id`（ISO 文字列）が収まるよう調整（game-scoped 実データ化でも共用）
- game-scoped mode はスタブのまま（実データ化は別 Issue）。global のスタブ描画テストは対象がスタブのため削除

## Test plan
- [x] `pytest` パス（pre-commit）
- [x] `npm test` パス（281 tests）
- [x] `npm run test:coverage` — 追加実装行は全カバー（`AgentRosterRow.jsx` uncovered: none）
- [x] Playwright 目視（実 `game_stats.json`）: 勝率8戦4勝/50%・過去戦績8件・横断15名リンク・行全域クリック・statusDot無し・選択ハイライト・`?view=public` 不変・empty state・コンソールエラー0

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)