### PR TITLE
Clean up AgentDetailScreen stub UI

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,7 +21,6 @@
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#530 ❌ | enhancement | — | — | Establish design token usage rules & design-lint enforcement | #522 レビューで発覚したスタイル不統一が起点。トークン使用規約の明文化＋design lint 導入。idd は lint 通過のみ軽量ゲート、逸脱発見/tech-debt/リファクタは self-reflection-review |
 | yukkie/AgentVillage#523 ❌ | enhancement | — | — | Implement AgentDetailScreen game-scoped mode | #515 §8.3 B/D。/game/:sessionId/agent/:name を spectator_log+agents/*.json で実データ化。中央を日付タブ統合・疑念マトリクス・viewerMode 出し分け。依存: #521, #526 |
-| yukkie/AgentVillage#524 ❌ | enhancement | — | — | Remove AgentDetailScreen stub-only UI and add viewerMode toggle | #515 §8.3 C。不要ボタン/並べ替え/応援/現在の目標/疑似時刻/疑い・信頼タブ/右ペイン夜行動を撤去し、game-scoped に viewerMode トグル追加 |
 | yukkie/AgentVillage#519 ❌ | enhancement | — | — | Real-data blurb for AgentDetailScreen via config/agents.json | #515 の仕分け（§8.3 E 分割案5）から切り出し。AGENT_BLURB を config/agents.json の静的フィールド（まず英語）へ実データ化し、AgentDetailScreen 両モードで表示 |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -2,18 +2,18 @@ import { useState, useEffect } from 'react';
 import { useParams, Link, useSearchParams } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
 import AgentRosterRow from '../components/AgentRosterRow.jsx';
-import TopBar, { TopBarBtn, topBarStyles } from '../components/TopBar.jsx';
+import TopBar, { TopBarBtn } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
 import { fetchGameStats, parseGameStats, parseAllAgentNames } from '../lib/archiveLoader.js';
 import {
   ALL_AGENTS, DEAD_AGENTS, ROLE_ASSIGNMENT,
-  AGENT_BLURB, AGENT_STATS, THOUGHTS, NIGHT_ACTIONS,
+  AGENT_BLURB, AGENT_STATS, THOUGHTS,
   getSuspicionMatrix,
 } from '../../stub/agentDetail.js';
 import styles from './AgentDetailScreen.module.css';
 
-const TABS = ['概要', '推論ログ', '疑い・信頼', '夜の行動', '過去の戦績'];
+const TABS = ['概要', '推論ログ', '過去の戦績'];
 
 function viewerModeFromSearchParams(searchParams) {
   return searchParams.get('view') === 'public' ? 'public' : 'spectator';
@@ -62,12 +62,6 @@ function LeftPane({ current, sessionId, viewerMode = 'spectator' }) {
           );
         })}
         </ul>
