### PR TITLE
feat: real-data blurb for AgentDetailScreen via config/agents.json

### DIFF
--- a/config/agents.json
+++ b/config/agents.json
@@ -8,7 +8,8 @@
     "age": "adult",
     "speech_style": "polite",
     "occupation": "Mediator",
-    "occupation_ja": "仲裁人"
+    "occupation_ja": "仲裁人",
+    "blurb": "Cools every heated room with reason, and never lets a quiet voice go unheard."
   },
   {
     "name": "Nana",
@@ -19,7 +20,8 @@
     "age": "teen",
     "speech_style": "tsundere",
     "occupation": "Trickster",
-    "occupation_ja": "道化者"
+    "occupation_ja": "道化者",
+    "blurb": "Hides a sharp mind behind sharper jokes, and means more than she ever admits."
   },
   {
     "name": "Ren",
@@ -30,7 +32,8 @@
     "age": "adult",
     "speech_style": "gentle",
     "occupation": "Watcher",
-    "occupation_ja": "見張り番"
+    "occupation_ja": "見張り番",
+    "blurb": "Says little and watches everything, letting others reveal what he already suspects."
   },
   {
     "name": "Mira",
@@ -41,7 +44,8 @@
     "age": "adult",
     "speech_style": "casual",
     "occupation": "Analyst",
-    "occupation_ja": "記録係"
+    "occupation_ja": "記録係",
+    "blurb": "Stands where instinct meets logic and smells a lie before it has finished forming."
   },
   {
     "name": "Vael",
@@ -52,7 +56,8 @@
     "age": null,
     "speech_style": "polite",
     "occupation": "Deceiver",
-    "occupation_ja": "詐欺師"
+    "occupation_ja": "詐欺師",
+    "blurb": "Builds a palace of lies, brick by polished brick, and invites you to live in it."
   },
   {
     "name": "Kai",
@@ -63,7 +68,8 @@
     "age": "adult",
     "speech_style": "dry",
     "occupation": "Strategist",
-    "occupation_ja": "策士"
+    "occupation_ja": "策士",
+    "blurb": "Wields silence as a weapon, spending the fewest words to sow the most doubt."
   },
   {
     "name": "Sera",
@@ -74,7 +80,8 @@
     "age": "adult",
     "speech_style": "cool",
     "occupation": "Executioner",
-    "occupation_ja": "処刑人"
+    "occupation_ja": "処刑人",
+    "blurb": "Beneath a smile everyone trusts, the hunt is already elegantly underway."
   },
   {
     "name": "Kael",
@@ -85,7 +92,8 @@
     "age": "teen",
     "speech_style": "blunt",
     "occupation": "Guardian",
-    "occupation_ja": "守衛"
+    "occupation_ja": "守衛",
+    "blurb": "Charges in headlong to shield the ones he trusts, and asks the hard questions later."
   },
   {
     "name": "Lumi",
@@ -96,7 +104,8 @@
     "age": "teen",
     "speech_style": "gentle",
     "occupation": "Florist",
-    "occupation_ja": "花屋"
+    "occupation_ja": "花屋",
+    "blurb": "Believes the best in everyone, and her open heart is both her gift and her risk."
   },
   {
     "name": "Shiki",
@@ -107,7 +116,8 @@
     "age": "adult",
     "speech_style": "assertive",
     "occupation": "Priest",
-    "occupation_ja": "司祭"
+    "occupation_ja": "司祭",
+    "blurb": "Remembers every word that was spoken, and quietly lays each contradiction bare."
   },
   {
     "name": "Toma",
@@ -118,7 +128,8 @@
     "age": "adult",
     "speech_style": "casual",
     "occupation": "Merchant",
-    "occupation_ja": "商人"
+    "occupation_ja": "商人",
+    "blurb": "Reads the room like a marketplace and always knows which side is worth backing today."
   },
   {
     "name": "Rei",
@@ -129,7 +140,8 @@
     "age": "adult",
     "speech_style": "cool",
     "occupation": "Spy",
-    "occupation_ja": "密偵"
+    "occupation_ja": "密偵",
+    "blurb": "Keeps her cards and her loyalties hidden, trading secrets while revealing none of her own."
   },
   {
     "name": "Haru",
@@ -140,7 +152,8 @@
     "age": "teen",
     "speech_style": "gentle",
     "occupation": "Farmhand",
-    "occupation_ja": "農夫"
+    "occupation_ja": "農夫",
+    "blurb": "Wears an easy smile that puts everyone at ease, and notices far more than he lets on."
   },
   {
     "name": "Nox",
@@ -151,7 +164,8 @@
     "age": "adult",
     "speech_style": "dry",
     "occupation": "Undertaker",
-    "occupation_ja": "葬儀屋"
+    "occupation_ja": "葬儀屋",
+    "blurb": "Quiet as a moonless night, he finds the frayed edge in everything you say."
   },
   {
     "name": "Sable",
@@ -162,6 +176,7 @@
     "age": "adult",
     "speech_style": "polite",
     "occupation": "Diplomat",
-    "occupation_ja": "外交官"
+    "occupation_ja": "外交官",
+    "blurb": "Reads the current of the room and knows the one word that will turn the tide."
   }
 ]

