### PR TITLE
docs: sync issue #321 in Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -26,7 +26,7 @@
 | yukkie/AgentVillage#495 | enhancement | 🟢 | 3 | Log visibility classes and recipient-based authorization model | LIVE/プレイヤー参加に向け、可視性クラス×受信者権限の配信認可モデルを先行設計（ADR）。replay は全配信の特殊ケース |
 | yukkie/AgentVillage#319 | enhancement | 🟢 | 3 | LIVE spectator | state/ を tail して進行中ゲームを表示（将来フェーズ） |
 | yukkie/AgentVillage#364 | enhancement | 🟢 | 5 | introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
-| yukkie/AgentVillage#321 | enhancement | 🟢 | 2 | Unify config data as shared JSON (SSOT) | config/*.json を Python/JS 共有にして constants.js のハードコードを廃止 |
+| yukkie/AgentVillage#321 | enhancement | 🟢 | 3 | Move config/ under frontend/public and share role/agent JSON (SSOT) | config/ を frontend/public/config/ へ移動し Python/JS 共有 SSOT 化、constants.js のハードコードを廃止 |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
 | yukkie/AgentVillage#403 | enhancement | 🟢 | 2 | Add avatars to CO status and night action sections | CO状況・夜の行動セクションにアバターアイコンを追加しコンポーネント化 |
 | yukkie/AgentVillage#379 | enhancement | 🟢 | 3 | Add static type checking to frontend JS (JSDoc or TypeScript) | フィールド名ミスをエディタ/CIで検出できるようにする。スタブ撤廃（#318）以降に検討 |


### PR DESCRIPTION
Issue #321 の revise（タイトル変更・SP 2→3・config を frontend/public/config/ へ移動する方針へ更新）に合わせ、Ideas.md の該当行を同期する。

- タイトル: Unify config data as shared JSON (SSOT) → Move config/ under frontend/public and share role/agent JSON (SSOT)
- SP: 2 → 3
- 要約: frontend/public/config/ への移動方針を反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)