### PR TITLE
fix: show agent actual death day in AgentDetail hero (#535)

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -636,6 +636,8 @@ SpectatorScreen から AgentDetailScreen への遷移、および AgentDetailScr
 
 データソース: `game_stats.json` / `agents/*.json` / `spectator_log.jsonl` / `frontend/public/config/agents.json`（§8.3 参照）。`stub/agentDetail.js` は #547 で削除済み。blurb（1行プロフィール）は `frontend/public/config/agents.json` の `blurb` フィールドを `/config/agents.json` として fetch（#519）。
 
+**死亡日表示（#535）**: `AgentHero` の `死亡 · Day N` の `N` は、ゲーム最終日ではなく**当該エージェントの死亡日**を使う。死亡日は `computeDeadByDay(events)` の**最終日の累積 Map** から `deadByDay[visibleDays.at(-1)]?.get(name)?.day` で引く（SpectatorScreen `RightPane` が `deadByDay[activeDay]` を直読みするのと同じパターン。AgentDetail は日タブに依存せず最終的な死亡状態を見るため最終日 Map を使う）。死亡イベント欠落で引けない場合は現在日（最終日）へフォールバックする。生存中エージェントの `生存中 · Day N` は従来どおり現在日を使う。
+
 Semantic HTML: `AgentHero` は画面内のエージェント見出しとして `<header>`、AgentPicker・推論ログ・夜行動・過去戦績・疑い度マトリクスの行群は `<ul><li>` で表現する。picker 行の clickable 化は React Router 導入時（#342）に `<a>` / `<Link>` として扱う。
 
 ### 6.3 セマンティック HTML 設計方針（#411）

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,7 +19,6 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
-| yukkie/AgentVillage#535 | bug | 🔴 | 2 | AgentDetailScreen game-scoped: 死亡日が「ゲーム最終日」で表示される不具合 | 死亡エージェントの hero 表示がゲーム最終日を死亡日として表示してしまう不具合。spectator_log.jsonl の死亡イベントから死亡日を算出する |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#530 | enhancement | 🟡 | 8 | Establish design token usage rules & design-lint enforcement | #522 レビューで発覚したスタイル不統一が起点。トークン使用規約の明文化＋design lint 導入。idd は lint 通過のみ軽量ゲート、逸脱発見/tech-debt/リファクタは self-reflection-review |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -8,7 +8,7 @@ import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLE_META_BY_KEY } from '../lib/roleMeta.js';
 import { fetchGameStats, parseGameStats, parseAllAgentNames, fetchGameBySessionId, fetchAgentConfig, parseBlurb } from '../lib/archiveLoader.js';
 import { fetchReplayGame } from '../lib/replayLoader.js';
-import { buildAgentDetailRoster, buildSuspicionMatrix, countAgentSpeeches } from '../lib/parseGameData.js';
+import { buildAgentDetailRoster, buildSuspicionMatrix, countAgentSpeeches, computeDeadByDay } from '../lib/parseGameData.js';
 import styles from './AgentDetailScreen.module.css';
 
 // blurb（frontend/public/config/agents.json 由来の1行プロフィール・#519）が無い／fetch 失敗時のフォールバック表示。
@@ -70,7 +70,7 @@ function LeftPane({ current, sessionId, viewerMode = 'spectator', roster = [] })
 }
 
 // --- 中央: ヒーロー ---
