### PR TITLE
refactor: replace death-day accessor

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -122,7 +122,7 @@ React Router v7 を導入済み。`App.jsx` は `Routes`/`Route` でルートを
 | `aggregateDaySummary` | 日別タイムライン・右ペイン表示に必要なサマリを単一ソースとして作る。旧 `aggregateDayResults` と `aggregateDayActions` の責務を統合する | raw `LogEvent[]` | `{ [day]: { speechCount, nightDone, nightActions, execResult } }` | private `night_attack` は `nightActions` に含める。public `night_attack` は夜明け結果の公知イベントなので `nightActions` には入れず、`nightDone` 判定だけに使う。public `elimination` は `execResult.target` に使う |
 | `aggregateCoStatus` | CO 状況を agent 名から claimed role へ引く map にする。日別表示では `upToDay` までを累積する | normalized `LogEvent[]`, optional `upToDay` | `{ [agentName]: claimed_role }` | `speech` イベントの `claimed_role` を正とする（CO は speech に統合）。旧ログの `co_announcement` 別行は read 側フォールバックで同様に扱う。`is_public` でフィルタしない |
 | `aggregateNightResults` | private 夜襲ログから日別の襲撃先を取り出す。後方互換の派生データ | raw `LogEvent[]` | `{ [day]: { attacked } }` | private `night_attack` の `target` のみ使う。public `night_attack` はログ生成側の agent/target 揺れを避けるため無視する |
-| `computeDeadByDay` | 各日終了時点の累積死亡者 map を作る | raw または normalized `LogEvent[]` | `{ [day]: Map<agentName, { day, content }> }` | `elimination` は死亡として扱う。private `night_attack` は死亡候補として扱い、同日同 target の private `guard_block` があれば除外する。public `night_attack` は使わない |
+| `deathsByAgent` / `deathDayOf` | log から死亡者ごとの死亡日・死因を引くドメイン寄りのアクセサ。`deathDayOf` は死亡日だけを返す薄い wrapper | raw または normalized `LogEvent[]` | `{ [agentName]: { day, cause, content } }` / `day \| -1` | 死亡確定イベントとして public `night_attack` と `elimination` のみを読む。private `night_attack` / `guard_block` は死亡判定に使わない |
 | `buildActionsTimeline` | 夜行動・処刑を横断的なアクション履歴に平坦化する | raw `LogEvent[]` | `[{ day, when, kind, who, target, label }]` | private `night_attack` は人狼視点の行動として含める。public `night_attack` は村への結果告知なので除外する。public `elimination` は処刑アクションとして含める |
 
 `daySummary` は `SpectatorScreen` の左右ペインで共有する日別データ名とする。`nightActions` や `execResult` のような行動系フィールドも `daySummary` 配下に置き、左ペインと右ペインが別々の集計結果を参照して表示ずれを起こさないようにする。
@@ -636,7 +636,7 @@ SpectatorScreen から AgentDetailScreen への遷移、および AgentDetailScr
 
 データソース: `game_stats.json` / `agents/*.json` / `spectator_log.jsonl` / `frontend/public/config/agents.json`（§8.3 参照）。`stub/agentDetail.js` は #547 で削除済み。blurb（1行プロフィール）は `frontend/public/config/agents.json` の `blurb` フィールドを `/config/agents.json` として fetch（#519）。
 
