### PR TITLE
Add AgentDetail day timeline

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,8 +20,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#530 ❌ | enhancement | — | — | Establish design token usage rules & design-lint enforcement | #522 レビューで発覚したスタイル不統一が起点。トークン使用規約の明文化＋design lint 導入。idd は lint 通過のみ軽量ゲート、逸脱発見/tech-debt/リファクタは self-reflection-review |
-| yukkie/AgentVillage#523 ❌ | enhancement | — | — | Implement AgentDetailScreen game-scoped basic data | #515 §8.3 B。/game/:sessionId/agent/:name の基礎表示を spectator_log+agents/*.json で実データ化。参加者ピッカー・役職/sessionメタ・発言数・疑念マトリクス。依存: #521。中央Dayタイムラインは #533 |
-| yukkie/AgentVillage#533 ❌ | enhancement | — | — | Implement AgentDetailScreen game-scoped day timeline | #523 から分割。中央を Day タブに統合し、対象エージェントの発言・思考・夜行動を #526 の FeedCard で時系列表示。依存: #523, #526 |
 | yukkie/AgentVillage#519 ❌ | enhancement | — | — | Real-data blurb for AgentDetailScreen via config/agents.json | #515 の仕分け（§8.3 E 分割案5）から切り出し。AGENT_BLURB を config/agents.json の静的フィールド（まず英語）へ実データ化し、AgentDetailScreen 両モードで表示 |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, Link, useSearchParams } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
 import AgentRosterRow from '../components/AgentRosterRow.jsx';
