### PR TITLE
docs: split #530 — extract design-lint into #557, sync Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,7 +20,8 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#530 | enhancement | 🟡 | 8 | Establish design token usage rules & design-lint enforcement | #522 レビューで発覚したスタイル不統一が起点。トークン使用規約の明文化＋design lint 導入。idd は lint 通過のみ軽量ゲート、逸脱発見/tech-debt/リファクタは self-reflection-review |
+| yukkie/AgentVillage#530 | enhancement | 🟡 | 5 | Establish design token usage rules & self-reflection-review観点追加 | #522 レビューで発覚したスタイル不統一が起点。トークン使用規約の明文化＋self-reflection-review への視覚的不統一発見観点追加。design lint 導入は #557 に分割 |
+| yukkie/AgentVillage#557 | enhancement | 🟡 | 3 | feat(frontend): introduce design-lint (stylelint) and add /idd gate | #530 の使用規約策定後に実装。stylelint 導入・CI/pre-commit 設定・/idd flow-js.md への軽量ゲート追加 |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#495 | enhancement | 🟢 | 3 | design: log visibility classes and recipient-based authorization model (for LIVE / player participation) | LIVE/プレイヤー参加に向け、可視性クラス×受信者権限の配信認可モデルを先行設計（ADR）。replay は全配信の特殊ケース |
 | yukkie/AgentVillage#319 | enhancement | 🟢 | 3 | feat(frontend): LIVE spectator (real-time view of in-progress game) | state/ を tail して進行中ゲームを表示（将来フェーズ） |


### PR DESCRIPTION
## Summary

- #530 から design lint 導入（旧 AC-2）・/idd ゲート追加（旧 AC-3）を #557 に分割
- Ideas.md を更新: #530 の SP・要約を修正し、#557 の行を追加

## 変更内容

- `doc/Ideas.md`: #530 行を更新（SP 8→5、要約修正）、#557 行を新規追加