--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -665,7 +665,7 @@ SpectatorScreen から AgentDetailScreen への遷移、および AgentDetailScr
 | `TabHistory` | 過去戦績（ゲーム番号・役職・勝敗） |
 | `MatrixRow` / `NightRow` | 各リストの行コンポーネント |
 
-データソース: `stub/agentDetail.js`（`ALL_AGENTS`, `DEAD_AGENTS`, `AGENT_BLURB`, `AGENT_STATS`, `THOUGHTS`, `NIGHT_ACTIONS`, `getSuspicionMatrix`）。
+データソース: `stub/agentDetail.js`（`ALL_AGENTS`, `DEAD_AGENTS`, `AGENT_STATS`, `THOUGHTS`, `NIGHT_ACTIONS`, `getSuspicionMatrix`）。blurb（1行プロフィール）は `config/agents.json` の `blurb` フィールドから fetch（#519）。
 
 Semantic HTML: `AgentHero` は画面内のエージェント見出しとして `<header>`、AgentPicker・推論ログ・夜行動・過去戦績・疑い度マトリクスの行群は `<ul><li>` で表現する。picker 行の clickable 化は React Router 導入時（#342）に `<a>` / `<Link>` として扱う。
 
@@ -784,7 +784,7 @@ Semantic HTML: `AgentHero` は画面内のエージェント見出しとして `
 |---|---|---|
 | `stub/spectator.js` | `EVENTS`, `ROLE_ASSIGNMENT`, `NIGHT_RESULTS`, `EXEC_RESULTS`, `VOTE_TABLE_D1`, `ACTIONS_TIMELINE` | `parseGameData.js` 経由で `state_archive/{sessionId}/spectator_log.jsonl` をパース |
 | `stub/gameList.js` | `GAMES`, `TOP_AGENTS`, `COMMUNITY_POSTS`, `VILLAGE_NAME_PRESETS` | ゲーム一覧は `state_archive/` のディレクトリ一覧を fetch（または FastAPI エンドポイント） |
-| `stub/agentDetail.js` | `ALL_AGENTS`, `DEAD_AGENTS`, `AGENT_BLURB`, `AGENT_STATS`, `THOUGHTS`, `NIGHT_ACTIONS` | モード別の項目仕分け・出所は §8.3（`game_stats.json` / `agents/*.json` / `spectator_log.jsonl` / `config/agents.json`） |
+| `stub/agentDetail.js` | `ALL_AGENTS`, `DEAD_AGENTS`, `AGENT_STATS`, `THOUGHTS`, `NIGHT_ACTIONS`（`AGENT_BLURB` は #519 で実データ化済み・削除） | モード別の項目仕分け・出所は §8.3（`game_stats.json` / `agents/*.json` / `spectator_log.jsonl` / `config/agents.json`） |
 
 ### 8.2 Milestone 2 移行計画
 
@@ -838,7 +838,7 @@ FastAPI + WebSocket でイベントをストリーミング配信する。`fetch
 | 項目 | 扱い | 出所 / 理由 |
 |---|---|---|
 | 名前 ＋ アバター | ✅ | `game_stats.json` の `players[].name` / アイコンは `/icons/{name}.png` |
-| blurb（1行プロフィール、`AGENT_BLURB`） | ✅（別 Issue・重い） | `config/agents.json` に静的な新フィールド（例: `blurb`）を追加して fetch。両モード共通。実装は別 Issue（`persona_short` は未実装のため使わない） |
+| blurb（1行プロフィール、旧 `AGENT_BLURB`） | ✅ 実装済み（#519） | `config/agents.json` の静的 `blurb` フィールド（英語）を `fetchAgentConfig()` で fetch し、`parseBlurb()` で抽出。両モード共通。fetch 失敗／未定義は `—` フォールバック。日本語化は将来の別 Issue |
 | 勝率・通算成績（`AGENT_STATS` の `games` / `wins`） | ✅ | `game_stats.json` の各 `game.players[]` を `name` でフィルタし `won` / 出場数を集計（`doc/DataSpec.md` §6） |
 | 過去の戦績一覧（`TabHistory` の `records`） | ✅ | `game_stats.json` 各 `game` を `name` でフィルタ（`game_id` / `role` / `won`）。**村名列は `game_stats.json` に無いため `session_id`（`game_id`）を代わりに表示する**。過去戦績テーブルの `role` 列は表示してよい（Hero / Avatar / 左ペインの役職タグ・役職刻印を出さない方針とは別物） |
 | 左ペイン名簿（`ALL_AGENTS` / `DEAD_AGENTS`） | ✅（別物に差し替え） | `global` では「同ゲームの参加者ピッカー」は概念として存在しない。代わりに**全エージェント横断のプロフィール一覧リンク集**にする（`game_stats.json` の全 `name` 集合 → 各行 `/agent/{encodeURIComponent(name)}`）。共通 `AgentRosterRow` を `showRole={false}`（役職を出さない・AC-4）・`showStatusDot={false}`（生死概念なし）・`selected={name === current}`（現在地ハイライト）で再利用する。行全体が `Link` のためクリック領域が行全域になる（独自 `display: contents` 行だと padding/gap が hit しない問題を回避） |
@@ -893,7 +893,7 @@ FastAPI + WebSocket でイベントをストリーミング配信する。`fetch
 2. **`game-scoped` 基本** — 参加者ピッカー・役職・session メタ・生死・推論ログ（`parseGameData.js` 拡張 ＋ `agents/*.json`）。
 3. **`game-scoped` 中央タイムライン統合** — 日付タブ ＋ 発言/思考/夜行動の統合表示。**SpectatorScreen フィードカードの共通コンポーネント化を含む**（D 参照）。viewerMode public 出し分けを含む。
 4. **TopBar / 演出の撤去 ＋ viewerMode トグル追加** — 不要ボタン削除・ダミー（応援・並べ替え・現在の目標・疑似時刻）撤去・`game-scoped` への viewerMode トグル追加。
-5. **blurb 実装** — `config/agents.json` に静的フィールド追加（両モード共通・別 Issue）。
+5. **blurb 実装** — `config/agents.json` に静的フィールド追加（両モード共通・別 Issue）。→ #519 で実装済み。
 
 ---
 

--- a/doc/GameData.md
+++ b/doc/GameData.md
@@ -136,7 +136,7 @@ AgentDetailScreen は現在 `stub/agentDetail.js` のデータのみを参照し
 
 | フィールド | 用途 | 現状 | 対応方針 |
 |---|---|---|---|
-| `persona_short`（blurb） | エージェントの1行プロフィール | ❌ `config/agents.json` に存在しない | `stub/agentDetail.js` の `AGENT_BLURB` スタブ固定。`config/agents.json` への追加が必要 |
+| blurb | エージェントの1行プロフィール | ✅ `config/agents.json` の `blurb`（英語）で実データ化済み（#519） | `fetchAgentConfig()` で fetch・`parseBlurb()` で抽出。fetch 失敗／未定義は `—` フォールバック。日本語化は将来の別 Issue（`persona_short` は使わない） |
 | 通算戦績（wins / games / cheers） | ヒーローヘッダーの統計表示 | ❌ アーカイブから集計されていない | `stub/agentDetail.js` の `AGENT_STATS` スタブ固定。#337 実データ集計で対応予定 |
 | 疑い・信頼スコア | 疑いマトリクス表示 | ❌ 実ログに存在しない | `getSuspicionMatrix()` が `charCodeAt` ベースのハッシュで生成。エージェントの `thought` から推定する設計が必要 |
 | 夜の行動ログ | 夜の行動タブ | ✅ `spectator_log.jsonl` に観戦者向けイベントとして存在 | `stub/agentDetail.js` の `NIGHT_ACTIONS` スタブ固定。実ログ接続が必要 |

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,7 +20,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#530 ❌ | enhancement | — | — | Establish design token usage rules & design-lint enforcement | #522 レビューで発覚したスタイル不統一が起点。トークン使用規約の明文化＋design lint 導入。idd は lint 通過のみ軽量ゲート、逸脱発見/tech-debt/リファクタは self-reflection-review |
-| yukkie/AgentVillage#519 ❌ | enhancement | — | — | Real-data blurb for AgentDetailScreen via config/agents.json | #515 の仕分け（§8.3 E 分割案5）から切り出し。AGENT_BLURB を config/agents.json の静的フィールド（まず英語）へ実データ化し、AgentDetailScreen 両モードで表示 |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | GameData registry | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#337 | enhancement | 🟡 | 2 | Top agents real stats | stub/gameList.js の TOP_AGENTS を実ゲーム結果の集計データに置き換え |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |

--- a/frontend/src/lib/archiveLoader.js
+++ b/frontend/src/lib/archiveLoader.js
@@ -129,6 +129,40 @@ export async function fetchGameStats() {
   return res.json();
 }
 
+// --- Agent config blurb (#519) ---
+
+// config/agents.json holds static, name-keyed agent metadata (style, occupation,
+// blurb …). Served by the /config middleware in vite.config.js (local dev only).
+// Replace with a FastAPI endpoint in production (#315).
+const AGENT_CONFIG_URL = '/config/agents.json';
+
+/**
+ * Look up an agent's static blurb (1-line profile) from config/agents.json.
+ * Returns null when the agent is absent or config is null/missing so the
+ * display side can fall back to a placeholder (AC-4). No placeholder string
+ * is baked in here to keep this pure and decoupled from the UI symbol.
+ *
+ * @param {{name: string, blurb?: string}[] | null} config - Parsed config/agents.json
+ * @param {string} name
+ * @returns {string | null}
+ */
+export function parseBlurb(config, name) {
+  if (!Array.isArray(config)) return null;
+  const entry = config.find(a => a.name === name);
+  return entry?.blurb ?? null;
+}
+
+/**
+ * Fetch and parse config/agents.json. Throws if the fetch fails.
+ *
+ * @returns {Promise<{name: string, blurb?: string}[]>}
+ */
+export async function fetchAgentConfig() {
+  const res = await fetch(AGENT_CONFIG_URL);
+  if (!res.ok) throw new Error(`Failed to fetch agent config: ${res.status}`);
+  return res.json();
+}
+
 /**
  * Fetch a single game entry by sessionId from state_archive/index.json.
  * Returns the raw index entry (including cast) for use by SpectatorScreen.

--- a/frontend/src/lib/archiveLoader.test.js
+++ b/frontend/src/lib/archiveLoader.test.js
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   parseIndexToGameList, parseEntryToGame, fetchGameBySessionId,
   parseGameStats, parseAllAgentNames, fetchGameStats,
+  parseBlurb, fetchAgentConfig,
 } from './archiveLoader.js';
 import { normalizeAgentJson } from '../legacy/normalizeAgentJson.js';
+import AGENT_CONFIG from '../../../config/agents.json';
 
 // --- fixture data ---
 
@@ -291,6 +293,95 @@ describe('parseAllAgentNames', () => {
     Objective: games が空のとき空配列を返すことを検証する
     */
     expect(parseAllAgentNames({ games: [] })).toEqual([]);