-        <div className={styles.sectionLabel} style={{ marginTop: 12 }}>並べ替え</div>
-        <div style={{ padding: '0 6px', display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <button className={styles.sortBtn}>発言数 ↓</button>
-          <button className={styles.sortBtn}>容疑度 ↓</button>
-          <button className={styles.sortBtn}>役職別</button>
-        </div>
       </div>
     </>
   );
@@ -104,10 +98,6 @@ function AgentHero({ agent }) {
           <div className={styles.statNum}>{stats.speeches}</div>
           <div className={styles.statLabel}>本村発言</div>
         </div>
-        <div className={styles.heroStat}>
-          <div className={styles.statNum} style={{ color: 'var(--alive)' }}>+{stats.cheers}</div>
-          <div className={styles.statLabel}>応援スコア</div>
-        </div>
       </div>
     </header>
   );
@@ -118,12 +108,6 @@ function TabOverview({ agent }) {
   const thoughts = (THOUGHTS[agent] || []).slice(0, 2);
   return (
     <>
-      <div className={styles.panel}>
-        <h3>現在の目標 <small>Day 2 議論フェーズ</small></h3>
-        <div className={styles.goalLine}>
-          真の占い師として認知を取りつつ、Kai を確実に処刑へ追い込む。Ren の偽占いを論理的に崩す。
-        </div>
-      </div>
       {thoughts.length > 0 && (
         <div className={styles.panel}>
           <h3>直近の推論 <small>{thoughts.length} 件 · spectator限定</small></h3>
@@ -132,7 +116,6 @@ function TabOverview({ agent }) {
               <li className={styles.thought} key={i}>
                 <div className={styles.thoughtHead}>
                   <strong>D{t.day} #{t.speechId} 発言前の思考</strong>
-                  <time className={styles.thoughtTs}>{(8 + t.speechId * 2) % 24}:{String((t.speechId * 13) % 60).padStart(2, '0')}</time>
                 </div>
                 <div className={styles.thoughtBody}>{t.text.slice(0, 180)}{t.text.length > 180 ? '…' : ''}</div>
               </li>
@@ -158,48 +141,10 @@ function TabThoughts({ agent }) {
           <li className={styles.thought} key={i}>
             <div className={styles.thoughtHead}>
               <strong>D{t.day} #{t.speechId} 発言前の思考</strong>
-              <time className={styles.thoughtTs}>{(8 + t.speechId * 2) % 24}:{String((t.speechId * 13) % 60).padStart(2, '0')}</time>
             </div>
             <div className={styles.thoughtBody}>{t.text}</div>
           </li>
         ))}
-      </ul>
-    </div>
-  );
-}
-
-// --- タブコンテンツ: 疑い・信頼 ---
-function TabSuspicion({ agent }) {
-  const matrix = getSuspicionMatrix(agent).slice(0, 8);
-  return (
-    <div className={styles.panel}>
-      <h3>疑い度マトリクス <small>{agent} 視点</small></h3>
-      <div className={styles.matrixHeader} aria-hidden="true">
-        <div className={styles.matrixHead}>対象</div>
-        <div className={styles.matrixHead}>疑い ←→ 信頼</div>
-        <div className={styles.matrixHead}>疑</div>
-        <div className={styles.matrixHead}>信</div>
-      </div>
-      <ul className={styles.matrix} aria-label="疑い度マトリクス">
-        {matrix.map(m => (
-          <MatrixRow key={m.name} m={m} />
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-// --- タブコンテンツ: 夜の行動 ---
-function TabNightActions({ agent }) {
-  const actions = NIGHT_ACTIONS[agent] || [];
-  if (actions.length === 0) {
-    return <div style={{ color: 'var(--tx-4)', fontSize: 13 }}>夜の行動なし（村人系役職）</div>;
-  }
-  return (
-    <div className={styles.panel}>
-      <h3>夜の行動</h3>
-      <ul className={styles.nightList} aria-label="夜の行動">
-        {actions.map((a, i) => <NightRow key={i} a={a} />)}
       </ul>
     </div>
   );
@@ -237,31 +182,6 @@ function TabHistory({ agent }) {
   );
 }
 
-// --- 共通パーツ: 夜の行動行 ---
-function NightRow({ a }) {
-  const resultClass = a.result === 'black' ? styles.resultBlack
-    : a.result === 'white' ? styles.resultWhite
-    : styles.resultSafe;
-  const resultLabel = a.result === 'black' ? '黒'
-    : a.result === 'white' ? '白'
-    : a.result === 'blocked' ? '護衛成功'
-    : '—';
-
-  return (
-    <li className={styles.nightRow}>
-      <div className={styles.nightDay}>D{a.day}{a.phase}</div>
-      <div>
-        <div className={styles.nightAction}>{a.action}</div>
-        <div className={styles.nightTarget}>
-          <Avatar name={a.target} size="xs" />
-          <span>{a.target}</span>
-        </div>
-      </div>
-      <div className={`${styles.nightResult} ${resultClass}`}>{resultLabel}</div>
-    </li>
-  );
-}
-
 // --- 共通パーツ: マトリクス行 ---
 function MatrixRow({ m }) {
   return (
@@ -287,7 +207,6 @@ function MatrixRow({ m }) {
 // --- 右ペイン ---
 function RightPane({ agent }) {
   const matrix  = getSuspicionMatrix(agent).slice(0, 8);
-  const actions = NIGHT_ACTIONS[agent] || [];
 
   return (
     <div className={styles.rightInner}>
@@ -303,14 +222,6 @@ function RightPane({ agent }) {
           {matrix.map(m => <MatrixRow key={m.name} m={m} />)}
         </ul>
       </div>
-      {actions.length > 0 && (
-        <div className={styles.panel}>
-          <h3>夜の行動</h3>
-          <ul className={styles.nightList} aria-label="夜の行動">
-            {actions.map((a, i) => <NightRow key={i} a={a} />)}
-          </ul>
-        </div>
-      )}
     </div>
   );
 }
@@ -447,7 +358,7 @@ function GlobalProfile({ agent }) {
 // === メイン画面 ===
 export default function AgentDetailScreen() {
   const { sessionId, agentName } = useParams();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const viewerMode = viewerModeFromSearchParams(searchParams);
   const viewerSearch = searchForViewerMode(viewerMode);
   const agent = agentName || 'Nox';
@@ -462,11 +373,13 @@ export default function AgentDetailScreen() {
   const role = ROLE_ASSIGNMENT[agent];
   const r    = ROLES[role];
 
+  const toggleViewerMode = () => {
+    setSearchParams(viewerMode === 'spectator' ? { view: 'public' } : {});
+  };
+
   const tabContent = [
     <TabOverview     agent={agent} />,
     <TabThoughts     agent={agent} />,
-    <TabSuspicion    agent={agent} />,
-    <TabNightActions agent={agent} />,
     <TabHistory      agent={agent} />,
   ];
 
@@ -479,9 +392,9 @@ export default function AgentDetailScreen() {
   return (
     <div className={styles.frame}>
       <TopBar crumbs={topCrumbs}>
-        <TopBarBtn><span className={topBarStyles.liveDot} /> LIVE観戦中</TopBarBtn>
-        <TopBarBtn>⤓ プロファイルJSON</TopBarBtn>
-        <TopBarBtn primary>★ ウォッチ</TopBarBtn>
+        <TopBarBtn onClick={toggleViewerMode}>
+          {viewerMode === 'spectator' ? '🔍 観戦者モード' : '👤 参加者視点'}
+        </TopBarBtn>
       </TopBar>
 
       <ThreePaneLayout

--- a/frontend/src/screens/AgentDetailScreen.module.css
+++ b/frontend/src/screens/AgentDetailScreen.module.css
@@ -109,22 +109,6 @@
   padding: 6px 8px 4px;
 }
 
-.sortBtn {
-  width: 100%;
-  text-align: left;
-  padding: 5px 8px;
-  font-size: 11px;
-  color: var(--tx-3);
-  background: none;
-  border: none;
-  border-radius: var(--r1);
-  cursor: pointer;
-  font-family: var(--sans);
-  margin-bottom: 2px;
-}
-
-.sortBtn:hover { background: var(--bg-2); color: var(--tx); }
-
 /* ===== 中央ペイン ===== */
 
 .mainPane {
@@ -268,16 +252,6 @@
   font-weight: 400;
 }
 
-.goalLine {
-  font-family: var(--serif);
-  font-size: 15px;
-  color: var(--tx);
-  line-height: 1.7;
-  border-left: 3px solid var(--acc);
-  padding: 4px 12px;
-  background: rgba(240, 199, 95, 0.04);
-}
-
 /* 推論ログ */
 .thought {
   border-left: 2px solid var(--bd);
@@ -309,56 +283,11 @@
 
 .thoughtHead strong { color: var(--tx-2); }
 
-.thoughtTs {
-  font-family: var(--mono);
-  font-size: 10px;
-  color: var(--tx-4);
-  margin-left: auto;
-}
-
 .thoughtBody {
   font-size: 13px;
   color: var(--tx);
   line-height: 1.65;
 }
-
-/* 夜の行動（中央タブ） */
-.nightRow {
-  display: grid;
-  grid-template-columns: 36px 1fr auto;
-  gap: 10px;
-  padding: 8px 0;
-  border-bottom: 1px dashed var(--bd-soft);
-  font-size: 12px;
-  align-items: center;
-}
-
-.nightRow:last-child { border-bottom: none; }
-
-.nightDay {
-  font-family: var(--mono);
-  color: var(--tx-4);
-  font-size: 10px;
-}
-
-.nightAction { color: var(--tx-2); margin-bottom: 2px; }
-
-.nightTarget {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.nightTarget span { color: var(--tx); font-family: var(--serif); }
-
-.nightResult {
-  font-family: var(--mono);
-  font-size: 11px;
-}
-
-.resultBlack { color: var(--danger); }
-.resultWhite { color: var(--info); }
-.resultSafe  { color: var(--alive); }
 
 /* 過去の戦績 */
 .recordRow {

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -97,6 +97,84 @@ describe('AgentDetailScreen game-scoped breadcrumbs', () => {
   });
 });
 
+describe('AgentDetailScreen game-scoped stub-only UI cleanup', () => {
+  it('game-scoped TopBar removes stub-only action buttons', () => {
+    /*
+     * SUT: AgentDetailScreen TopBar
+     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
+     * Level: integration
+     * Objective: game-scoped AgentDetailScreen の TopBar から stub-only action buttons が撤去されることを検証する (AC-1)
+     */
+    renderGameScoped({ sessionId: 'test-session-001', agentName: 'Nox' });
+
+    expect(screen.queryByText(/LIVE観戦中/)).toBeNull();
+    expect(screen.queryByText(/プロファイルJSON/)).toBeNull();
+    expect(screen.queryByText(/ウォッチ/)).toBeNull();
+  });
+
+  it('game-scoped TopBar toggles viewerMode query like SpectatorScreen', async () => {
+    /*
+     * SUT: AgentDetailScreen TopBar viewerMode toggle
+     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
+     * Level: contract
+     * Objective: game-scoped mode のみに viewerMode トグルがあり、SpectatorScreen と同じ query 遷移を行うことを検証する (AC-2)
+     */
+    const { userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    renderGameScoped({ sessionId: 'test-session-001', agentName: 'Nox' });
+
+    const spectatorToggle = screen.getByRole('button', { name: /観戦者モード/ });
+    await user.click(spectatorToggle);
+    expect(screen.getByRole('button', { name: /参加者視点/ })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'test-session-001' }).getAttribute('href')).toBe('/game/test-session-001?view=public');
+
+    await user.click(screen.getByRole('button', { name: /参加者視点/ }));
+    expect(screen.getByRole('button', { name: /観戦者モード/ })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'test-session-001' }).getAttribute('href')).toBe('/game/test-session-001');
+  });
+
+  it('game-scoped left pane removes sort controls', () => {
+    /*
+     * SUT: AgentDetailScreen LeftPane
+     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
+     * Level: integration
+     * Objective: 左ペインの onClick なし並べ替えボタンが撤去されることを検証する (AC-3)
+     */
+    renderGameScoped({ sessionId: 'test-session-001', agentName: 'Nox' });
+
+    expect(screen.queryByRole('button', { name: /発言数/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /容疑度/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /役職別/ })).toBeNull();
+  });
+
+  it('game-scoped removes cheers goal and pseudo thought timestamps', () => {
+    /*
+     * SUT: AgentDetailScreen game-scoped center pane
+     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
+     * Level: integration
+     * Objective: 応援スコア・現在の目標・thought 疑似時刻が撤去されることを検証する (AC-4)
+     */
+    renderGameScoped({ sessionId: 'test-session-001', agentName: 'Nox' });
+
+    expect(screen.queryByText('応援スコア')).toBeNull();
+    expect(screen.queryByText(/現在の目標/)).toBeNull();
+    expect(screen.queryByText(/^\d{1,2}:\d{2}$/)).toBeNull();
+  });
+
+  it('game-scoped removes suspicion tab and right pane night actions', () => {
+    /*
+     * SUT: AgentDetailScreen game-scoped tabs and RightPane
+     * Mock: なし（stub/agentDetail.js の既存スタブデータを使用）
+     * Level: integration
+     * Objective: 「疑い・信頼」タブと右ペインの「夜の行動」パネルが撤去されることを検証する (AC-5)
+     */
+    renderGameScoped({ sessionId: 'test-session-001', agentName: 'Nox' });
+
+    expect(screen.queryByRole('button', { name: '疑い・信頼' })).toBeNull();
+    expect(screen.queryByText('夜の行動')).toBeNull();
+  });
+});
+
 // --- global profile mode（#522・実データ化） ---
 
 describe('AgentDetailScreen(global)', () => {


### PR DESCRIPTION
## Summary
- Remove AgentDetailScreen game-scoped stub-only UI: TopBar dummy actions, left-pane sort controls, cheers, hardcoded goal, pseudo thought timestamps, duplicated suspicion/night tabs.
- Add the same viewerMode toggle behavior as SpectatorScreen to game-scoped AgentDetailScreen only.
- Remove the completed Issue #524 row from doc/Ideas.md.

## Implementation notes
- global profile mode remains unchanged and still does not render viewerMode controls.
- The game-scoped route preserves viewerMode query propagation through breadcrumbs and agent picker links.

## Test plan
- [x] npm.cmd test
- [x] npm.cmd run test:coverage
- [x] npm.cmd run build
- [x] Browser check on http://[::1]:5173/game/test-session-001/agent/Nox
- [x] uv run ruff check .
- [x] uv run pytest

Closes #524

🤖 Generated with [OpenAI Codex](https://openai.com/codex)