### PR TITLE
docs: add issue #530 to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,6 +19,7 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
+| yukkie/AgentVillage#530 ❌ | enhancement | — | — | Establish design token usage rules & design-lint enforcement | #522 レビューで発覚したスタイル不統一が起点。トークン使用規約の明文化＋design lint 導入。idd は lint 通過のみ軽量ゲート、逸脱発見/tech-debt/リファクタは self-reflection-review |
 | yukkie/AgentVillage#523 ❌ | enhancement | — | — | Implement AgentDetailScreen game-scoped mode | #515 §8.3 B/D。/game/:sessionId/agent/:name を spectator_log+agents/*.json で実データ化。中央を日付タブ統合・疑念マトリクス・viewerMode 出し分け。依存: #521, #526 |
 | yukkie/AgentVillage#524 ❌ | enhancement | — | — | Remove AgentDetailScreen stub-only UI and add viewerMode toggle | #515 §8.3 C。不要ボタン/並べ替え/応援/現在の目標/疑似時刻/疑い・信頼タブ/右ペイン夜行動を撤去し、game-scoped に viewerMode トグル追加 |
 | yukkie/AgentVillage#519 ❌ | enhancement | — | — | Real-data blurb for AgentDetailScreen via config/agents.json | #515 の仕分け（§8.3 E 分割案5）から切り出し。AGENT_BLURB を config/agents.json の静的フィールド（まず英語）へ実データ化し、AgentDetailScreen 両モードで表示 |


### PR DESCRIPTION
## Summary
- `doc/Ideas.md` の Milestone 3 リスト先頭に Issue #530（Establish design token usage rules & design-lint enforcement）を追記。

## Context
#522 のレビューで発覚したスタイル不統一（過去戦績一覧の列ごとのフォント/色/サイズ不揃い）を起点に、デザインシステム・ガバナンスの観点で起票した Issue のバックログ登録。トークン使用規約の明文化＋design lint 導入を本体とし、idd は lint 通過のみの軽量ゲート、逸脱の発見・tech-debt 化・リファクタリングは self-reflection-review の責務、という分担。

🤖 Generated with [Claude Code](https://claude.com/claude-code)