+  });
+});
+
+// --- parseBlurb / fetchAgentConfig（#519 blurb 実データ化） ---
+
+const CONFIG_FIXTURE = [
+  { name: 'Nox', style: 'cynical, detached, intelligent', blurb: 'Finds the frayed edge in every word, quiet as a moonless night.' },
+  { name: 'Mira', style: 'analytical, methodical, honest', blurb: 'Stands where instinct meets logic, smelling a lie before it lands.' },
+];
+
+describe('parseBlurb', () => {
+  it('pure: parseBlurb が name 一致の blurb を返す', () => {
+    /*
+    SUT: parseBlurb
+    Mock: なし
+    Level: unit
+    Objective: config 配列から name 一致エントリの blurb 文字列を返すことを検証する (AC-2/AC-3)
+    */
+    expect(parseBlurb(CONFIG_FIXTURE, 'Nox')).toBe('Finds the frayed edge in every word, quiet as a moonless night.');
+  });
+
+  it('pure: parseBlurb は未知 name に null を返す', () => {
+    /*
+    SUT: parseBlurb
+    Mock: なし
+    Level: unit
+    Objective: config に存在しない名前では null を返し、表示側のフォールバックに委ねることを検証する (AC-4)
+    */
+    expect(parseBlurb(CONFIG_FIXTURE, 'Unknown')).toBeNull();
+  });
+
+  it('pure: parseBlurb は config が null でも null を返す', () => {
+    /*
+    SUT: parseBlurb
+    Mock: なし
+    Level: unit
+    Objective: fetch 失敗で config が null のとき例外を投げず null を返すことを検証する (AC-4)
+    */
+    expect(parseBlurb(null, 'Nox')).toBeNull();
+  });
+});
+
+describe('agents.json blurb data', () => {
+  it('pure: agents.json の全エージェントに英語 blurb が存在する', () => {
+    /*
+    SUT: config/agents.json
+    Mock: なし
+    Level: unit
+    Objective: 全エージェントに非空の英語 blurb 文字列が存在することを検証する (AC-1)
+    */
+    expect(AGENT_CONFIG.length).toBeGreaterThan(0);
+    for (const agent of AGENT_CONFIG) {
+      expect(typeof agent.blurb).toBe('string');
+      expect(agent.blurb.trim().length).toBeGreaterThan(0);
+      // 英語版（ASCII のみ・日本語文字を含まない）であることを担保する
+      expect(/[　-鿿]/.test(agent.blurb)).toBe(false);
+    }
+  });
+});
+
+describe('fetchAgentConfig', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns parsed config/agents.json on success', async () => {
+    /*
+    SUT: fetchAgentConfig
+    Mock: global fetch（config/agents.json のレスポンスを固定）
+    Level: unit
+    Objective: fetch 成功時に config/agents.json をパースして返すことを検証する。
+    */
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(CONFIG_FIXTURE),
+    }));
+    const result = await fetchAgentConfig();
+    expect(result).toBe(CONFIG_FIXTURE);
+  });
+
+  it('throws when fetch fails', async () => {
+    /*
+    SUT: fetchAgentConfig
+    Mock: global fetch（ok:false）
+    Level: unit
+    Objective: fetch 失敗時に Error をスローすることを検証する (AC-4 fallback path)。
+    */
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    await expect(fetchAgentConfig()).rejects.toThrow('Failed to fetch agent config: 500');
   });
 });
 

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -6,10 +6,29 @@ import { FeedItem } from '../components/FeedCard.jsx';
 import TopBar, { TopBarBtn } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLES } from '../lib/constants.js';
