### PR TITLE
docs: add issue #561 and #562 to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,6 +21,8 @@
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#557 | enhancement | 🟡 | 3 | feat(frontend): introduce design-lint (stylelint) and add /idd gate | #530 の使用規約策定後に実装。stylelint 導入・CI/pre-commit 設定・/idd flow-js.md への軽量ゲート追加 |
+| ❌ yukkie/AgentVillage#561 | tech-debt | （なし） | （なし） | Fix existing raw color/border-radius values flagged by stylelint | #557 で warning 許容した既存違反（color ~54件・border-radius ~26件）をトークン参照に置き換え、ルールを error 化する |
+| ❌ yukkie/AgentVillage#562 | tech-debt | （なし） | （なし） | Survey font-size usage to design font-size tokens | font-size の使用実態を一覧化し、トークン化の粒度案を提案する（#557 のスコープ拡張から派生） |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#495 | enhancement | 🟢 | 3 | design: log visibility classes and recipient-based authorization model (for LIVE / player participation) | LIVE/プレイヤー参加に向け、可視性クラス×受信者権限の配信認可モデルを先行設計（ADR）。replay は全配信の特殊ケース |
 | yukkie/AgentVillage#319 | enhancement | 🟢 | 3 | feat(frontend): LIVE spectator (real-time view of in-progress game) | state/ を tail して進行中ゲームを表示（将来フェーズ） |


### PR DESCRIPTION
## Summary
- #557 のスコープ拡張ゲートから派生したフォローアップ Issue 2件（#561, #562）を Ideas.md に追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)