-function AgentHero({ agent, agentData, speechCount, sessionMeta, currentDay, viewerMode = 'spectator', blurb }) {
+function AgentHero({ agent, agentData, speechCount, sessionMeta, currentDay, deathDay, viewerMode = 'spectator', blurb }) {
   const role = agentData?.role ?? null;
   const r = ROLE_META_BY_KEY[role];
   const isPublic = viewerMode === 'public';
@@ -88,7 +88,7 @@ function AgentHero({ agent, agentData, speechCount, sessionMeta, currentDay, vie
           {!isPublic && r && <span>所属: <strong style={{ color: 'var(--tx-2)' }}>{teamLabel}</strong></span>}
           <span>{sessionLabel}</span>
           <span style={{ color: isAlive ? 'var(--alive)' : 'var(--dead)' }}>
-            {isAlive ? `生存中 · Day ${currentDay || 0}` : `死亡 · Day ${currentDay || 0}`}
+            {isAlive ? `生存中 · Day ${currentDay || 0}` : `死亡 · Day ${deathDay ?? currentDay ?? 0}`}
           </span>
         </div>
         <p className={styles.heroBlurb}>{blurb}</p>
@@ -414,6 +414,10 @@ export default function AgentDetailScreen() {
     const speechCount = countAgentSpeeches(events, agent);
     const visibleDays = [...new Set(events.map(ev => ev.day).filter(Boolean))].sort((a, b) => a - b);
     const currentDay = entry?.days ?? visibleDays.at(-1) ?? 0;
+    // 死亡日は computeDeadByDay の最終日累積 Map から引く（SpectatorScreen RightPane と同パターン・#535）。
+    // 死亡イベント欠落で引けなければ undefined → AgentHero が currentDay にフォールバックする（AC-4）。
+    const deadByDay = computeDeadByDay(events);
+    const deathDay = deadByDay[visibleDays.at(-1)]?.get(agent)?.day;
     const roleAssignment = Object.fromEntries(
       Object.entries(agents).map(([name, data]) => [name, data.role])
     );
@@ -432,6 +436,7 @@ export default function AgentDetailScreen() {
             speechCount={speechCount}
             sessionMeta={entry}
             currentDay={currentDay}
+            deathDay={deathDay}
             viewerMode={viewerMode}
             blurb={blurb}
           />

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -358,6 +358,56 @@ describe('AgentDetailScreen game-scoped real data', () => {
   });
 });
 
+// --- 死亡日表示（#535）: hero の「死亡 · Day N」が当該エージェントの死亡日を出す ---
+describe('AgentDetailScreen game-scoped death day', () => {
+  // 最終日 Day 2 まで続くゲーム。Mira は Day 1 に elimination で死亡（agent JSON も is_alive:false で整合）。
+  // Kai は is_alive:false だが log に死亡イベントが無い（AC-4 のフォールバックケース）。
+  const DEATH_DAY_INDEX = { session_id: 'session-death-001', title: '死亡日村', days: 2, cast: ['Nox', 'Mira', 'Kai'] };
+  const DEATH_DAY_JSONL = [
+    { id: 's1', day: 1, event_type: 'speech', agent: 'Mira', speech_id: 1, content: 'Mira speaks', is_public: true },
+    { id: 'e1', day: 1, event_type: 'elimination', agent: 'Mira', content: 'Mira was eliminated', is_public: true },
+    { id: 's2', day: 2, event_type: 'speech', agent: 'Nox', speech_id: 2, content: 'Nox speaks', is_public: true },
+  ].map(e => JSON.stringify(e)).join('\n');
+  const DEATH_DAY_AGENTS = {
+    Nox: { profile: { name: 'Nox', model: 'm', persona: {} }, state: { is_alive: true, beliefs: {}, claimed_role: null }, role: 'Villager' },
+    Mira: { profile: { name: 'Mira', model: 'm', persona: {} }, state: { is_alive: false, beliefs: {}, claimed_role: null }, role: 'Villager' },
+    Kai: { profile: { name: 'Kai', model: 'm', persona: {} }, state: { is_alive: false, beliefs: {}, claimed_role: null }, role: 'Werewolf' },
+  };
+
+  function mockDeathDayReplay() {
+    mockGameScopedFetch({ indexEntry: DEATH_DAY_INDEX, jsonlText: DEATH_DAY_JSONL, agentJsonByName: DEATH_DAY_AGENTS });
+  }
+
+  it('game-scoped hero shows the agent actual death day, not the game last day', async () => {
+    /*
+     * SUT: AgentDetailScreen (game-scoped mode) AgentHero
+     * Mock: global fetch（state_archive/index.json, spectator_log.jsonl, agents/*.json を返す）
+     * Level: integration
+     * Objective: Day 1 に死亡し最終日 Day 2 まで続くゲームで、死亡エージェントの hero が「死亡 · Day 1」を表示することを検証する (AC-1)
+     */
+    mockDeathDayReplay();
+    renderGameScoped({ sessionId: 'session-death-001', agentName: 'Mira' });
+
+    await screen.findByRole('heading', { name: 'Mira' });
+    expect(screen.getByText(/死亡 · Day 1/)).toBeTruthy();
+    expect(screen.queryByText(/死亡 · Day 2/)).toBeNull();
+  });
+
+  it('game-scoped hero falls back to the last day when no death event exists', async () => {
+    /*
+     * SUT: AgentDetailScreen (game-scoped mode) AgentHero
+     * Mock: global fetch（state_archive/index.json, spectator_log.jsonl, agents/*.json を返す）
+     * Level: integration
+     * Objective: is_alive:false だが log に死亡イベントが無いエージェントでも、クラッシュせず最終日（Day 2）にフォールバック表示することを検証する (AC-4)
+     */
+    mockDeathDayReplay();
+    renderGameScoped({ sessionId: 'session-death-001', agentName: 'Kai' });
+
+    await screen.findByRole('heading', { name: 'Kai' });
+    expect(screen.getByText(/死亡 · Day 2/)).toBeTruthy();
+  });
+});
+
 describe('AgentDetailScreen game-scoped day timeline', () => {
   it('game-scoped renders day tabs and switches the agent timeline day', async () => {
     /*


### PR DESCRIPTION
## Summary
- AgentDetail game-scoped の hero が表示する `死亡 · Day N` の `N` を、ゲーム最終日ではなく**当該エージェントの死亡日**にする。
- 死亡日は既存の `computeDeadByDay(events)` の**最終日累積 Map** から `deadByDay[visibleDays.at(-1)]?.get(name)?.day` で引く（SpectatorScreen `RightPane` が `deadByDay[activeDay]` を直読みするのと同じパターン）。
- 死亡イベント（`elimination` / 非公開 `night_attack`）が log に無く死亡日を引けない場合は、現在日（最終日）へフォールバックする。
- 生存中エージェントの `生存中 · Day N` は従来どおり現在日を使う（リグレッションなし）。
- `doc/FrontendDesign.md` の AgentDetailScreen 節に「死亡日表示」の仕様を追記（この読み口が未明文化だったため）。

## Implementation notes
- 新関数は追加せず、SpectatorScreen RightPane と同じ `computeDeadByDay` 直読みパターンに揃えた。
- follow-up（tech-debt）として、`computeDeadByDay` が表示ロジックに引きずられた返り値構造（`{ [day]: Map }`）になっている点を整理し、`deathDayOf(events, name)` 系の純粋アクセサへ切り出して AgentDetail / SpectatorScreen RightPane の呼び側を簡潔化する issue を別途起票予定。

## Test plan
- [x] `pytest` パス（pre-commit）
- [x] `npm test` パス（333 tests）／`npm run test:coverage` パス（pre-commit）
- [x] AC-1: Day1 死亡・最終日Day2 fixture で hero が `死亡 · Day 1` を表示する統合テスト
- [x] AC-4: 死亡イベント欠落エージェントが最終日へフォールバックする統合テスト
- [x] AC-3: 既存 `生存中 · Day 2` テスト維持（リグレッションなし）
- [x] Playwright 目視（作成者が実行・実アーカイブ `20260524_194759`／全8日）:
  - Day1 に死亡した `Sera` の hero が `死亡 · Day 1` を表示（修正前は `死亡 · Day 8` 相当の誤表示）
  - 最終日まで生存した `Kai` の hero が `生存中 · Day 8` を表示
  - ※ レビュアーはリモート環境のためブラウザ確認不可。上記は作成者環境での確認結果。

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)