-import { fetchGameStats, parseGameStats, parseAllAgentNames, fetchGameBySessionId } from '../lib/archiveLoader.js';
+import { fetchGameStats, parseGameStats, parseAllAgentNames, fetchGameBySessionId, fetchAgentConfig, parseBlurb } from '../lib/archiveLoader.js';
 import { fetchReplayGame } from '../lib/replayLoader.js';
 import { buildAgentDetailRoster, buildSuspicionMatrix, countAgentSpeeches } from '../lib/parseGameData.js';
 import styles from './AgentDetailScreen.module.css';
+
+// blurb（config/agents.json 由来の1行プロフィール・#519）が無い／fetch 失敗時のフォールバック表示。
+const BLURB_FALLBACK = '—';
+
+// blurb は viewerMode にもモード（global / game-scoped）にも依存しない名前依存の静的データ。
+// 戦績／リプレイの fetch チェーンに混ぜず独立して取得し、失敗しても本体描画を妨げない（AC-4）。
+function useAgentBlurb(agent) {
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAgentConfig()
+      .then(c => { if (!cancelled) setConfig(c); })
+      .catch(() => { if (!cancelled) setConfig(null); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return parseBlurb(config, agent) ?? BLURB_FALLBACK;
+}
 
 function viewerModeFromSearchParams(searchParams) {
   return searchParams.get('view') === 'public' ? 'public' : 'spectator';
@@ -51,7 +70,7 @@ function LeftPane({ current, sessionId, viewerMode = 'spectator', roster = [] })
 }
 
 // --- 中央: ヒーロー ---
-function AgentHero({ agent, agentData, speechCount, sessionMeta, currentDay, viewerMode = 'spectator' }) {
+function AgentHero({ agent, agentData, speechCount, sessionMeta, currentDay, viewerMode = 'spectator', blurb }) {
   const role = agentData?.role ?? null;
   const r = ROLES[role];
   const isPublic = viewerMode === 'public';
@@ -72,6 +91,7 @@ function AgentHero({ agent, agentData, speechCount, sessionMeta, currentDay, vie
             {isAlive ? `生存中 · Day ${currentDay || 0}` : `死亡 · Day ${currentDay || 0}`}
           </span>
         </div>
+        <p className={styles.heroBlurb}>{blurb}</p>
       </div>
       <div className={styles.heroStats}>
         <div className={styles.heroStat}>
@@ -233,7 +253,7 @@ function GlobalLeftPane({ allNames, current }) {
 
 // --- global ヒーロー: 名前・アバター・勝率・通算成績（AC-1 / AC-6） ---
 // 役職タグ・生死・session ラベルは出さない（AC-4）。
-function GlobalHero({ agent, stats }) {
+function GlobalHero({ agent, stats, blurb }) {
   const winPct = stats.total ? Math.round(stats.wins / stats.total * 100) : 0;
 
   return (
@@ -244,6 +264,7 @@ function GlobalHero({ agent, stats }) {
         <div className={styles.heroSub}>
           <span>通算 {stats.total} 戦 {stats.wins} 勝</span>
         </div>
+        <p className={styles.heroBlurb}>{blurb}</p>
       </div>
       <div className={styles.heroStats}>
         <div className={styles.heroStat}>
@@ -284,7 +305,7 @@ function GlobalHistory({ stats }) {
 }
 
 // --- global profile mode 本体（非同期 fetch・loading/error/empty を扱う・AC-7） ---
-function GlobalProfile({ agent }) {
+function GlobalProfile({ agent, blurb }) {
   const [state, setState] = useState({ status: 'loading', games: null });
 
   useEffect(() => {
@@ -311,7 +332,7 @@ function GlobalProfile({ agent }) {
         left={<GlobalLeftPane allNames={allNames} current={agent} />}
       >
         <div className={styles.mainPane}>
-          <GlobalHero agent={agent} stats={stats} />
+          <GlobalHero agent={agent} stats={stats} blurb={blurb} />
           <div className={styles.tabContent}>
             <GlobalHistory stats={stats} />
           </div>
@@ -335,6 +356,7 @@ export default function AgentDetailScreen() {
   const viewerMode = viewerModeFromSearchParams(searchParams);
   const viewerSearch = searchForViewerMode(viewerMode);
   const agent = agentName || 'Nox';
+  const blurb = useAgentBlurb(agent);
   const [gameScopedState, setGameScopedState] = useState({
     status: sessionId ? 'loading' : 'idle',
     entry: null,
@@ -364,7 +386,7 @@ export default function AgentDetailScreen() {
 
   // sessionId なし → global profile mode（横断戦績・実データ）
   if (!sessionId) {
-    return <GlobalProfile agent={agent} />;
+    return <GlobalProfile agent={agent} blurb={blurb} />;
   }
 
   const toggleViewerMode = () => {
@@ -411,6 +433,7 @@ export default function AgentDetailScreen() {
             sessionMeta={entry}
             currentDay={currentDay}
             viewerMode={viewerMode}
+            blurb={blurb}
           />
           <AgentDayTimeline
             agent={agent}

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -37,11 +37,36 @@ function mockFetchOk(data) {
   }));
 }
 
-function mockGameScopedFetch({ indexEntry, jsonlText, agentJsonByName }) {
+// global mode fetch mock: /stats/game_stats.json と /config/agents.json を出し分ける（#519）。
+// configBlurbs=null で blurb fetch だけ失敗させ、フォールバック（—）を検証する。
+function mockGlobalFetch({ stats, configBlurbs }) {
+  vi.stubGlobal('fetch', vi.fn(url => {
+    const path = String(url);
+    if (path === '/config/agents.json') {
+      return configBlurbs
+        ? Promise.resolve({ ok: true, json: () => Promise.resolve(configBlurbs) })
+        : Promise.resolve({ ok: false, status: 500 });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(stats) });
+  }));
+}
+
+// blurb fixture（config/agents.json 形状・#519）。fetch mock が /config/agents.json に返す。
+const CONFIG_FIXTURE = [
+  { name: 'Nox', blurb: 'Quiet as a moonless night, he finds the frayed edge in everything you say.' },
+  { name: 'Mira', blurb: 'Stands where instinct meets logic and smells a lie before it forms.' },
+];
+
+function mockGameScopedFetch({ indexEntry, jsonlText, agentJsonByName, configBlurbs = CONFIG_FIXTURE }) {
   vi.stubGlobal('fetch', vi.fn(url => {
     const path = String(url);
     if (path === '/state_archive/index.json') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve([indexEntry]) });
+    }
+    if (path === '/config/agents.json') {
+      return configBlurbs
+        ? Promise.resolve({ ok: true, json: () => Promise.resolve(configBlurbs) })
+        : Promise.resolve({ ok: false, status: 500 });
     }
     if (path.endsWith('/spectator_log.jsonl')) {
       return Promise.resolve({ ok: true, text: () => Promise.resolve(jsonlText) });
@@ -577,5 +602,50 @@ describe('AgentDetailScreen(global)', () => {
     await waitFor(() => {
       expect(screen.getByText(/読み込め|エラー/)).toBeTruthy();
     });
+  });
+});
+
+// --- blurb 実データ化（#519・両モード共通） ---
+
+describe('AgentDetailScreen blurb', () => {
+  it('統合: global mode が config の blurb をヒーローに表示する', async () => {
+    /*
+    SUT: AgentDetailScreen (global profile mode) GlobalHero blurb
+    Mock: global fetch（game_stats.json と config/agents.json を出し分ける）
+    Level: integration
+    Objective: global mode のヒーローが config/agents.json 由来の blurb を表示することを検証する (AC-2)
+    */
+    mockGlobalFetch({ stats: STATS_FIXTURE, configBlurbs: CONFIG_FIXTURE });
+    renderGlobal('/agent/Nox');
+
+    expect(await screen.findByText('Quiet as a moonless night, he finds the frayed edge in everything you say.')).toBeTruthy();
+  });
+
+  it('統合: game-scoped mode が config の blurb をヒーローに表示する', async () => {
+    /*
+    SUT: AgentDetailScreen (game-scoped mode) AgentHero blurb
+    Mock: global fetch（state_archive/index.json, spectator_log.jsonl, agents/*.json, config/agents.json を返す）
+    Level: integration
+    Objective: game-scoped mode のヒーローが config/agents.json 由来の blurb を表示することを検証する (AC-2)
+    */
+    mockGameScopedReplay();
+    renderGameScoped({ sessionId: 'session-real-001', agentName: 'Nox' });
+
+    expect(await screen.findByText('Quiet as a moonless night, he finds the frayed edge in everything you say.')).toBeTruthy();
+  });
+
+  it('統合: blurb fetch 失敗時もヒーロー本体を表示しフォールバックする', async () => {
+    /*
+    SUT: AgentDetailScreen (global profile mode) GlobalHero blurb fallback
+    Mock: global fetch（game_stats.json は成功・config/agents.json のみ失敗）
+    Level: integration
+    Objective: blurb fetch が失敗してもヒーロー本体（名前・勝率）を描画し、blurb は — にフォールバックすることを検証する (AC-4)
+    */
+    mockGlobalFetch({ stats: STATS_FIXTURE, configBlurbs: null });
+    renderGlobal('/agent/Nox');
+
+    expect(await screen.findByRole('heading', { name: 'Nox' })).toBeTruthy();
+    expect(screen.getByText('50%')).toBeTruthy();
+    expect(screen.getByText('—')).toBeTruthy();
   });
 });

--- a/frontend/stub/agentDetail.js
+++ b/frontend/stub/agentDetail.js
@@ -8,21 +8,7 @@ export { ROLE_ASSIGNMENT };
 export const ALL_AGENTS = ['Nox','Mira','Ren','Kai','Shiki','Rei','Sable','Sera','Kael','Sora','Toma'];
 export const DEAD_AGENTS = new Set(['Sora', 'Toma']);
 
-// エージェントごとの1行プロフィール（blurb）
-// TODO: config/agents.json の persona_short フィールドに移行予定（GameData ギャップ #312）
-export const AGENT_BLURB = {
-  Nox:   '静かな夜のように、相手の言葉のほつれを見つける。',
-  Mira:  '直感と論理の交差点に立ち、誰よりも早く嘘を嗅ぎ取る。',
-  Ren:   '軽やかな笑顔の裏に、緻密な計算が走り続けている。',
-  Kai:   '沈黙を武器に、最小の言葉で最大の混乱を生む。',
-  Shiki: '過去の言葉をすべて記憶し、矛盾を静かに暴く。',
-  Rei:   '仲間を守るために、自分が盾になることを厭わない。',
-  Sable: '流れを読み、空気を変える一言を知っている。',
-  Sera:  '誰もが信じる笑顔の下で、狩りの計画が動く。',
-  Kael:  '嘘の上に嘘を積み重ね、城を築く建築家。',
-  Sora:  '太陽のように人を照らし、嵐のようにかき乱す。',
-  Toma:  '正直すぎる言葉が、時に凶器になることを知らない。',
-};
+// blurb（1行プロフィール）は config/agents.json の blurb フィールドへ実データ化済み（#519）。
 
 // エージェントごとの通算戦績（スタブ）
 export const AGENT_STATS = {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,7 @@ import fs from 'fs';
 
 const ARCHIVE_DIR = path.resolve(__dirname, '../state_archive');
 const STATS_DIR = path.resolve(__dirname, '../state/stats');
+const CONFIG_DIR = path.resolve(__dirname, '../config');
 
 export default defineConfig({
   plugins: [
@@ -32,6 +33,22 @@ export default defineConfig({
       configureServer(server) {
         server.middlewares.use('/stats', (req, res, next) => {
           const filePath = path.join(STATS_DIR, req.url);
+          if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+            res.setHeader('Content-Type', 'application/json');
+            fs.createReadStream(filePath).pipe(res);
+          } else {
+            next();
+          }
+        });
+      },
+    },
+    // Serve config/ as static files under /config/ (local dev only).
+    // agents.json blurb (#519 agent detail blurb). Replace with FastAPI in production (#315).
+    {
+      name: 'serve-config',
+      configureServer(server) {
+        server.middlewares.use('/config', (req, res, next) => {
+          const filePath = path.join(CONFIG_DIR, req.url);
           if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
             res.setHeader('Content-Type', 'application/json');
             fs.createReadStream(filePath).pipe(res);


### PR DESCRIPTION
## Summary
- `config/agents.json` の全15体に英語 `blurb` フィールドを追加（config にないキャラは style/occupation から新規生成）
- `archiveLoader.js` に `fetchAgentConfig()` / `parseBlurb()` を追加（fetch 境界に集約）
- `vite.config.js` に `/config` 静的配信ミドルウェアを追加
- `AgentDetailScreen` のヒーロー（`AgentHero` / `GlobalHero` 両方）に config 由来の blurb を表示
- `stub/agentDetail.js` の `AGENT_BLURB` を削除（screen から既に未 import だったため実行時影響なし）

## Implementation notes
- blurb fetch は既存の戦績/リプレイ fetch チェーンに混ぜず独立した `useAgentBlurb` フック（fetch 失敗が本体描画に影響しないよう分離・AC-4）
- `parseBlurb` は `Array.isArray` で null/非配列を弾き fallback を `—` に統一
- スタブ日本語と config の `style` が食い違うキャラ（Sora/Toma/Kael 等）は config を正とし新規英語 blurb を生成

## Test plan
- [x] `npm test` 310 tests パス（新規 contract テスト7本追加）
- [x] `npm run build` パス
- [x] `npm run test:coverage` 新規追加行はカバー済み
- [x] Playwright 目視: global mode `/agent/Nox` → blurb 表示 ✅
- [x] Playwright 目視: game-scoped mode `/game/.../agent/Nox` → blurb 表示 ✅
- [x] Playwright 目視: 未知エージェント → `—` フォールバック ✅
- [x] `grep AGENT_BLURB` → ゼロ件（AC-3）

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)