-**死亡日表示（#535）**: `AgentHero` の `死亡 · Day N` の `N` は、ゲーム最終日ではなく**当該エージェントの死亡日**を使う。死亡日は `computeDeadByDay(events)` の**最終日の累積 Map** から `deadByDay[visibleDays.at(-1)]?.get(name)?.day` で引く（SpectatorScreen `RightPane` が `deadByDay[activeDay]` を直読みするのと同じパターン。AgentDetail は日タブに依存せず最終的な死亡状態を見るため最終日 Map を使う）。死亡イベント欠落で引けない場合は現在日（最終日）へフォールバックする。生存中エージェントの `生存中 · Day N` は従来どおり現在日を使う。
+**死亡日表示（#535 / #554）**: `AgentHero` の `死亡 · Day N` の `N` は、ゲーム最終日ではなく**当該エージェントの死亡日**を使う。死亡日は `deathDayOf(events, name)` で public `night_attack` / `elimination` 由来の死亡確定イベントから引く。死亡イベント欠落で `-1` が返った場合は現在日（最終日）へフォールバックする。生存中エージェントの `生存中 · Day N` は従来どおり現在日を使う。
 
 Semantic HTML: `AgentHero` は画面内のエージェント見出しとして `<header>`、AgentPicker・推論ログ・夜行動・過去戦績・疑い度マトリクスの行群は `<ul><li>` で表現する。picker 行の clickable 化は React Router 導入時（#342）に `<a>` / `<Link>` として扱う。
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -22,7 +22,6 @@
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#530 | enhancement | 🟡 | 8 | Establish design token usage rules & design-lint enforcement | #522 レビューで発覚したスタイル不統一が起点。トークン使用規約の明文化＋design lint 導入。idd は lint 通過のみ軽量ゲート、逸脱発見/tech-debt/リファクタは self-reflection-review |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
-| yukkie/AgentVillage#554 | tech-debt | 🟡 | 3 | refactor: replace computeDeadByDay with pure death-day accessor | ❌ PR #553/#535 派生。computeDeadByDay が表示ロジックに引きずられ、かつ死を private night_attack×guard_block で再導出している。public night_attack+elimination 読みの deathsByAgent / deathDayOf を切り出し AgentDetail・SpectatorScreen RightPane を移行、computeDeadByDay を削除 |
 | yukkie/AgentVillage#495 | enhancement | 🟢 | 3 | design: log visibility classes and recipient-based authorization model (for LIVE / player participation) | LIVE/プレイヤー参加に向け、可視性クラス×受信者権限の配信認可モデルを先行設計（ADR）。replay は全配信の特殊ケース |
 | yukkie/AgentVillage#319 | enhancement | 🟢 | 3 | feat(frontend): LIVE spectator (real-time view of in-progress game) | state/ を tail して進行中ゲームを表示（将来フェーズ） |
 | yukkie/AgentVillage#364 | enhancement | 🟢 | 5 | refactor: introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |

--- a/frontend/src/lib/parseGameData.js
+++ b/frontend/src/lib/parseGameData.js
@@ -261,55 +261,35 @@ export function aggregateCoStatus(events, upToDay) {
 }
 
 /**
- * Build a cumulative dead-map per day from elimination and night_attack events.
- *
- * Returns a map from day number → Map<agentName, { day: number, content: string }>.
- * Days with no new deaths inherit the previous day's map so callers can simply
- * do `deadByDay[activeDay]?.has(name)` or `.get(name)` without caring about history.
+ * Build death records by agent from public death-confirmation events.
  *
  * @param {object[]} events
- * @returns {Record<number, Map<string, { day: number, content: string }>>}
+ * @returns {Record<string, { day: number, cause: 'attack'|'elimination', content: string }>}
  */
-export function computeDeadByDay(events) {
-  const dayNumbers = [...new Set(events.map(ev => ev.day).filter(Boolean))].sort((a, b) => a - b);
-  if (dayNumbers.length === 0) return {};
+export function deathsByAgent(events) {
+  const result = {};
 
-  const deathsByDay = {};
-  const guardBlocksByDay = {};
   for (const ev of events) {
     if (!ev.day) continue;
-    if (ev.event_type === 'elimination' && ev.agent) {
-      if (!deathsByDay[ev.day]) deathsByDay[ev.day] = [];
-      deathsByDay[ev.day].push({ name: ev.agent, day: ev.day, content: ev.content ?? '' });
-    } else if (ev.event_type === 'night_attack' && !ev.is_public && ev.target) {
-      if (!deathsByDay[ev.day]) deathsByDay[ev.day] = [];
-      deathsByDay[ev.day].push({ name: ev.target, day: ev.day, content: ev.content ?? '', isNightAttack: true });
-    } else if (ev.event_type === 'guard_block' && !ev.is_public && ev.target) {
-      if (!guardBlocksByDay[ev.day]) guardBlocksByDay[ev.day] = new Set();
-      guardBlocksByDay[ev.day].add(ev.target);
+    if (ev.event_type === 'elimination' && ev.agent && !result[ev.agent]) {
+      result[ev.agent] = { day: ev.day, cause: 'elimination', content: ev.content ?? '' };
+    } else if (ev.event_type === 'night_attack' && ev.is_public === true && ev.target && !result[ev.target]) {
+      result[ev.target] = { day: ev.day, cause: 'attack', content: ev.content ?? '' };
     }
   }
 
-  const result = {};
-  let cumulative = new Map();
-  for (const day of dayNumbers) {
-    const blocked = guardBlocksByDay[day] ?? new Set();
-    const entries = deathsByDay[day] ?? [];
-    if (entries.length > 0) {
-      cumulative = new Map(cumulative);
-      for (const entry of entries) {
-        if (entry.isNightAttack) {
-          if (!blocked.has(entry.name)) {
-            cumulative.set(entry.name, { day: entry.day, content: entry.content });
-          }
-        } else {
-          cumulative.set(entry.name, { day: entry.day, content: entry.content });
-        }
-      }
-    }
-    result[day] = cumulative;
-  }
   return result;
+}
+
+/**
+ * Return the day an agent died, or -1 when no death record exists.
+ *
+ * @param {object[]} events
+ * @param {string} name
+ * @returns {number}
+ */
+export function deathDayOf(events, name) {
+  return deathsByAgent(events)[name]?.day ?? -1;
 }
 
 function collectParticipantNames(events, agents) {

--- a/frontend/src/lib/parseGameData.test.js
+++ b/frontend/src/lib/parseGameData.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseEventLine, parseGameData, normalizeEvents, aggregateDaySummary, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, computeDeadByDay, buildAgentDetailRoster, countAgentSpeeches, buildSuspicionMatrix } from './parseGameData.js';
+import { parseEventLine, parseGameData, normalizeEvents, aggregateDaySummary, aggregateNightResults, buildActionsTimeline, aggregateCoStatus, deathsByAgent, deathDayOf, buildAgentDetailRoster, countAgentSpeeches, buildSuspicionMatrix } from './parseGameData.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -563,188 +563,64 @@ describe('aggregateCoStatus', () => {
   });
 });
 
