### PR TITLE
feat: add avatars to CO status and night action sections (#403)

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -549,7 +549,7 @@ Semantic HTML: `GameCard` は自己完結したゲーム項目として `<articl
 | 内部コンポーネント | 責務 |
 |---|---|
 | `LeftPane` | フェーズナビ（日 × フェーズ、クリックで中央フィードを切り替え） + エージェント/役職/表示フィルタ |
-| `RightPane` | ロスター（生存/死亡、共通 `AgentRosterRow` を使用）/ COボード / 夜の行動タイムライン |
+| `RightPane` | ロスター（生存/死亡、共通 `AgentRosterRow` を使用）/ `CoStatusBoard`（COボード）/ `NightActionsPanel`（夜の行動タイムライン） |
 
 #### viewerMode トグル（#314）
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -27,7 +27,6 @@
 | yukkie/AgentVillage#319 | enhancement | 🟢 | 3 | feat(frontend): LIVE spectator (real-time view of in-progress game) | state/ を tail して進行中ゲームを表示（将来フェーズ） |
 | yukkie/AgentVillage#364 | enhancement | 🟢 | 5 | refactor: introduce SpectatorScreen view model indexes | SpectatorScreen 用 view model/index を導入し、render 中の events 全走査を減らす |
 | yukkie/AgentVillage#323 | enhancement | 🟢 | 3 | feat(frontend): i18n support for frontend UI strings (ja/en) | JSX 内の日本語ハードコードを locale リソースに外出しし、ja/en 切り替えに対応 |
-| yukkie/AgentVillage#403 | enhancement | 🟢 | 2 | Add avatars to CO status and night action sections | CO状況・夜の行動セクションにアバターアイコンを追加しコンポーネント化 |
 | yukkie/AgentVillage#379 | enhancement | 🟢 | 3 | Add static type checking to frontend JS (JSDoc or TypeScript) | フィールド名ミスをエディタ/CIで検出できるようにする。スタブ撤廃（#318）以降に検討 |
 
 ### ゲームロジック系（Web UI 軸とは別系統）

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -169,6 +169,62 @@ export function LeftPane({
 const NIGHT_ACTION_ICON = { inspection: '🔮', guard: '🛡', night_attack: '🐺' };
 const NIGHT_ACTION_LABEL = { inspection: '占い', guard: '護衛', night_attack: '襲撃' };
 
+function CoStatusBoard({ coStatus, sessionId, viewerMode }) {
+  return (
+    <ul className={styles.coBoard} aria-label="カミングアウト状況">
+      {listRoles()
+        .map(roleDef => [roleDef.key, roleDef])
+        .filter(([k]) => k !== 'Villager' && k !== 'Werewolf' && k !== 'Madman')
+        .map(([roleKey, roleDef]) => {
+          const coAgents = Object.entries(coStatus)
+            .filter(([, cr]) => cr === roleKey)
+            .map(([name]) => name);
+          return (
+            <li key={roleKey} className={styles.coRow} style={{ '--r-color': roleDef.color }}>
+              <span className={styles.coRole}>{roleDef.ja}</span>
+              <span className={styles.coName} style={{ color: coAgents.length ? 'var(--tx)' : 'var(--tx-3)' }}>
+                {coAgents.length ? coAgents.map((name, i) => (
+                  <span key={name} className={styles.coAgent}>
+                    {i > 0 && ', '}
+                    <Link to={agentDetailPath(sessionId, name, viewerMode)} className={styles.agentLink}>
+                      <Avatar name={name} size="xs" label={name} layout="horizontal" />
+                    </Link>
+                  </span>
+                )) : '未CO'}
+              </span>
+            </li>
+          );
+        })}
+    </ul>
+  );
+}
+
+function NightActionsPanel({ nightActions, roleAssignment, sessionId, viewerMode, activeDay }) {
+  return (
+    <ul className={styles.actionList} aria-label={`Day ${activeDay} 夜の行動`}>
+      {nightActions.map((a, i) => (
+        <li key={i} className={`${styles.action} ${styles[a.event_type] || ''}`}>
+          <div className={styles.actionIco}>{NIGHT_ACTION_ICON[a.event_type] || '・'}</div>
+          <div className={styles.what}>
+            <Link to={agentDetailPath(sessionId, a.agent, viewerMode)} className={styles.agentLink}>
+              <Avatar name={a.agent} size="xs" label={a.agent} layout="horizontal" />
+            </Link>
+            {a.target && (
+              <> → <Link to={agentDetailPath(sessionId, a.target, viewerMode)} className={styles.agentLink} style={{ '--r-color': ROLE_META_BY_KEY[roleAssignment[a.target]]?.color }}>
+                <Avatar name={a.target} size="xs" label={a.target} layout="horizontal" />
+              </Link></>
+            )}
+            <span style={{ color: 'var(--tx-4)', marginLeft: 6 }}>{NIGHT_ACTION_LABEL[a.event_type]}</span>
+          </div>
+        </li>
+      ))}
+      {nightActions.length === 0 && (
+        <li className={styles.action} style={{ color: 'var(--tx-3)' }}>夜の行動ログなし</li>
+      )}
+    </ul>
+  );
+}
+
 // === 右ペイン ===
 export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = {}, activeDay, deaths = {}, viewerMode = 'spectator' }) {
   const { sessionId } = useParams();
@@ -187,43 +243,10 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
   return (
     <div className={styles.roster}>
       <div className={styles.sectionLabel}>カミングアウト状況</div>
-      <ul className={styles.coBoard} aria-label="カミングアウト状況">
-        {listRoles()
-          .map(roleDef => [roleDef.key, roleDef])
-          .filter(([k]) => k !== 'Villager' && k !== 'Werewolf' && k !== 'Madman')
-          .map(([roleKey, roleDef]) => {
-            const coAgents = Object.entries(coStatus)
-              .filter(([, cr]) => cr === roleKey)
-              .map(([name]) => name);
-            return (
-              <li key={roleKey} className={styles.coRow} style={{ '--r-color': roleDef.color }}>
-                <span className={styles.coRole}>{roleDef.ja}</span>
-                <span className={styles.coName} style={{ color: coAgents.length ? 'var(--tx)' : 'var(--tx-3)' }}>
-                  {coAgents.length ? coAgents.map((name, i) => (
-                    <span key={name}>{i > 0 && ', '}<Link to={agentDetailPath(sessionId, name, viewerMode)} className={styles.agentLink}>{name}</Link></span>
-                  )) : '未CO'}
-                </span>
-              </li>
-            );
-          })}
-      </ul>
+      <CoStatusBoard coStatus={coStatus} sessionId={sessionId} viewerMode={viewerMode} />
 
       <div className={styles.sectionLabel}>Day {activeDay} 夜の行動</div>
-      <ul className={styles.actionList} aria-label={`Day ${activeDay} 夜の行動`}>
-        {nightActions.map((a, i) => (
-          <li key={i} className={`${styles.action} ${styles[a.event_type] || ''}`}>
-            <div className={styles.actionIco}>{NIGHT_ACTION_ICON[a.event_type] || '・'}</div>
-            <div className={styles.what}>
-              <Link to={agentDetailPath(sessionId, a.agent, viewerMode)} className={styles.agentLink}><strong>{a.agent}</strong></Link>
-              {a.target && <> → <Link to={agentDetailPath(sessionId, a.target, viewerMode)} className={styles.agentLink}><em style={{ '--r-color': ROLE_META_BY_KEY[roleAssignment[a.target]]?.color }}>{a.target}</em></Link></>}
-              <span style={{ color: 'var(--tx-4)', marginLeft: 6 }}>{NIGHT_ACTION_LABEL[a.event_type]}</span>
-            </div>
-          </li>
-        ))}
-        {nightActions.length === 0 && (
-          <li className={styles.action} style={{ color: 'var(--tx-3)' }}>夜の行動ログなし</li>
-        )}
-      </ul>
+      <NightActionsPanel nightActions={nightActions} roleAssignment={roleAssignment} sessionId={sessionId} viewerMode={viewerMode} activeDay={activeDay} />
 
       {execResult && (
         <>

--- a/frontend/src/screens/SpectatorScreen.test.jsx
+++ b/frontend/src/screens/SpectatorScreen.test.jsx
@@ -1946,3 +1946,72 @@ describe('SpectatorScreen: viewerMode toggle (AC1 / #314)', () => {
     expect(screen.getByLabelText('current-location').textContent).toBe('/game/test-session-001');
   });
 });
+
+describe('RightPane: avatars in CO status and night actions (#403)', () => {
+  it('統合: RightPane: CO済みエージェント行にアバターアイコンと名前テキストが表示される', () => {
+    /*
+     * SUT: RightPane (CoStatusBoard)
+     * Mock: なし
+     * Level: integration
+     * Objective: coStatus に Seer: Alice がある場合、COボード内に Alice のアバター画像と名前テキストが Link で表示されることを検証する（AC-1）。
+     */
+    const { container } = renderRightPane({
+      coStatus: { Alice: 'Seer' },
+    });
+    const coBoard = container.querySelector('[aria-label="カミングアウト状況"]');
+    const aliceImg = coBoard.querySelector('img[src*="Alice"]');
+    expect(aliceImg).toBeTruthy();
+    const aliceLabel = coBoard.querySelector('[data-testid="avatar-label"]');
+    expect(aliceLabel).toBeTruthy();
+    expect(aliceLabel.textContent).toBe('Alice');
+    expect(aliceImg.closest('a')).toBeTruthy();
+  });
+
+  it('統合: RightPane: 夜の行動actor行にアバターと名前が表示される', () => {
+    /*
+     * SUT: RightPane (NightActionsPanel)
+     * Mock: なし
+     * Level: integration
+     * Objective: nightActions に inspection(agent=Alice) がある場合、夜の行動リスト内に Alice のアバター画像と名前テキストが表示されることを検証する（AC-2）。
+     */
+    const daySummary = {
+      1: {
+        nightActions: [{ event_type: 'inspection', agent: 'Alice', target: 'Bob', is_public: false }],
+        execResult: null,
+        speechCount: 0,
+        nightDone: true,
+      },
+    };
+    const { container } = renderRightPane({ daySummary, activeDay: 1 });
+    const actionList = container.querySelector('[aria-label="Day 1 夜の行動"]');
+    const aliceImg = actionList.querySelector('img[src*="Alice"]');
+    expect(aliceImg).toBeTruthy();
+    const labels = actionList.querySelectorAll('[data-testid="avatar-label"]');
+    const aliceLabel = Array.from(labels).find(el => el.textContent === 'Alice');
+    expect(aliceLabel).toBeTruthy();
+  });
+
+  it('統合: RightPane: 夜の行動ターゲット行にアバターと名前が表示される', () => {
+    /*
+     * SUT: RightPane (NightActionsPanel)
+     * Mock: なし
+     * Level: integration
+     * Objective: nightActions に target=Bob がある場合、夜の行動リスト内に Bob のアバター画像と名前テキストが表示されることを検証する（AC-2）。
+     */
+    const daySummary = {
+      1: {
+        nightActions: [{ event_type: 'inspection', agent: 'Alice', target: 'Bob', is_public: false }],
+        execResult: null,
+        speechCount: 0,
+        nightDone: true,
+      },
+    };
+    const { container } = renderRightPane({ daySummary, activeDay: 1 });
+    const actionList = container.querySelector('[aria-label="Day 1 夜の行動"]');
+    const bobImg = actionList.querySelector('img[src*="Bob"]');
+    expect(bobImg).toBeTruthy();
+    const labels = actionList.querySelectorAll('[data-testid="avatar-label"]');
+    const bobLabel = Array.from(labels).find(el => el.textContent === 'Bob');
+    expect(bobLabel).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- CO ボードの各 CO 済みエージェントを `Avatar(label, layout=horizontal)` を Link で包む形に置き換え
- 夜の行動リストの actor・target を同様の Avatar+Link に置き換え
- 両セクションを `CoStatusBoard` / `NightActionsPanel` としてスタンドアロン関数コンポーネントに切り出し

## Test plan
- [x] `npm test` パス（329 tests）
- [x] `npm run test:coverage` パス
- [x] Playwright skipped due to remote/localhost instability. Intended checks:
  - 観戦画面の右ペイン「カミングアウト状況」で CO 済みエージェント行にアバター＋名前が表示される
  - 夜の行動行でアクター・ターゲットそれぞれのアバター＋名前が表示される

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)