@@ -139,10 +139,12 @@ function AgentDayTimeline({ agent, events, visibleDays, roleAssignment, sessionI
   const [selectedDay, setSelectedDay] = useState(null);
   const activeDay = visibleDays.includes(selectedDay) ? selectedDay : visibleDays[0] ?? null;
 
-  const prevById = buildPrevById(events);
+  const prevById = useMemo(() => buildPrevById(events), [events]);
   const timelineEvents = activeDay == null
     ? []
     : events.filter(ev => ev.day === activeDay && isAgentTimelineEvent(ev, agent));
+  const activeTabId = activeDay == null ? undefined : `agent-day-tab-${activeDay}`;
+  const activePanelId = activeDay == null ? undefined : `agent-day-panel-${activeDay}`;
 
   if (visibleDays.length === 0) {
     return (
@@ -158,8 +160,10 @@ function AgentDayTimeline({ agent, events, visibleDays, roleAssignment, sessionI
         {visibleDays.map(day => (
           <button
             key={day}
+            id={`agent-day-tab-${day}`}
             type="button"
             role="tab"
+            aria-controls={`agent-day-panel-${day}`}
             aria-selected={activeDay === day}
             className={`${styles.tab} ${activeDay === day ? styles.tabOn : ''}`}
             onClick={() => setSelectedDay(day)}
@@ -168,7 +172,12 @@ function AgentDayTimeline({ agent, events, visibleDays, roleAssignment, sessionI
           </button>
         ))}
       </div>
-      <div className={`${styles.tabContent} ${styles.timelineContent}`}>
+      <div
+        id={activePanelId}
+        className={`${styles.tabContent} ${styles.timelineContent}`}
+        role="tabpanel"
+        aria-labelledby={activeTabId}
+      >
         {timelineEvents.length === 0 ? (
           <div className={styles.emptyState}>Day{activeDay} の {agent} の行動はありません。</div>
         ) : (

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, Link, useSearchParams } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
 import AgentRosterRow from '../components/AgentRosterRow.jsx';
+import { FeedItem } from '../components/FeedCard.jsx';
 import TopBar, { TopBarBtn } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
@@ -115,6 +116,77 @@ function RightPane({ matrix }) {
         </ul>
       </div>
     </div>
+  );
+}
+
+const AGENT_TIMELINE_EVENT_TYPES = new Set(['speech', 'inspection', 'guard', 'night_attack']);
+
+function buildPrevById(events) {
+  return Object.fromEntries(
+    events
+      .filter(ev => ev.event_type === 'speech' && ev.speech_id != null)
+      .map(ev => [`${ev.day}-${ev.speech_id}`, ev])
+  );
+}
+
+function isAgentTimelineEvent(ev, agent) {
+  if (!AGENT_TIMELINE_EVENT_TYPES.has(ev.event_type)) return false;
+  if (ev.event_type === 'night_attack' && ev.is_public) return false;
+  return ev.agent === agent;
+}
+
+function AgentDayTimeline({ agent, events, visibleDays, roleAssignment, sessionId, viewerMode }) {
+  const [selectedDay, setSelectedDay] = useState(null);
+  const activeDay = visibleDays.includes(selectedDay) ? selectedDay : visibleDays[0] ?? null;
+
+  const prevById = buildPrevById(events);
+  const timelineEvents = activeDay == null
+    ? []
+    : events.filter(ev => ev.day === activeDay && isAgentTimelineEvent(ev, agent));
+
+  if (visibleDays.length === 0) {
+    return (
+      <div className={styles.tabContent}>
+        <div className={styles.emptyState}>このゲームの Day イベントはありません。</div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className={styles.tabs} role="tablist" aria-label="日付タブ">
+        {visibleDays.map(day => (
+          <button
+            key={day}
+            type="button"
+            role="tab"
+            aria-selected={activeDay === day}
+            className={`${styles.tab} ${activeDay === day ? styles.tabOn : ''}`}
+            onClick={() => setSelectedDay(day)}
+          >
+            Day{day}
+          </button>
+        ))}
+      </div>
+      <div className={`${styles.tabContent} ${styles.timelineContent}`}>
+        {timelineEvents.length === 0 ? (
+          <div className={styles.emptyState}>Day{activeDay} の {agent} の行動はありません。</div>
+        ) : (
+          <div className={styles.timelineList} aria-label={`Day${activeDay} ${agent} タイムライン`}>
+            {timelineEvents.map((ev, index) => (
+              <FeedItem
+                key={ev.id ?? `${ev.day}-${ev.event_type}-${ev.agent}-${ev.speech_id ?? ev.target ?? index}`}
+                ev={ev}
+                prevById={prevById}
+                roleAssignment={roleAssignment}
+                sessionId={sessionId}
+                viewerMode={viewerMode}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
   );
 }
 
@@ -311,6 +383,9 @@ export default function AgentDetailScreen() {
     const speechCount = countAgentSpeeches(events, agent);
     const visibleDays = [...new Set(events.map(ev => ev.day).filter(Boolean))].sort((a, b) => a - b);
     const currentDay = entry?.days ?? visibleDays.at(-1) ?? 0;
+    const roleAssignment = Object.fromEntries(
+      Object.entries(agents).map(([name, data]) => [name, data.role])
+    );
 
     body = (
       <ThreePaneLayout
@@ -326,6 +401,14 @@ export default function AgentDetailScreen() {
             speechCount={speechCount}
             sessionMeta={entry}
             currentDay={currentDay}
+            viewerMode={viewerMode}
+          />
+          <AgentDayTimeline
+            agent={agent}
+            events={events}
+            visibleDays={visibleDays}
+            roleAssignment={roleAssignment}
+            sessionId={sessionId}
             viewerMode={viewerMode}
           />
         </div>

--- a/frontend/src/screens/AgentDetailScreen.module.css
+++ b/frontend/src/screens/AgentDetailScreen.module.css
@@ -225,6 +225,25 @@
   padding: 20px 36px 60px;
 }
 
+.timelineContent {
+  padding-top: 18px;
+}
+
+.timelineList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.emptyState {
+  color: var(--tx-4);
+  font-size: 13px;
+  border: 1px solid var(--bd-soft);
+  background: var(--bg-1);
+  border-radius: var(--r2);
+  padding: 18px;
+}
+
 .panel {
   background: var(--bg-1);
   border: 1px solid var(--bd);

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -348,10 +348,13 @@ describe('AgentDetailScreen game-scoped day timeline', () => {
 
     expect(await screen.findByRole('tab', { name: 'Day1' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Day2' })).toBeTruthy();
+    expect(screen.getByRole('tabpanel', { name: 'Day1' }).getAttribute('id')).toBe('agent-day-panel-1');
+    expect(screen.getByRole('tab', { name: 'Day1' }).getAttribute('aria-controls')).toBe('agent-day-panel-1');
     expect(screen.getByText('私は占い師です')).toBeTruthy();
     expect(screen.queryByText('Kaiを疑います')).toBeNull();
 
     await user.click(screen.getByRole('tab', { name: 'Day2' }));
+    expect(screen.getByRole('tabpanel', { name: 'Day2' }).getAttribute('id')).toBe('agent-day-panel-2');
     expect(screen.getByText('Kaiを疑います')).toBeTruthy();
     expect(screen.queryByText('私は占い師です')).toBeNull();
   });

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -64,6 +64,9 @@ const GAME_SCOPED_INDEX = {
 const GAME_SCOPED_JSONL = [
   { id: 's1', day: 1, event_type: 'speech', agent: 'Nox', speech_id: 1, content: '私は占い師です', is_public: true, reasoning: 'Kaiが怪しい。', claimed_role: 'Seer' },
   { id: 's2', day: 1, event_type: 'speech', agent: 'Mira', speech_id: 2, content: '了解です', is_public: true },
+  { id: 'i1', day: 1, event_type: 'inspection', agent: 'Nox', target: 'Kai', content: 'Nox inspects Kai: Werewolf', is_public: false, reasoning: 'Kaiの視点漏れを確認する。' },
+  { id: 'g1', day: 1, event_type: 'guard', agent: 'Nox', target: 'Mira', content: 'Nox guards Mira', is_public: false, reasoning: 'Miraを守る価値が高い。' },
+  { id: 'a1', day: 1, event_type: 'night_attack', agent: 'Nox', target: 'Mira', content: 'Nox attacks Mira', is_public: false, reasoning: '護衛が薄い。' },
   { id: 's3', day: 2, event_type: 'speech', agent: 'Nox', speech_id: 3, content: 'Kaiを疑います', is_public: true },
   { id: 'u1', day: 2, event_type: 'suspicion_update', agent: 'Nox', is_public: false, suspicion_snapshot: { Kai: 0.86, Mira: 0.24 } },
 ].map(event => JSON.stringify(event)).join('\n');
@@ -282,8 +285,9 @@ describe('AgentDetailScreen game-scoped real data', () => {
 
     await screen.findByRole('heading', { name: 'Nox' });
     expect(screen.getByText('2')).toBeTruthy();
-    expect(screen.getByRole('link', { name: /Mira/ }).getAttribute('href')).toBe('/game/session-real-001/agent/Mira');
-    expect(screen.getByRole('link', { name: /Kai/ }).getAttribute('href')).toBe('/game/session-real-001/agent/Kai');
+    const picker = screen.getByRole('list', { name: 'エージェント一覧' });
+    expect(within(picker).getByRole('link', { name: /Mira/ }).getAttribute('href')).toBe('/game/session-real-001/agent/Mira');
+    expect(within(picker).getByRole('link', { name: /Kai/ }).getAttribute('href')).toBe('/game/session-real-001/agent/Kai');
   });
 
   it('game-scoped public mode hides role faction and suspicion matrix', async () => {
@@ -326,6 +330,117 @@ describe('AgentDetailScreen game-scoped real data', () => {
     renderGameScoped({ sessionId: 'session-real-001', agentName: 'Nox' });
 
     expect(await screen.findByText(/Failed to fetch game list/)).toBeTruthy();
+  });
+});
+
+describe('AgentDetailScreen game-scoped day timeline', () => {
+  it('game-scoped renders day tabs and switches the agent timeline day', async () => {
+    /*
+     * SUT: AgentDetailScreen game-scoped day timeline
+     * Mock: global fetch（state_archive/index.json, spectator_log.jsonl, agents/*.json を返す）
+     * Level: integration
+     * Objective: 中央ペインの Day タブをクリックすると、選択日の対象エージェント timeline に切り替わることを検証する。
+     */
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    mockGameScopedReplay();
+    renderGameScoped({ sessionId: 'session-real-001', agentName: 'Nox' });
+
+    expect(await screen.findByRole('tab', { name: 'Day1' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Day2' })).toBeTruthy();
+    expect(screen.getByText('私は占い師です')).toBeTruthy();
+    expect(screen.queryByText('Kaiを疑います')).toBeNull();
+
+    await user.click(screen.getByRole('tab', { name: 'Day2' }));
+    expect(screen.getByText('Kaiを疑います')).toBeTruthy();
+    expect(screen.queryByText('私は占い師です')).toBeNull();
+  });
+
+  it('game-scoped renders selected agent speech and spectator reasoning through FeedItem', async () => {
+    /*
+     * SUT: AgentDetailScreen game-scoped day timeline
+     * Mock: global fetch（state_archive/index.json, spectator_log.jsonl, agents/*.json を返す）
+     * Level: integration
+     * Objective: 対象エージェントの speech が FeedItem 経由で表示され、spectator mode では reasoning を確認できることを検証する。
+     */
+    mockGameScopedReplay();
+    renderGameScoped({ sessionId: 'session-real-001', agentName: 'Nox' });
+
+    expect(await screen.findByText('私は占い師です')).toBeTruthy();
+    expect(screen.getAllByText('思考ログを読む').length).toBeGreaterThan(0);
+    expect(screen.getByText('Kaiが怪しい。')).toBeTruthy();
+  });
+
+  it('game-scoped renders selected agent private night actions through shared feed rows', async () => {
+    /*
+     * SUT: AgentDetailScreen game-scoped day timeline
+     * Mock: global fetch（state_archive/index.json, spectator_log.jsonl, agents/*.json を返す）
+     * Level: integration
+     * Objective: 対象エージェントの inspection / guard / private night_attack が共通 FeedItem/SystemRow 表示で描画されることを検証する。
+     */
+    mockGameScopedReplay();
+    renderGameScoped({ sessionId: 'session-real-001', agentName: 'Nox' });
+
+    expect(await screen.findByText('占い結果')).toBeTruthy();
+    expect(screen.getByText('Nox inspects Kai: Werewolf')).toBeTruthy();
+    expect(screen.getByText('護衛')).toBeTruthy();
+    expect(screen.getByText('Nox guards Mira')).toBeTruthy();
+    expect(screen.getByText('人狼の襲撃')).toBeTruthy();
+    expect(screen.getByText('Nox attacks Mira')).toBeTruthy();
+  });
+
+  it('game-scoped public mode locks reasoning and hides private night actions', async () => {
+    /*
+     * SUT: AgentDetailScreen game-scoped day timeline
+     * Mock: global fetch（state_archive/index.json, spectator_log.jsonl, agents/*.json を返す）
+     * Level: integration
+     * Objective: public mode では speech reasoning がロック表示になり、private 夜行動は非表示になることを検証する。
+     */
+    mockGameScopedReplay();
+    renderGameScoped({ sessionId: 'session-real-001', agentName: 'Nox', search: '?view=public' });
+
+    expect(await screen.findByText('私は占い師です')).toBeTruthy();
+    expect(screen.getByText('🔒 思考ログ')).toBeTruthy();
+    expect(screen.queryByText('Kaiが怪しい。')).toBeNull();
+    expect(screen.queryByText('Nox inspects Kai: Werewolf')).toBeNull();
+    expect(screen.queryByText('Nox guards Mira')).toBeNull();
+    expect(screen.queryByText('Nox attacks Mira')).toBeNull();
+  });
+
+  it('game-scoped timeline uses FeedItem semantics for speech links and system rows', async () => {
+    /*
+     * SUT: AgentDetailScreen game-scoped day timeline
+     * Mock: global fetch（state_archive/index.json, spectator_log.jsonl, agents/*.json を返す）
+     * Level: integration
+     * Objective: 中央タイムラインが FeedItem のリンク・SystemRow 表示契約を使って描画されることを検証する。
+     */
+    mockGameScopedReplay();
+    renderGameScoped({ sessionId: 'session-real-001', agentName: 'Nox' });
+
+    expect(await screen.findByText('私は占い師です')).toBeTruthy();
+    expect(screen.getAllByRole('link', { name: /Nox/ }).some(link => (
+      link.getAttribute('href') === '/game/session-real-001/agent/Nox'
+    ))).toBe(true);
+    expect(screen.getByText('占い結果')).toBeTruthy();
+    expect(screen.getByText('人狼の襲撃')).toBeTruthy();
+  });
+
+  it('game-scoped timeline shows an empty state when no Day events exist', async () => {
+    /*
+     * SUT: AgentDetailScreen game-scoped day timeline
+     * Mock: global fetch（day=0 のみの spectator_log.jsonl と agents/*.json を返す）
+     * Level: integration
+     * Objective: Day1 以降のイベントが無い game-scoped archive では Day タブを出さず空状態を表示することを検証する。
+     */
+    mockGameScopedFetch({
+      indexEntry: { session_id: 'session-empty-001', title: '空村', days: 0, cast: ['Nox'] },
+      jsonlText: JSON.stringify({ id: 'r0', day: 0, event_type: 'role_assigned', agent: 'Nox', is_public: false }),
+      agentJsonByName: { Nox: GAME_SCOPED_AGENTS.Nox },
+    });
+    renderGameScoped({ sessionId: 'session-empty-001', agentName: 'Nox' });
+
+    expect(await screen.findByText('このゲームの Day イベントはありません。')).toBeTruthy();
+    expect(screen.queryByRole('tab', { name: 'Day1' })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add Day tabs to game-scoped AgentDetailScreen and render the selected agent timeline with shared FeedCard components.
- Show selected-agent speech, spectator reasoning, and private night actions in spectator mode.
- Preserve public viewerMode behavior by locking reasoning and hiding spectator-only private actions.
- Remove completed #523/#533 rows from doc/Ideas.md.

## Implementation notes
- Timeline events are scoped to actions by the selected agent (`agent === selectedAgent`), not events targeting that agent.
- AgentDetail reuses `FeedItem` from `src/components/FeedCard.jsx`; no AgentDetail-only feed card implementation was added.
- Day tabs use native `<button type="button">` elements with `role="tab"`.

## Test plan
- [x] `npm.cmd test -- AgentDetailScreen.test.jsx`
- [x] `npm.cmd test`
- [x] `npm.cmd run test:coverage`
- [x] `npm.cmd run build`
- [x] Playwright smoke check on `20260611_195733`
- [x] `uv run ruff check .`
- [x] `uv run pytest`

Closes #533

🤖 Generated with [OpenAI Codex](https://openai.com/codex)