### PR TITLE
refactor: replace raw border-radius values with tokens (#561)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,8 +20,8 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| ❌ yukkie/AgentVillage#561 | tech-debt | （なし） | （なし） | Fix existing raw color/border-radius values flagged by stylelint | #557 で warning 許容した既存違反（color ~54件・border-radius ~26件）をトークン参照に置き換え、ルールを error 化する |
 | ❌ yukkie/AgentVillage#562 | tech-debt | （なし） | （なし） | Survey font-size usage to design font-size tokens | font-size の使用実態を一覧化し、トークン化の粒度案を提案する（#557 のスコープ拡張から派生） |
+| ❌ yukkie/AgentVillage#565 | tech-debt | （なし） | （なし） | Decide token strategy for color/background raw values flagged by stylelint | #561 の調査で機械的に置換できなかった color/background 系生値11件のトークン化方針を決定する |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#495 | enhancement | 🟢 | 3 | design: log visibility classes and recipient-based authorization model (for LIVE / player participation) | LIVE/プレイヤー参加に向け、可視性クラス×受信者権限の配信認可モデルを先行設計（ADR）。replay は全配信の特殊ケース |
 | yukkie/AgentVillage#319 | enhancement | 🟢 | 3 | feat(frontend): LIVE spectator (real-time view of in-progress game) | state/ を tail して進行中ゲームを表示（将来フェーズ） |

--- a/frontend/.stylelintrc.json
+++ b/frontend/.stylelintrc.json
@@ -13,9 +13,9 @@
       {
         "ignoreValues": {
           "": ["inherit", "transparent", "none"],
-          "border-radius": ["50%"]
+          "border-radius": ["50%", "0", "inherit"]
         },
-        "severity": "warning"
+        "severity": "error"
       }
     ]
   }

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -43,7 +43,7 @@
 .iconRow img {
   width: 48px;
   height: 48px;
-  border-radius: 4px;
+  border-radius: var(--r1);
   border: 1px solid var(--bd);
   object-fit: cover;
 }

--- a/frontend/src/components/AgentRosterRow.module.css
+++ b/frontend/src/components/AgentRosterRow.module.css
@@ -62,7 +62,7 @@
   border: 1px solid color-mix(in oklab, var(--co-color, var(--acc)) 50%, transparent);
   color: var(--co-color, var(--acc));
   padding: 1px 5px;
-  border-radius: 2px;
+  border-radius: var(--r-xs);
   letter-spacing: 0.04em;
 }
 

--- a/frontend/src/components/Avatar.module.css
+++ b/frontend/src/components/Avatar.module.css
@@ -1,7 +1,7 @@
 .av {
   width: 60px;
   height: 76px;
-  border-radius: 4px;
+  border-radius: var(--r1);
   background: var(--bg-2);
   border: 1px solid var(--bd);
   position: relative;
@@ -50,7 +50,7 @@
   background: rgba(0, 0, 0, 0.55);
   color: var(--av-c);
   padding: 1px 4px;
-  border-radius: 2px;
+  border-radius: var(--r-xs);
   letter-spacing: 0.05em;
 }
 
@@ -87,7 +87,7 @@
   width: 22px;
   height: 28px;
   flex: 0 0 22px;
-  border-radius: 3px;
+  border-radius: var(--r-sm);
 }
 .xs .mono { font-size: 10px; }
 .xs .roleTag { display: none; }

--- a/frontend/src/components/FeedCard.module.css
+++ b/frontend/src/components/FeedCard.module.css
@@ -62,7 +62,7 @@
   border: 1px solid color-mix(in oklab, var(--co-color, var(--acc)) 50%, transparent);
   color: var(--co-color, var(--acc));
   padding: 1px 5px;
-  border-radius: 2px;
+  border-radius: var(--r-xs);
   letter-spacing: 0.04em;
 }
 
@@ -73,7 +73,7 @@
   background: var(--bg-1);
   font-size: 12px;
   color: var(--tx-3);
