### PR TITLE
feat(frontend): connect win rate ranking to real stats

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -56,7 +56,7 @@ frontend/
 │   └── tokens.css      # デザイントークン（CSS Variables）
 ├── stub/               # Milestone 1 用スタブデータ（Milestone 2 で削除）
 │   ├── spectator.js    # EVENTS / ROLE_ASSIGNMENT / NIGHT_RESULTS 等
-│   ├── gameList.js     # TOP_AGENTS / VILLAGE_NAME_PRESETS（GAMES は #338 で削除済み、COMMUNITY_POSTS は #541 で削除済み）
+│   ├── gameList.js     # VILLAGE_NAME_PRESETS（GAMES は #338、COMMUNITY_POSTS は #541、TOP_AGENTS は #337 で削除済み）
 │   └── agentDetail.js  # ALL_AGENTS / THOUGHTS / NIGHT_ACTIONS 等
 ├── index.html
 ├── vite.config.js      # fs.allow でリポジトリルートへのアクセスを許可
@@ -225,7 +225,7 @@ stateDiagram-v2
     {+
       == SideWidgets (280px)
       {+
-        == 今週の勝率トップ (<section><ul><li>)
+        == 勝率ランキング (<section><ul><li> / 15人)
         1 | [Nox]  | 72%
         2 | [Kai]  | 68%
         3 | [Sera] | 64%
@@ -537,9 +537,9 @@ CSS Grid `grid-template-columns: var(--lcol) 1fr var(--rcol)` で 3 ペインを
 | `NewVillageForm` | 展開/収納トグル付きのゲーム作成フォーム。人数選択 → エージェント選択 → 作成ボタン |
 | `GameCard` | ゲーム1件のカード表示（タイトル / ロスターストリップ / 👁同時観戦数） |
 | `LeftPane` | サイドナビ（ルールのみ。#541 でマイページ / カテゴリ / 注目エージェントを削除） |
-| `RightPane` | サイドウィジェット（勝率トップのみ。#541 で次回開催 / コミュニティ投稿を削除） |
+| `RightPane` | サイドウィジェット（勝率ランキングのみ。#541 で次回開催 / コミュニティ投稿を削除、#337 で `game_stats.json` 実集計化） |
 
-データソース: `stub/gameList.js`（`TOP_AGENTS`, `VILLAGE_NAME_PRESETS`。`COMMUNITY_POSTS` は #541 で削除済み）。
+データソース: `state_archive/index.json`（ゲーム一覧）、`state/stats/game_stats.json`（右ペイン勝率ランキング）、`stub/gameList.js`（`VILLAGE_NAME_PRESETS` のみ。`COMMUNITY_POSTS` は #541、`TOP_AGENTS` は #337 で削除済み）。
 
 Semantic HTML: `GameCard` は自己完結したゲーム項目として `<article>`、サイドナビと複数項目を持つ右ウィジェットの項目群は `<ul><li>` で表現する。
 
@@ -755,7 +755,7 @@ Semantic HTML: `AgentHero` は画面内のエージェント見出しとして `
 | ファイル | 提供するデータ | 将来の差し替え先 |
 |---|---|---|
 | `stub/spectator.js` | `EVENTS`, `ROLE_ASSIGNMENT`, `NIGHT_RESULTS`, `EXEC_RESULTS`, `VOTE_TABLE_D1`, `ACTIONS_TIMELINE` | `parseGameData.js` 経由で `state_archive/{sessionId}/spectator_log.jsonl` をパース |
-| `stub/gameList.js` | `TOP_AGENTS`, `VILLAGE_NAME_PRESETS`（`GAMES` は #338 で削除済み、`COMMUNITY_POSTS` は #541 で削除済み） | `TOP_AGENTS` は #337 で実データ化予定 |
+| `stub/gameList.js` | `VILLAGE_NAME_PRESETS`（`GAMES` は #338、`COMMUNITY_POSTS` は #541、`TOP_AGENTS` は #337 で削除済み） | 新規村フォームの村名候補のみ。右ペイン勝率ランキングは `game_stats.json` から15人分を集計済み |
 | `stub/agentDetail.js` | `ALL_AGENTS`, `DEAD_AGENTS`, `AGENT_STATS`, `THOUGHTS`, `NIGHT_ACTIONS`（`AGENT_BLURB` は #519 で実データ化済み・削除） | モード別の項目仕分け・出所は §8.3（`game_stats.json` / `agents/*.json` / `spectator_log.jsonl` / `frontend/public/config/agents.json`） |
 
 ### 8.2 Milestone 2 移行計画

--- a/doc/GameData.md
+++ b/doc/GameData.md
@@ -44,13 +44,13 @@ Milestone 3（FastAPI / DB 導入後）に改めて対応方針を検討する�
 | ルール（標準11人 / 拡張15人 / 妖狐入り / 短期戦） | クリックしてもフィルターなし | 実データ化候補（`config/roles.json` 連動）。現行ラベルは roles.json と不整合のため実データ化は別途行う |
 | ~~マイページ（ホーム / ウォッチ中 / 履歴 / 自分のbot）~~ | ~~リンクなしのダミーナビ~~ | **削除済み（#541）** |
 | ~~カテゴリ（村人陣営勝 / 狼陣営勝 / 研究村 / 解説付き）~~ | ~~クリックしてもフィルターなし~~ | **削除済み（#541）** |
-| ~~注目エージェント / 勝率~~ | ~~`TOP_AGENTS` スタブ固定~~ | **削除済み（#541）** — 右ペイン「勝率トップ」に一本化 |
+| ~~注目エージェント / 勝率~~ | ~~`TOP_AGENTS` スタブ固定~~ | **削除済み（#541）** — 右ペイン「勝率ランキング」に一本化 |
 
 **右サイドウィジェット（RightPane）**
 
 | UI要素 | 現状 | 対応方針 |
 |---|---|---|
-| 🏆 今週の勝率トップ | `stub/gameList.js` の `TOP_AGENTS` スタブ固定 | #337 実データ集計で対応予定 |
+| 🏆 勝率ランキング | ✅ `state/stats/game_stats.json` の `players[].won` / 出場数から15人分を集計 | **実装済み（#337）** — `fetchGameStats()` / `parseWinRateRanking()` で右ペインに表示 |
 | ~~📅 次回開催（第14回「夜霧の灯台」）~~ | ~~完全ハードコード~~ | **削除済み（#541）** |
 | ~~📰 観戦コミュニティ~~ | ~~`COMMUNITY_POSTS` スタブ固定~~ | **削除済み（#541）** |
 
@@ -144,7 +144,7 @@ AgentDetailScreen は現在 `stub/agentDetail.js` のデータのみを参照し
 | フィールド | 用途 | 現状 | 対応方針 |
 |---|---|---|---|
 | blurb | エージェントの1行プロフィール | ✅ `frontend/public/config/agents.json` の `blurb`（英語）で実データ化済み（#519） | `/config/agents.json` を `fetchAgentConfig()` で fetch・`parseBlurb()` で抽出。fetch 失敗／未定義は `—` フォールバック。日本語化は将来の別 Issue（`persona_short` は使わない） |
-| 通算戦績（wins / games / cheers） | ヒーローヘッダーの統計表示 | ❌ アーカイブから集計されていない | `stub/agentDetail.js` の `AGENT_STATS` スタブ固定。#337 実データ集計で対応予定 |
+| 通算戦績（wins / games） | global profile mode のヒーローヘッダー統計表示 | ✅ `state/stats/game_stats.json` から集計済み | #522 で `fetchGameStats()` / `parseGameStats()` により実データ化済み。`cheers` はソーシャル要素のため実装対象外 |
 | 疑い・信頼スコア | 疑いマトリクス表示 | ❌ 実ログに存在しない | `getSuspicionMatrix()` が `charCodeAt` ベースのハッシュで生成。エージェントの `thought` から推定する設計が必要 |
 | 夜の行動ログ | 夜の行動タブ | ✅ `spectator_log.jsonl` に観戦者向けイベントとして存在 | `stub/agentDetail.js` の `NIGHT_ACTIONS` スタブ固定。実ログ接続が必要 |
 
@@ -186,7 +186,7 @@ AgentDetailScreen は現在 `stub/agentDetail.js` のデータのみを参照し
 
 | UI要素 | 現状 | 対応方針 |
 |---|---|---|
-| 戦績レコード（#9〜#13） | エージェントによらずハードコード5件 | #337 実データ集計で対応予定 |
+| 戦績レコード（#9〜#13） | global profile mode では `game_stats.json` 由来の実データ表示済み | #522 で実データ化済み。game-scoped mode では過去戦績タブを出さない |
 
 ---
 

--- a/doc/GameData.md
+++ b/doc/GameData.md
@@ -50,7 +50,7 @@ Milestone 3（FastAPI / DB 導入後）に改めて対応方針を検討する�
 
 | UI要素 | 現状 | 対応方針 |
 |---|---|---|
-| 🏆 勝率ランキング | ✅ `state/stats/game_stats.json` の `players[].won` / 出場数から15人分を集計 | **実装済み（#337）** — `fetchGameStats()` / `parseWinRateRanking()` で右ペインに表示 |
+| 🏆 勝率ランキング | ✅ `state/stats/game_stats.json` の `players[].won` / 出場数から15人分を集計 | **実装済み（#337）** — `fetchGameStats()` / `parseWinRateRanking()` で右ペインに表示。出場2試合未満は集計対象外 |
 | ~~📅 次回開催（第14回「夜霧の灯台」）~~ | ~~完全ハードコード~~ | **削除済み（#541）** |
 | ~~📰 観戦コミュニティ~~ | ~~`COMMUNITY_POSTS` スタブ固定~~ | **削除済み（#541）** |
 

--- a/frontend/src/lib/archiveLoader.js
+++ b/frontend/src/lib/archiveLoader.js
@@ -115,6 +115,42 @@ export function parseAllAgentNames(gamesJson) {
 }
 
 /**
+ * Build the GameListScreen win-rate ranking from game_stats.json.
+ *
+ * @param {{games: object[]} | null} gamesJson - Parsed game_stats.json
+ * @param {{limit?: number, minGames?: number}} options
+ * @returns {{name: string, wins: number, games: number, winRate: number}[]}
+ */
+export function parseWinRateRanking(gamesJson, { limit = 15, minGames = 2 } = {}) {
+  if (!Array.isArray(gamesJson?.games)) return [];
+
+  const byName = new Map();
+  for (const game of gamesJson.games) {
+    if (!Array.isArray(game.players)) continue;
+    for (const player of game.players) {
+      if (!player?.name) continue;
+      const current = byName.get(player.name) ?? { name: player.name, wins: 0, games: 0 };
+      current.games += 1;
+      if (player.won) current.wins += 1;
+      byName.set(player.name, current);
+    }
+  }
+
+  return [...byName.values()]
+    .filter(agent => agent.games >= minGames)
+    .map(agent => ({
+      ...agent,
+      winRate: Math.round((agent.wins / agent.games) * 100),
+    }))
+    .sort((a, b) =>
+      b.winRate - a.winRate ||
+      b.games - a.games ||
+      a.name.localeCompare(b.name)
+    )
+    .slice(0, limit);
+}
+
+/**
  * Fetch and parse game_stats.json. Throws if the fetch fails.
  *
  * @returns {Promise<{games: object[]}>}

--- a/frontend/src/lib/archiveLoader.test.js
+++ b/frontend/src/lib/archiveLoader.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   parseIndexToGameList, parseEntryToGame, fetchGameBySessionId,
-  parseGameStats, parseAllAgentNames, fetchGameStats,
+  parseGameStats, parseAllAgentNames, parseWinRateRanking, fetchGameStats,
   parseBlurb, fetchAgentConfig,
 } from './archiveLoader.js';
 import { normalizeAgentJson } from '../legacy/normalizeAgentJson.js';
@@ -293,6 +293,81 @@ describe('parseAllAgentNames', () => {
     Objective: games が空のとき空配列を返すことを検証する
     */
     expect(parseAllAgentNames({ games: [] })).toEqual([]);
+  });
+});
+
+describe('parseWinRateRanking', () => {
+  it('pure: parseWinRateRanking: game_stats players の won と出場数から minGames 以上の勝率ランキングを返す', () => {
+    /*
+    SUT: parseWinRateRanking
+    Mock: なし
+    Level: unit
+    Objective: game_stats.json の players[].won を name ごとに集計し、minGames 以上のエージェントだけを勝率順で返すことを検証する (AC-2/AC-3/AC-6)
+    */
+    const stats = {
+      games: [
+        {
+          game_id: 'g1',
+          players: [
+            { name: 'Nox', won: true },
+            { name: 'Kai', won: false },
+            { name: 'Mira', won: true },
+          ],
+        },
+        {
+          game_id: 'g2',
+          players: [
+            { name: 'Nox', won: false },
+            { name: 'Kai', won: true },
+            { name: 'Mira', won: true },
+          ],
+        },
+        {
+          game_id: 'g3',
+          players: [
+            { name: 'Nox', won: true },
+            { name: 'Kai', won: true },
+            { name: 'Solo', won: true },
+          ],
+        },
+      ],
+    };
+
+    expect(parseWinRateRanking(stats, { limit: 3, minGames: 2 })).toEqual([
+      { name: 'Mira', wins: 2, games: 2, winRate: 100 },
+      { name: 'Kai', wins: 2, games: 3, winRate: 67 },
+      { name: 'Nox', wins: 2, games: 3, winRate: 67 },
+    ]);
+  });
+
+  it('pure: parseWinRateRanking: デフォルトでは15人分の勝率ランキングを返す', () => {
+    /*
+    SUT: parseWinRateRanking
+    Mock: なし
+    Level: unit
+    Objective: 5人に絞らず、現行エージェント全員分（15人）の勝率を返すことを検証する (AC-1/AC-2)
+    */
+    const agents = Array.from({ length: 15 }, (_, i) => `Agent ${String(i + 1).padStart(2, '0')}`);
+    const stats = {
+      games: [
+        { game_id: 'g1', players: agents.map(name => ({ name, won: name === 'Agent 01' })) },
+        { game_id: 'g2', players: agents.map(name => ({ name, won: name === 'Agent 01' || name === 'Agent 02' })) },
+      ],
+    };
+
+    expect(parseWinRateRanking(stats)).toHaveLength(15);
+    expect(parseWinRateRanking(stats)[0]).toMatchObject({ name: 'Agent 01', winRate: 100 });
+  });
+
+  it('pure: parseWinRateRanking: 空または不正な game_stats では空ランキングを返す', () => {
+    /*
+    SUT: parseWinRateRanking
+    Mock: なし
+    Level: unit
+    Objective: games が空または欠落している場合に例外ではなく空配列を返し UI fallback に委ねることを検証する (AC-4)
+    */
+    expect(parseWinRateRanking({ games: [] })).toEqual([]);
+    expect(parseWinRateRanking(null)).toEqual([]);
   });
 });
 