-describe('computeDeadByDay', () => {
-  it('returns empty Maps for all days when there are no eliminations', () => {
+describe('death accessors', () => {
+  it('returns elimination and public night_attack death records by agent', () => {
     /*
-     * SUT: computeDeadByDay
+     * SUT: deathsByAgent
      * Mock: なし
      * Level: unit
-     * Objective: elimination イベントがない場合、全日で空の Map が返ることを検証する。
-     */
-    const events = [
-      { day: 1, event_type: 'speech', agent: 'Mira' },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[1]).toEqual(new Map());
-  });
-
-  it('includes only Day 1 victim in Day 1 dead map', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: Day 1 を選択したとき、Day 1 の処刑対象のみが死亡者として含まれることを検証する（AC1）。
-     */
-    const events = [
-      { day: 1, event_type: 'elimination', agent: 'Toma' },
-      { day: 2, event_type: 'elimination', agent: 'Nox' },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[1].has('Toma')).toBe(true);
-    expect(result[1].has('Nox')).toBe(false);
-  });
-
-  it('accumulates previous victims in later days (AC2)', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: Day 2 以降を選択したとき、それ以前の累積死亡者が Map に含まれることを検証する（AC2）。
-     */
-    const events = [
-      { day: 1, event_type: 'elimination', agent: 'Toma' },
-      { day: 2, event_type: 'elimination', agent: 'Nox' },
-      { day: 3, event_type: 'elimination', agent: 'Rei' },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[2].has('Toma')).toBe(true);
-    expect(result[2].has('Nox')).toBe(true);
-    expect(result[2].has('Rei')).toBe(false);
-  });
-
-  it('final day map contains all dead agents (AC3)', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: 最終日の Map が全死亡者を含むことを検証する（AC3）。
-     */
-    const events = [
-      { day: 1, event_type: 'elimination', agent: 'Toma' },
-      { day: 2, event_type: 'elimination', agent: 'Nox' },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[2].has('Toma')).toBe(true);
-    expect(result[2].has('Nox')).toBe(true);
-    expect(result[2].size).toBe(2);
-  });
-
-  it('handles days with no elimination by copying previous day dead map', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: elimination がない日（speech のみ）も前日の累積を引き継ぐことを検証する。
-     */
-    const events = [
-      { day: 1, event_type: 'speech', agent: 'Mira' },
-      { day: 1, event_type: 'elimination', agent: 'Toma' },
-      { day: 2, event_type: 'speech', agent: 'Mira' },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[2].has('Toma')).toBe(true);
-  });
-
-  it('includes night_attack victim in dead map (AC1)', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: private night_attack の target が死亡者 Map に含まれることを検証する（AC1）。
-     */
-    const events = [
-      { day: 1, event_type: 'night_attack', target: 'Rei', is_public: false },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[1].has('Rei')).toBe(true);
-  });
-
-  it('does not include night_attack victim when guard_block exists for same target (AC2)', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: 同日同 target の private guard_block がある場合、night_attack の target が死亡者 Map に含まれないことを検証する（AC2）。
-     */
-    const events = [
-      { day: 1, event_type: 'night_attack', target: 'Toma', is_public: false },
-      { day: 1, event_type: 'guard_block',  target: 'Toma', is_public: false },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[1].has('Toma')).toBe(false);
-  });
-
-  it('night_attack victim appears in later days if killed on earlier day', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: 夜襲犠牲者は翌日以降の累積 Map にも引き継がれることを検証する。
-     */
-    const events = [
-      { day: 1, event_type: 'night_attack', target: 'Rei', is_public: false },
-      { day: 2, event_type: 'speech', agent: 'Mira' },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[2].has('Rei')).toBe(true);
-  });
-
-  it('guard_block on different day does not protect night_attack victim', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: guard_block が別の日のものであれば、night_attack の target は死亡者 Map に含まれることを検証する。
-     */
-    const events = [
-      { day: 1, event_type: 'night_attack', target: 'Rei', is_public: false },
-      { day: 2, event_type: 'guard_block',  target: 'Rei', is_public: false },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[1].has('Rei')).toBe(true);
-  });
-
-  it('stores day and content metadata for elimination victim (contract)', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: elimination 死亡者のメタデータ（day, content）が Map の value として取得できることを検証する（#391 contract）。
-     */
-    const events = [
-      { day: 2, event_type: 'elimination', agent: 'Toma', content: 'Toma was executed.', is_public: true },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[2].get('Toma')).toEqual({ day: 2, content: 'Toma was executed.' });
-  });
-
-  it('stores day and content metadata for night_attack victim (contract)', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: night_attack 死亡者のメタデータ（day, content）が Map の value として取得できることを検証する（#391 contract）。
-     */
-    const events = [
-      { day: 1, event_type: 'night_attack', target: 'Rei', content: 'Werewolves attacked Rei.', is_public: false },
-    ];
-    const result = computeDeadByDay(events);
-    expect(result[1].get('Rei')).toEqual({ day: 1, content: 'Werewolves attacked Rei.' });
-  });
-
-  it('metadata is preserved when victim carries over to later days', () => {
-    /*
-     * SUT: computeDeadByDay
-     * Mock: なし
-     * Level: unit
-     * Objective: 死亡者のメタデータが翌日以降の Map にも引き継がれることを検証する（#391 contract）。
+     * Objective: public night_attack / elimination 由来の死亡日・死因・content を agent 名で取得できることを検証する。
      */
     const events = [
       { day: 1, event_type: 'elimination', agent: 'Toma', content: 'Toma was executed.', is_public: true },
-      { day: 2, event_type: 'speech', agent: 'Mira' },
+      { day: 2, event_type: 'night_attack', agent: null, target: 'Rei', content: 'Rei was found dead at dawn.', is_public: true },
     ];
-    const result = computeDeadByDay(events);
-    expect(result[2].get('Toma')).toEqual({ day: 1, content: 'Toma was executed.' });
+    expect(deathsByAgent(events)).toEqual({
+      Toma: { day: 1, cause: 'elimination', content: 'Toma was executed.' },
+      Rei: { day: 2, cause: 'attack', content: 'Rei was found dead at dawn.' },
+    });
+  });
+
+  it('deathDayOf returns the death day or -1 fallback', () => {
+    /*
+     * SUT: deathDayOf
+     * Mock: なし
+     * Level: unit
+     * Objective: 死亡イベントがある agent は死亡日、死亡イベントがない agent は -1 を返すことを検証する。
+     */
+    const events = [
+      { day: 3, event_type: 'elimination', agent: 'Nox', content: 'Nox was executed.', is_public: true },
+    ];
+    expect(deathDayOf(events, 'Nox')).toBe(3);
+    expect(deathDayOf(events, 'Mira')).toBe(-1);
+  });
+
+  it('ignores private night_attack and guard_block for death detection', () => {
+    /*
+     * SUT: deathsByAgent
+     * Mock: なし
+     * Level: unit
+     * Objective: private night_attack / guard_block の突き合わせを死亡判定に使わず、護衛成功夜を死亡として誤検出しないことを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', agent: 'Kai', target: 'Toma', content: 'Kai attacks Toma.', is_public: false },
+      { day: 1, event_type: 'guard_block', agent: 'Mira', target: 'Toma', content: 'Toma was protected.', is_public: false },
+      { day: 1, event_type: 'guard_block', agent: null, target: 'Toma', content: 'The attack was blocked.', is_public: true },
+    ];
+    expect(deathsByAgent(events)).toEqual({});
+  });
+
+  it('ignores private night_attack even when no guard_block exists', () => {
+    /*
+     * SUT: deathsByAgent
+     * Mock: なし
+     * Level: unit
+     * Objective: public night_attack が出ていない限り、private night_attack 単体では死亡確定扱いしないことを検証する。
+     */
+    const events = [
+      { day: 1, event_type: 'night_attack', agent: 'Kai', target: 'Rei', content: 'Kai attacks Rei.', is_public: false },
+    ];
+    expect(deathsByAgent(events)).toEqual({});
   });
 });
 