-  border-radius: 0 2px 2px 0;
+  border-radius: 0 var(--r-xs) var(--r-xs) 0;
 }
 .spQuote .qhead { font-size: 10px; color: var(--tx-4); margin-bottom: 2px; font-family: var(--mono); }
 
@@ -104,7 +104,7 @@
   display: inline-flex; align-items: center; gap: 7px;
   font-family: var(--sans);
   border: 1px solid var(--bd);
-  border-radius: 14px;
+  border-radius: var(--r-lg);
   background: var(--bg-1);
   transition: all 120ms;
 }
@@ -169,7 +169,7 @@
   font-family: var(--serif); font-size: 10px;
   background: color-mix(in oklab, var(--co-color, var(--acc)) 18%, transparent);
   border: 1px solid color-mix(in oklab, var(--co-color, var(--acc)) 50%, transparent);
-  color: var(--co-color, var(--acc)); padding: 1px 5px; border-radius: 2px; letter-spacing: 0.04em;
+  color: var(--co-color, var(--acc)); padding: 1px 5px; border-radius: var(--r-xs); letter-spacing: 0.04em;
 }
 .qhead { font-size: 10px; color: var(--tx-4); margin-bottom: 2px; font-family: var(--mono); }
 .mention { color: var(--info); font-weight: 500; }
@@ -264,7 +264,7 @@
 }
 .scoreTrack {
   height: 6px;
-  border-radius: 3px;
+  border-radius: var(--r-sm);
   background: var(--bg-3);
   overflow: hidden;
   min-width: 0;

--- a/frontend/src/components/RoleTag.module.css
+++ b/frontend/src/components/RoleTag.module.css
@@ -5,7 +5,7 @@
   border: 1px solid color-mix(in oklab, var(--r-color, var(--bd)) 50%, transparent);
   background: color-mix(in oklab, var(--r-color, transparent) 12%, transparent);
   padding: 1px 6px;
-  border-radius: 2px;
+  border-radius: var(--r-xs);
   letter-spacing: 0.05em;
   display: inline-block;
 }

--- a/frontend/src/components/TopBar.module.css
+++ b/frontend/src/components/TopBar.module.css
@@ -40,7 +40,7 @@
   color: var(--acc);
   font-family: var(--serif);
   font-size: 13px;
-  border-radius: 2px;
+  border-radius: var(--r-xs);
 }
 
 .crumb {

--- a/frontend/src/screens/AgentDetailScreen.module.css
+++ b/frontend/src/screens/AgentDetailScreen.module.css
@@ -156,7 +156,7 @@
   letter-spacing: 0.04em;
   border: 1px solid color-mix(in oklab, var(--r-color) 50%, transparent);
   padding: 1px 8px;
-  border-radius: 2px;
+  border-radius: var(--r-xs);
   background: color-mix(in oklab, var(--r-color) 10%, transparent);
 }
 
@@ -372,7 +372,7 @@
 .barWrap {
   height: 6px;
   background: var(--bg-3);
-  border-radius: 3px;
+  border-radius: var(--r-sm);
   overflow: hidden;
 }
 
@@ -380,7 +380,7 @@
   display: block;
   height: 100%;
   background: var(--danger);
-  border-radius: 3px;
+  border-radius: var(--r-sm);
 }
 
 .matrixNum {

--- a/frontend/src/screens/GameListScreen.module.css
+++ b/frontend/src/screens/GameListScreen.module.css
@@ -180,7 +180,7 @@
   font-size: 10px;
   font-weight: 700;
   padding: 1px 7px;
-  border-radius: 10px;
+  border-radius: var(--r-md);
   letter-spacing: 0.06em;
 }
 .livePillDot {
@@ -198,7 +198,7 @@
   font-size: 10px;
   font-weight: 700;
   padding: 1px 6px;
-  border-radius: 2px;
+  border-radius: var(--r-xs);
   letter-spacing: 0.04em;
 }
 .winnerWolf    { background: rgba(226,107,107,0.15); color: var(--r-werewolf); }

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -92,7 +92,7 @@
   display: inline-flex; align-items: center; gap: 6px;
   background: transparent;
   border: 1px solid var(--bd);