--- a/frontend/src/screens/GameListScreen.jsx
+++ b/frontend/src/screens/GameListScreen.jsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 import Avatar, { AvatarButton } from '../components/Avatar.jsx';
 import TopBar, { TopBarBtn } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
-import { TOP_AGENTS, VILLAGE_NAME_PRESETS } from '../../stub/gameList.js';
-import { fetchGameList } from '../lib/archiveLoader.js';
+import { VILLAGE_NAME_PRESETS } from '../../stub/gameList.js';
+import { fetchGameList, fetchGameStats, parseWinRateRanking } from '../lib/archiveLoader.js';
 import { AGENT_PALETTE } from '../lib/constants.js';
 import styles from './GameListScreen.module.css';
 
@@ -184,23 +184,34 @@ function LeftPane() {
 }
 
 // === 右サイドウィジェット ===
-function RightPane() {
+function RightPane({ winRateRankingState }) {
   return (
     <div className={styles.sideWidgets}>
       <section className={styles.sideCard}>
-        <h5>🏆 今週の勝率トップ</h5>
-        <ul className={styles.sideList} aria-label="今週の勝率トップ">
-          {TOP_AGENTS.map(({ name, winRate }, i) => (
-            <li className={styles.rankRow} key={name}>
-              <Link to={`/agent/${encodeURIComponent(name)}`} className={styles.rankLink}>
-                <span className={styles.rank}>{i + 1}</span>
-                <Avatar name={name} size="xs" />
-                <span className={styles.rankName}>{name}</span>
-                <span className={styles.rankNum}>{winRate}%</span>
-              </Link>
-            </li>
-          ))}
-        </ul>
+        <h5>🏆 勝率ランキング</h5>
+        {winRateRankingState.status === 'loading' && (
+          <p className={styles.sideNote}>勝率を集計中…</p>
+        )}
+        {winRateRankingState.status === 'error' && (
+          <p className={styles.sideNote}>勝率を読み込めませんでした</p>
+        )}
+        {winRateRankingState.status === 'ready' && winRateRankingState.agents.length === 0 && (
+          <p className={styles.sideNote}>集計できる戦績がありません</p>
+        )}
+        {winRateRankingState.status === 'ready' && winRateRankingState.agents.length > 0 && (
+          <ul className={styles.sideList} aria-label="勝率ランキング">
+            {winRateRankingState.agents.map(({ name, winRate }, i) => (
+              <li className={styles.rankRow} key={name}>
+                <Link to={`/agent/${encodeURIComponent(name)}`} className={styles.rankLink}>
+                  <span className={styles.rank}>{i + 1}</span>
+                  <Avatar name={name} size="xs" />
+                  <span className={styles.rankName}>{name}</span>
+                  <span className={styles.rankNum}>{winRate}%</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
       </section>
     </div>
   );
@@ -211,11 +222,26 @@ export default function GameListScreen() {
   const [activeTab, setActiveTab] = useState('完了');
   const [games, setGames] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [winRateRankingState, setWinRateRankingState] = useState({ status: 'loading', agents: [] });
 
   useEffect(() => {
     fetchGameList()
       .then(setGames)
       .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchGameStats()
+      .then(stats => {
+        if (!cancelled) {
+          setWinRateRankingState({ status: 'ready', agents: parseWinRateRanking(stats) });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setWinRateRankingState({ status: 'error', agents: [] });
+      });
+    return () => { cancelled = true; };
   }, []);
 
   const visibleGames = filterGames(games, activeTab);
@@ -225,7 +251,12 @@ export default function GameListScreen() {
     <div className={styles.frame}>
       <TopBar crumbs={[{ label: 'r/agent-jinrou' }, { label: 'Live & Recent' }]} />
 
-      <ThreePaneLayout collapsibleLeft collapsibleRight left={<LeftPane />} right={<RightPane />}>
+      <ThreePaneLayout
+        collapsibleLeft
+        collapsibleRight
+        left={<LeftPane />}
+        right={<RightPane winRateRankingState={winRateRankingState} />}
+      >
         <div className={styles.listMain}>
           <NewVillageForm />
 

--- a/frontend/src/screens/GameListScreen.module.css
+++ b/frontend/src/screens/GameListScreen.module.css
@@ -283,6 +283,12 @@
   display: block;
 }
 
+.sideNote {
+  margin: 0;
+  font-size: 12px;
+  color: var(--tx-3);
+}
+
 .rankRow {
   display: flex;
   align-items: center;

--- a/frontend/src/screens/GameListScreen.test.jsx
+++ b/frontend/src/screens/GameListScreen.test.jsx
@@ -81,12 +81,8 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function mockGameList(games = [game]) {
+function mockGameList(games = [game], stats = statsFixture) {
   archiveLoader.fetchGameList.mockResolvedValue(games);
-  archiveLoader.fetchGameStats.mockResolvedValue(statsFixture);
-}
-
-function mockGameStats(stats = statsFixture) {
   archiveLoader.fetchGameStats.mockResolvedValue(stats);
 }
 
@@ -198,7 +194,7 @@ describe('GameListScreen real stats ranking（#337）', () => {
      * SUT: GameListScreen / RightPane
      * Mock: fetchGameList / fetchGameStats
      * Level: component
-     * Objective: 統計取得中・失敗時・空ランキング時に右ペインだけが fallback 表示になることを検証する (AC-4)
+     * Objective: 統計取得中・失敗時・空ランキング時に右ペインだけが fallback 表示になることを検証する (AC-5)
      */
     mockGameList();
     archiveLoader.fetchGameStats.mockImplementation(() => new Promise(() => {}));
@@ -212,8 +208,7 @@ describe('GameListScreen real stats ranking（#337）', () => {
     expect(await screen.findByText('勝率を読み込めませんでした')).toBeTruthy();
     cleanup();
 
-    mockGameList();
-    mockGameStats({ games: [] });
+    mockGameList([game], { games: [] });
     renderGameList();
     expect(await screen.findByText('集計できる戦績がありません')).toBeTruthy();
   });

--- a/frontend/src/screens/GameListScreen.test.jsx
+++ b/frontend/src/screens/GameListScreen.test.jsx
@@ -5,8 +5,10 @@ import userEvent from '@testing-library/user-event';
 import GameListScreen from './GameListScreen.jsx';
 import * as archiveLoader from '../lib/archiveLoader.js';
 
-vi.mock('../lib/archiveLoader.js', () => ({
+vi.mock('../lib/archiveLoader.js', async (importOriginal) => ({
+  ...(await importOriginal()),
   fetchGameList: vi.fn(),
+  fetchGameStats: vi.fn(),
 }));
 
 const game = {
@@ -37,6 +39,43 @@ const liveGame = {
   desc: '',
 };
 
+const rankingAgents = [
+  'Ada Lovelace',
+  'Kai',
+  'Mira',
+  'Nox',
+  'Sera',
+  'Rei',
+  'Haru',
+  'Toma',
+  'Lumi',
+  'Nana',
+  'Vael',
+  'Sora',
+  'Ren',
+  'Kael',
+  'Sable',
+];
+
+const statsFixture = {
+  games: [
+    {
+      game_id: 'g1',
+      players: rankingAgents.map(name => ({
+        name,
+        won: name === 'Ada Lovelace' || name === 'Kai',
+      })),
+    },
+    {
+      game_id: 'g2',
+      players: rankingAgents.map(name => ({
+        name,
+        won: name === 'Ada Lovelace',
+      })),
+    },
+  ],
+};
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -44,6 +83,11 @@ afterEach(() => {
 
 function mockGameList(games = [game]) {
   archiveLoader.fetchGameList.mockResolvedValue(games);
+  archiveLoader.fetchGameStats.mockResolvedValue(statsFixture);
+}
+
+function mockGameStats(stats = statsFixture) {
+  archiveLoader.fetchGameStats.mockResolvedValue(stats);
 }
 
 function renderGameList() {
@@ -95,7 +139,7 @@ describe('GameListScreen list semantics', () => {
      * SUT: GameListScreen / LeftPane / RightPane
      * Mock: fetchGameList（state_archive index の取得を固定）
      * Level: component
-     * Objective: 左サイドナビ（ルールのみ）と右ウィジェット（勝率トップのみ）の項目群が list/listitem role で特定できることを検証する。
+     * Objective: 左サイドナビ（ルールのみ）と右ウィジェット（勝率ランキングのみ）の項目群が list/listitem role で特定できることを検証する。
      */
     mockGameList();
 
@@ -106,26 +150,72 @@ describe('GameListScreen list semantics', () => {
     expect(within(sideNav).getAllByRole('list').length).toBeGreaterThanOrEqual(1);
     expect(within(sideNav).getAllByRole('listitem').length).toBeGreaterThanOrEqual(4);
 
-    const ranking = screen.getByRole('list', { name: '今週の勝率トップ' });
-    expect(within(ranking).getAllByRole('listitem')).toHaveLength(5);
+    const ranking = await screen.findByRole('list', { name: '勝率ランキング' });
+    expect(within(ranking).getAllByRole('listitem')).toHaveLength(15);
   });
 
-  it('renders agent links to /agent/:agentName in ranking only', async () => {
+  it('統合: GameListScreen: 勝率ランキングの行は encodeURIComponent した /agent/:name リンクを維持する', async () => {
     /*
      * SUT: GameListScreen / RightPane
-     * Mock: fetchGameList
+     * Mock: fetchGameList / fetchGameStats
      * Level: component
-     * Objective: 右ペイン「勝率トップ」が /agent/:name へのリンクを持つことを検証する（注目エージェント削除後、勝率トップのみが agent リンクを持つ）。
+     * Objective: 右ペイン「勝率ランキング」が encodeURIComponent した /agent/:name へのリンクを持つことを検証する (AC-5)
      */
     mockGameList();
 
     renderGameList();
-    await screen.findByRole('article', { name: '20260510_102927' });
+    const ranking = await screen.findByRole('list', { name: '勝率ランキング' });
 
-    const agentLinks = screen.getAllByRole('link').filter(
-      l => l.getAttribute('href')?.startsWith('/agent/')
-    );
-    expect(agentLinks.length).toBeGreaterThan(0);
+    const adaLink = within(ranking).getByRole('link', { name: /Ada Lovelace/ });
+    expect(adaLink.getAttribute('href')).toBe('/agent/Ada%20Lovelace');
+  });
+});
+
+describe('GameListScreen real stats ranking（#337）', () => {
+  it('統合: GameListScreen: 勝率ランキングは fetchGameStats 由来の15人分を表示し TOP_AGENTS 固定値を表示しない', async () => {
+    /*
+     * SUT: GameListScreen / RightPane
+     * Mock: fetchGameList / fetchGameStats
+     * Level: component
+     * Objective: TOP_AGENTS スタブではなく game_stats.json 由来の15人分のランキング順と勝率が表示されることを検証する (AC-1/AC-7)
+     */
+    mockGameList();
+    renderGameList();
+
+    const ranking = await screen.findByRole('list', { name: '勝率ランキング' });
+    const rows = within(ranking).getAllByRole('listitem');
+
+    expect(rows).toHaveLength(15);
+    expect(within(rows[0]).getByText('Ada Lovelace')).toBeTruthy();
+    expect(within(rows[0]).getByText('100%')).toBeTruthy();
+    expect(within(rows[1]).getByText('Kai')).toBeTruthy();
+    expect(within(rows[1]).getByText('50%')).toBeTruthy();
+    expect(within(ranking).queryByText('72%')).toBeNull();
+  });
+
+  it('統合: GameListScreen: 勝率ランキングの loading/error/empty fallback を表示する', async () => {
+    /*
+     * SUT: GameListScreen / RightPane
+     * Mock: fetchGameList / fetchGameStats
+     * Level: component
+     * Objective: 統計取得中・失敗時・空ランキング時に右ペインだけが fallback 表示になることを検証する (AC-4)
+     */
+    mockGameList();
+    archiveLoader.fetchGameStats.mockImplementation(() => new Promise(() => {}));
+    const { unmount } = renderGameList();
+    expect(screen.getByText('勝率を集計中…')).toBeTruthy();
+    unmount();
+
+    mockGameList();
+    archiveLoader.fetchGameStats.mockRejectedValue(new Error('boom'));
+    renderGameList();
+    expect(await screen.findByText('勝率を読み込めませんでした')).toBeTruthy();
+    cleanup();
+
+    mockGameList();
+    mockGameStats({ games: [] });
+    renderGameList();
+    expect(await screen.findByText('集計できる戦績がありません')).toBeTruthy();
   });
 });
 
@@ -173,18 +263,18 @@ describe('GameListScreen stub UI 削除（AC-1〜AC-4）', () => {
     expect(within(nav).queryByText('注目エージェント')).toBeNull();
   });
 
-  it('統合: RightPane は勝率トップのみ残し次回開催・観戦コミュニティを表示しない', async () => {
+  it('統合: RightPane は勝率ランキングのみ残し次回開催・観戦コミュニティを表示しない', async () => {
     /*
      * SUT: GameListScreen / RightPane
      * Mock: fetchGameList
      * Level: component
-     * Objective: #541 で削除した RightPane セクションが存在せず、勝率トップが残ることを検証する (AC-3)
+     * Objective: #541 で削除した RightPane セクションが存在せず、勝率ランキングが残ることを検証する (AC-3)
      */
     mockGameList();
     renderGameList();
     await screen.findByRole('article', { name: '20260510_102927' });
 
-    expect(screen.getByRole('list', { name: '今週の勝率トップ' })).toBeTruthy();
+    expect(screen.getByRole('list', { name: '勝率ランキング' })).toBeTruthy();
     expect(screen.queryByText(/次回開催/)).toBeNull();
     expect(screen.queryByRole('list', { name: '観戦コミュニティ' })).toBeNull();
   });

--- a/frontend/stub/gameList.js
+++ b/frontend/stub/gameList.js
@@ -1,17 +1,9 @@
 // ゲーム一覧画面 スタブデータ
 // GAMES は state_archive/index.json から動的に生成されるため削除済み (#338)
-
-export const TOP_AGENTS = [
-  { name: 'Nox', winRate: 72 },
-  { name: 'Kai', winRate: 68 },
-  { name: 'Sera', winRate: 64 },
-  { name: 'Rei', winRate: 61 },
-  { name: 'Mira', winRate: 58 },
-];
+// TOP_AGENTS は state/stats/game_stats.json から動的に集計するため削除済み (#337)
 
 export const VILLAGE_NAME_PRESETS = [
   '桜霞', '黎明の小径', '霜降る塔', '黒鏡の湖', '灰色の朝',
   '暁の森', '夜霧の灯台', '蒼穹の丘', '残雪の庭', '星詠みの里',
   '朱鷺色の夕', '月影の渚', '雪解けの道', '風薫る谷', '銀霧の廊',
 ];
-


### PR DESCRIPTION
## Summary

- Replace the fixed `TOP_AGENTS` right-pane data with `game_stats.json` aggregation via `fetchGameStats()`.
- Rename the widget to `勝率ランキング` and display the current 15-agent ranking instead of limiting it to 5 entries.
- Add loading/error/empty fallbacks, preserve `/agent/${encodeURIComponent(name)}` links, and update frontend docs for the new data source.

Closes #337

## Verification

- `npm.cmd test -- src/lib/archiveLoader.test.js src/screens/GameListScreen.test.jsx`
- `npm.cmd test`
- `npm.cmd run test:coverage` (lines 94.8%)
- `npm.cmd run build`
- `git diff --check`
- `uv run ruff check .`
- `uv run pytest`
- Browser check: `http://localhost:5173/` shows `🏆 勝率ランキング` with ranks 1-15.