--- a/frontend/src/lib/useDeaths.js
+++ b/frontend/src/lib/useDeaths.js
@@ -1,0 +1,6 @@
+import { useMemo } from 'react';
+import { deathsByAgent } from './parseGameData.js';
+
+export function useDeaths(events) {
+  return useMemo(() => deathsByAgent(events ?? []), [events]);
+}

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -8,7 +8,8 @@ import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLE_META_BY_KEY } from '../lib/roleMeta.js';
 import { fetchGameStats, parseGameStats, parseAllAgentNames, fetchGameBySessionId, fetchAgentConfig, parseBlurb } from '../lib/archiveLoader.js';
 import { fetchReplayGame } from '../lib/replayLoader.js';
-import { buildAgentDetailRoster, buildSuspicionMatrix, countAgentSpeeches, deathDayOf } from '../lib/parseGameData.js';
+import { buildAgentDetailRoster, buildSuspicionMatrix, countAgentSpeeches } from '../lib/parseGameData.js';
+import { useDeaths } from '../lib/useDeaths.js';
 import styles from './AgentDetailScreen.module.css';
 
 // blurb（frontend/public/config/agents.json 由来の1行プロフィール・#519）が無い／fetch 失敗時のフォールバック表示。
@@ -363,6 +364,8 @@ export default function AgentDetailScreen() {
     gameData: null,
     error: null,
   });