-  border-radius: 12px;
+  border-radius: var(--r3);
   font-size: 11px;
   color: var(--tx-2);
   cursor: pointer;
@@ -100,7 +100,7 @@
 }
 .chip:hover { border-color: var(--tx-3); color: var(--tx); }
 .chip.on { background: var(--bg-3); border-color: var(--tx-3); color: var(--tx); }
-.chip .swatch { width: 8px; height: 8px; border-radius: 2px; }
+.chip .swatch { width: 8px; height: 8px; border-radius: var(--r-xs); }
 
 /* === Feed (center pane) === */
 .feedHead {
@@ -147,7 +147,7 @@
   color: var(--danger);
   font-size: 10px;
   padding: 1px 6px;
-  border-radius: 2px;
+  border-radius: var(--r-xs);
   letter-spacing: 0.05em;
 }
 .voteGrid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 6px 18px; }
@@ -224,7 +224,7 @@
 .action .what  { color: var(--tx-2); flex: 1; }
 .action .what strong { color: var(--tx); font-weight: 600; }
 .action .what em { font-style: normal; color: var(--r-color, var(--tx)); font-family: var(--serif); }
-.action .res   { font-family: var(--mono); font-size: 10px; padding: 1px 5px; border-radius: 2px; }
+.action .res   { font-family: var(--mono); font-size: 10px; padding: 1px 5px; border-radius: var(--r-xs); }
 .action .res.black { color: var(--r-werewolf); background: rgba(226,107,107,0.12); }
 .action .res.white { color: var(--r-seer);     background: rgba(110,168,255,0.12); }
 
@@ -268,7 +268,7 @@
 .coMeta { margin-left: auto; color: var(--tx-3); font-size: 10px; font-family: var(--mono); }
 
 /* filter chip swatch */
-.swatch { width: 8px; height: 8px; border-radius: 2px; }
+.swatch { width: 8px; height: 8px; border-radius: var(--r-xs); }
 
 /* game_over result row in left pane */
 .phaseGameOver { color: var(--tx-2); }

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -40,9 +40,13 @@
   --acc: #f0c75f;
 
   /* 角丸 */
+  --r-xs: 2px;
+  --r-sm: 3px;
   --r1: 4px;
   --r2: 8px;
+  --r-md: 10px;
   --r3: 12px;
+  --r-lg: 14px;
 
   /* フォント */
   --serif: "Noto Serif JP", "Hiragino Mincho ProN", serif;


### PR DESCRIPTION
## Summary
- `tokens.css`に新トークン（`--r-xs`=2px, `--r-sm`=3px, `--r-md`=10px, `--r-lg`=14px）を追加し、stylelintが検出していたborder-radiusの生値19箇所をトークン参照に置換
- `border-radius: 0` / `inherit`は値そのものに意味があるため`.stylelintrc.json`の`ignoreValues`に追加
- `.stylelintrc.json`の`scale-unlimited/declaration-strict-value`ルールを`severity: "warning"`から`"error"`に変更

## Implementation notes
- 調査の結果、color/background系の生値11件（hover/暗色シェード・グラデーション専用値）はいずれも既存トークンと一致せず機械的に置換できないと判明したため、本Issueのスコープから外し、Follow up issue #565（トークン戦略の決定）に切り出した
- `severity: "error"`化により、`npm run lint:css`は本PR後もcolor/background系11件のエラーが残る（#565で解消予定）。これは想定どおりであり、Issue #561のAC-3もそれを前提に更新済み
- pre-commitの`design-lint`フックはこの想定済みエラーでブロックされるため、この1コミットのみ`--no-verify`で例外的にスキップした（ユーザー承認済み）

## Test plan
- [x] `npm run lint:css` — border-radius系エラー0件（color/background系11件のエラーは既知・許容、#565で対応）
- [x] Playwright目視確認（GameListScreen / SpectatorScreen+FeedCard+TopBar+AgentRosterRow / AgentDetailScreen）— 角丸の見た目変化なし

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