+  const gameScopedEvents = gameScopedState.gameData?.events;
+  const deaths = useDeaths(gameScopedEvents);
 
   useEffect(() => {
     if (!sessionId) return undefined;
@@ -415,8 +418,7 @@ export default function AgentDetailScreen() {
     const visibleDays = [...new Set(events.map(ev => ev.day).filter(Boolean))].sort((a, b) => a - b);
     const currentDay = entry?.days ?? visibleDays.at(-1) ?? 0;
     // 死亡イベント欠落で引けなければ undefined → AgentHero が currentDay にフォールバックする（AC-4）。
-    const resolvedDeathDay = deathDayOf(events, agent);
-    const deathDay = resolvedDeathDay === -1 ? undefined : resolvedDeathDay;
+    const deathDay = deaths[agent]?.day;
     const roleAssignment = Object.fromEntries(
       Object.entries(agents).map(([name, data]) => [name, data.role])
     );

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -8,7 +8,7 @@ import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLE_META_BY_KEY } from '../lib/roleMeta.js';
 import { fetchGameStats, parseGameStats, parseAllAgentNames, fetchGameBySessionId, fetchAgentConfig, parseBlurb } from '../lib/archiveLoader.js';
 import { fetchReplayGame } from '../lib/replayLoader.js';
-import { buildAgentDetailRoster, buildSuspicionMatrix, countAgentSpeeches, computeDeadByDay } from '../lib/parseGameData.js';
+import { buildAgentDetailRoster, buildSuspicionMatrix, countAgentSpeeches, deathDayOf } from '../lib/parseGameData.js';
 import styles from './AgentDetailScreen.module.css';
 
 // blurb（frontend/public/config/agents.json 由来の1行プロフィール・#519）が無い／fetch 失敗時のフォールバック表示。
@@ -414,10 +414,9 @@ export default function AgentDetailScreen() {
     const speechCount = countAgentSpeeches(events, agent);
     const visibleDays = [...new Set(events.map(ev => ev.day).filter(Boolean))].sort((a, b) => a - b);
     const currentDay = entry?.days ?? visibleDays.at(-1) ?? 0;
-    // 死亡日は computeDeadByDay の最終日累積 Map から引く（SpectatorScreen RightPane と同パターン・#535）。
     // 死亡イベント欠落で引けなければ undefined → AgentHero が currentDay にフォールバックする（AC-4）。
-    const deadByDay = computeDeadByDay(events);
-    const deathDay = deadByDay[visibleDays.at(-1)]?.get(agent)?.day;
+    const resolvedDeathDay = deathDayOf(events, agent);
+    const deathDay = resolvedDeathDay === -1 ? undefined : resolvedDeathDay;
     const roleAssignment = Object.fromEntries(
       Object.entries(agents).map(([name, data]) => [name, data.role])
     );

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -9,7 +9,8 @@ import { ROLE_META_BY_KEY, ROLE_KEYS, listRoles } from '../lib/roleMeta.js';
 import { agentDetailPath } from '../lib/agentLinks.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
 import { fetchGameBySessionId } from '../lib/archiveLoader.js';
-import { parseGameData, aggregateCoStatus, deathsByAgent } from '../lib/parseGameData.js';
+import { parseGameData, aggregateCoStatus } from '../lib/parseGameData.js';
+import { useDeaths } from '../lib/useDeaths.js';
 import { filterByAgents, filterByRoles, filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
 
@@ -299,7 +300,6 @@ export default function SpectatorScreen() {
   const [replayEvents, setReplayEvents] = useState(null);
   const [replayAgents, setReplayAgents] = useState({});
   const [replayDaySummary, setReplayDaySummary] = useState({});
-  const [replayDeaths, setReplayDeaths] = useState({});
   const [gameWinner, setGameWinner] = useState(null);
   const [gameOverDay, setGameOverDay] = useState(null);
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
@@ -349,7 +349,6 @@ export default function SpectatorScreen() {
     setReplayEvents(null);
     setReplayAgents({});
     setReplayDaySummary({});
-    setReplayDeaths({});
     setGameWinner(null);
     setGameOverDay(null);
     setLoadingEvents(true);
@@ -375,7 +374,6 @@ export default function SpectatorScreen() {
         const parsed = parseGameData(jsonlText);
         setReplayEvents(parsed.events);
         setReplayDaySummary(parsed.daySummary);
-        setReplayDeaths(deathsByAgent(parsed.events));
         setGameWinner(parsed.winner ?? null);
         const goEvent = parsed.events.find(e => e.event_type === 'game_over');
         if (goEvent) setGameOverDay(goEvent.day);
@@ -395,6 +393,7 @@ export default function SpectatorScreen() {
   }, [sessionId]);
 
   const events = replayEvents ?? [];
+  const replayDeaths = useDeaths(replayEvents);
   const agents = replayAgents;
   const daySummary = replayDaySummary;
   const roleAssignment = useMemo(() => Object.fromEntries(

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -9,7 +9,7 @@ import { ROLE_META_BY_KEY, ROLE_KEYS, listRoles } from '../lib/roleMeta.js';
 import { agentDetailPath } from '../lib/agentLinks.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
 import { fetchGameBySessionId } from '../lib/archiveLoader.js';
-import { parseGameData, aggregateCoStatus, computeDeadByDay } from '../lib/parseGameData.js';
+import { parseGameData, aggregateCoStatus, deathsByAgent } from '../lib/parseGameData.js';
 import { filterByAgents, filterByRoles, filterFeedEvents } from '../lib/feedFilter.js';
 import styles from './SpectatorScreen.module.css';
 
@@ -169,13 +169,15 @@ const NIGHT_ACTION_ICON = { inspection: '🔮', guard: '🛡', night_attack: '�
 const NIGHT_ACTION_LABEL = { inspection: '占い', guard: '護衛', night_attack: '襲撃' };
 
 // === 右ペイン ===
-export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = {}, activeDay, deadByDay = {}, viewerMode = 'spectator' }) {
+export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = {}, activeDay, deaths = {}, viewerMode = 'spectator' }) {
   const { sessionId } = useParams();
   const order = Object.keys(agents);
-  const activeDead = deadByDay[activeDay] ?? new Map();
-  const deadNames = order.filter(n => activeDead.has(n))
-    .sort((a, b) => (activeDead.get(a)?.day ?? 0) - (activeDead.get(b)?.day ?? 0));
-  const alive = order.filter(n => !activeDead.has(n));
+  const activeDeadNames = new Set(Object.entries(deaths)
+    .filter(([, death]) => death?.day <= activeDay)
+    .map(([name]) => name));
+  const deadNames = order.filter(n => activeDeadNames.has(n))
+    .sort((a, b) => (deaths[a]?.day ?? 0) - (deaths[b]?.day ?? 0));
+  const alive = order.filter(n => !activeDeadNames.has(n));
 
   const dayData = daySummary[activeDay];
   const nightActions = dayData?.nightActions ?? [];
@@ -278,7 +280,7 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
               to={agentDetailPath(sessionId, n, viewerMode)}
               showRole={viewerMode === 'spectator'}
               dead
-              deathMeta={activeDead.get(n)}
+              deathMeta={deaths[n]}
             />
           ))}
         </ul>
@@ -297,7 +299,7 @@ export default function SpectatorScreen() {
   const [replayEvents, setReplayEvents] = useState(null);
   const [replayAgents, setReplayAgents] = useState({});
   const [replayDaySummary, setReplayDaySummary] = useState({});
-  const [replayDeadByDay, setReplayDeadByDay] = useState({});
+  const [replayDeaths, setReplayDeaths] = useState({});
   const [gameWinner, setGameWinner] = useState(null);
   const [gameOverDay, setGameOverDay] = useState(null);
   const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
@@ -347,7 +349,7 @@ export default function SpectatorScreen() {
     setReplayEvents(null);
     setReplayAgents({});
     setReplayDaySummary({});
-    setReplayDeadByDay({});
+    setReplayDeaths({});
     setGameWinner(null);
     setGameOverDay(null);
     setLoadingEvents(true);
@@ -373,7 +375,7 @@ export default function SpectatorScreen() {
         const parsed = parseGameData(jsonlText);
         setReplayEvents(parsed.events);
         setReplayDaySummary(parsed.daySummary);
-        setReplayDeadByDay(computeDeadByDay(parsed.events));
+        setReplayDeaths(deathsByAgent(parsed.events));
         setGameWinner(parsed.winner ?? null);
         const goEvent = parsed.events.find(e => e.event_type === 'game_over');
         if (goEvent) setGameOverDay(goEvent.day);
@@ -436,7 +438,7 @@ export default function SpectatorScreen() {
         collapsibleLeft
         collapsibleRight
         left={<LeftPane activeDay={activeDay} setDay={setActiveDay} activePhase={activePhase} setPhase={setActivePhase} days={visibleDays} agentNames={agentNames} daySummary={daySummary} gameOverDay={gameOverDay} selectedAgents={selectedAgents} onToggleAgent={toggleAgentFilter} presentRoles={presentRoles} selectedRoles={selectedRoles} onToggleRole={toggleRoleFilter} thoughtsOpen={thoughtsOpen} onToggleThoughts={toggleThoughtsOpen} viewerMode={viewerMode} />}
-        right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} daySummary={daySummary} activeDay={activeDay} deadByDay={replayDeadByDay} viewerMode={viewerMode} />}
+        right={<RightPane agents={agents} roleAssignment={roleAssignment} coStatus={replayCoStatus} daySummary={daySummary} activeDay={activeDay} deaths={replayDeaths} viewerMode={viewerMode} />}
       >
         <div className={styles.feedHead}>
           <h2>{activePhase === 'game_over' ? '勝敗結果' : activePhase === 'eve' ? '前夜 プロローグ' : `Day ${activeDay} ${{ discuss: '議論', vote: '投票・処刑', night: '夜フェーズ' }[activePhase]}`} <small>{sessionId}</small></h2>

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -677,7 +677,7 @@ const baseAgents = {
 };
 
 // Bob is dead at day 1
-const baseDeadByDay = { 1: new Map([['Bob', { day: 1, content: 'Bob was executed.' }]]) };
+const baseDeaths = { Bob: { day: 1, cause: 'elimination', content: 'Bob was executed.' } };
 
 function renderRightPane(overrides = {}) {
   const props = {
@@ -686,7 +686,7 @@ function renderRightPane(overrides = {}) {
     coStatus: {},
     daySummary: {},
     activeDay: 1,
-    deadByDay: baseDeadByDay,
+    deaths: baseDeaths,
     viewerMode: 'spectator',
     ...overrides,
   };
@@ -700,6 +700,21 @@ function renderRightPane(overrides = {}) {
 }
 
 describe('RightPane: death reason display (#391)', () => {
+  it('keeps future death records alive before their death day', () => {
+    /*
+     * SUT: RightPane
+     * Mock: なし
+     * Level: unit
+     * Objective: activeDay より後の日に死亡するエージェントは、activeDay 時点の生存者として表示されることを検証する（#554 AC-4）。
+     */
+    renderRightPane({
+      deaths: { Bob: { day: 2, cause: 'attack', content: 'Bob was found dead at dawn.' } },
+      activeDay: 1,
+    });
+    expect(within(screen.getByRole('list', { name: '生存エージェント' })).getByText('Bob')).toBeTruthy();
+    expect(within(screen.getByRole('list', { name: '死亡者' })).queryByText('Bob')).toBeNull();
+  });
+
   it('shows day and content for dead agent in roster', () => {
     /*
      * SUT: RightPane
@@ -708,7 +723,7 @@ describe('RightPane: death reason display (#391)', () => {
      * Objective: 死亡者行に死亡日（Day N）と死因テキスト（content）が表示されることを検証する（AC1 / #391）。
      */
     renderRightPane({
-      deadByDay: { 1: new Map([['Bob', { day: 1, content: 'Bob was executed.' }]]) },
+      deaths: { Bob: { day: 1, cause: 'elimination', content: 'Bob was executed.' } },
       activeDay: 1,
     });
     expect(screen.getByText(/Day 1 · Bob was executed\./)).toBeTruthy();
@@ -722,13 +737,13 @@ describe('RightPane: death reason display (#391)', () => {
      * Objective: 夜襲死亡者行に night_attack の content テキストが表示されることを検証する（AC2 / #391）。
      */
     renderRightPane({
-      deadByDay: { 1: new Map([['Bob', { day: 1, content: 'Werewolves attacked Bob.' }]]) },
+      deaths: { Bob: { day: 1, cause: 'attack', content: 'Werewolves attacked Bob.' } },
       activeDay: 1,
     });
     expect(screen.getByText(/Werewolves attacked Bob\./)).toBeTruthy();
   });
 
-  it('shows no deathReason when deadByDay entry has no metadata', () => {
+  it('shows no deathReason when death entry has no metadata', () => {
     /*
      * SUT: RightPane
      * Mock: なし
@@ -736,7 +751,7 @@ describe('RightPane: death reason display (#391)', () => {
      * Objective: メタデータなし（Map.get が undefined）の死亡者行には死亡理由が表示されないことを検証する。
      */
     const { container } = renderRightPane({
-      deadByDay: { 1: new Map([['Bob', undefined]]) },
+      deaths: { Bob: undefined },
       activeDay: 1,
     });
     expect(container.querySelector('[class*="deathReason"]')).toBeNull();
@@ -843,7 +858,7 @@ describe('RightPane: dead role hidden in public mode (#521 AC-3)', () => {
      */
     const { container } = renderRightPane({
       viewerMode: 'public',
-      deadByDay: { 1: new Map([['Bob', { day: 1, content: 'Werewolves attacked Bob.' }]]) },
+      deaths: { Bob: { day: 1, cause: 'attack', content: 'Werewolves attacked Bob.' } },
       activeDay: 1,
       coStatus: {},
     });
@@ -861,7 +876,7 @@ describe('RightPane: dead role hidden in public mode (#521 AC-3)', () => {
      */
     const { container } = renderRightPane({
       viewerMode: 'spectator',
-      deadByDay: { 1: new Map([['Bob', { day: 1, content: 'Werewolves attacked Bob.' }]]) },
+      deaths: { Bob: { day: 1, cause: 'attack', content: 'Werewolves attacked Bob.' } },
       activeDay: 1,
       coStatus: {},
     });
@@ -1742,7 +1757,7 @@ describe('avatar navigation links (#485)', () => {
         coStatus={{}}
         daySummary={{}}
         activeDay={1}
-        deadByDay={baseDeadByDay}
+        deaths={baseDeaths}
         viewerMode="spectator"
       />
     );
@@ -1763,7 +1778,7 @@ describe('avatar navigation links (#485)', () => {
         coStatus={{ Alice: 'Seer' }}
         daySummary={{}}
         activeDay={1}
-        deadByDay={baseDeadByDay}
+        deaths={baseDeaths}
         viewerMode="spectator"
       />
     );
@@ -1790,7 +1805,7 @@ describe('avatar navigation links (#485)', () => {
         coStatus={{}}
         daySummary={daySummary}
         activeDay={1}
-        deadByDay={baseDeadByDay}
+        deaths={baseDeaths}
         viewerMode="spectator"
       />
     );
@@ -1820,7 +1835,7 @@ describe('avatar navigation links (#485)', () => {
         coStatus={{}}
         daySummary={daySummary}
         activeDay={1}
-        deadByDay={baseDeadByDay}
+        deaths={baseDeaths}
         viewerMode="spectator"
       />
     );


### PR DESCRIPTION
## Summary
- Add `deathsByAgent` / `deathDayOf` as death-record accessors based on public `night_attack` and `elimination`
- Migrate AgentDetail hero and Spectator RightPane away from `computeDeadByDay`
- Remove private `night_attack` / `guard_block` death recomputation and update frontend design docs

## Implementation notes
- RightPane derives active-day alive/dead rosters from all agents plus death records whose `day <= activeDay`.
- Attack death metadata now comes from the public death notification event.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest`
- [x] `uv run --directory frontend npm test`

Closes #554

🤖 Generated with [Codex](https://Codex.com/Codex)
