### PR TITLE
refactor: replace raw color/background values with tokens (#565)

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -21,7 +21,6 @@
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | ❌ yukkie/AgentVillage#562 | tech-debt | （なし） | （なし） | Survey font-size usage to design font-size tokens | font-size の使用実態を一覧化し、トークン化の粒度案を提案する（#557 のスコープ拡張から派生） |
-| ❌ yukkie/AgentVillage#565 | tech-debt | （なし） | （なし） | Decide token strategy for color/background raw values flagged by stylelint | #561 の調査で機械的に置換できなかった color/background 系生値11件のトークン化方針を決定する |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#495 | enhancement | 🟢 | 3 | design: log visibility classes and recipient-based authorization model (for LIVE / player participation) | LIVE/プレイヤー参加に向け、可視性クラス×受信者権限の配信認可モデルを先行設計（ADR）。replay は全配信の特殊ケース |
 | yukkie/AgentVillage#319 | enhancement | 🟢 | 3 | feat(frontend): LIVE spectator (real-time view of in-progress game) | state/ を tail して進行中ゲームを表示（将来フェーズ） |

--- a/frontend/.stylelintrc.json
+++ b/frontend/.stylelintrc.json
@@ -13,7 +13,13 @@
       {
         "ignoreValues": {
           "": ["inherit", "transparent", "none"],
-          "border-radius": ["50%", "0", "inherit"]
+          "border-radius": ["50%", "0", "inherit"],
+          "background": [
+            "inherit",
+            "transparent",
+            "none",
+            "/^radial-gradient\\(/"
+          ]
         },
         "severity": "error"
       }

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -80,7 +80,7 @@
   gap: 14px;
   padding: 40px 24px;
   background:
-    radial-gradient(circle at 50% 32%, rgba(125, 181, 255, 0.12), transparent 34%),
+    radial-gradient(circle at 50% 32%, rgba(var(--info-rgb), 0.12), transparent 34%),
     var(--bg);
   color: var(--tx);
   text-align: center;

--- a/frontend/src/components/Avatar.module.css
+++ b/frontend/src/components/Avatar.module.css
@@ -14,7 +14,7 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(ellipse at 50% 30%, var(--av-c, #444) 0%, transparent 70%),
+    radial-gradient(ellipse at 50% 30%, var(--av-c, var(--av-fallback)) 0%, transparent 70%),
     linear-gradient(180deg, color-mix(in oklab, var(--av-c, #555) 35%, #1a1d24), #0e1015);
 }
 

--- a/frontend/src/components/FeedCard.module.css
+++ b/frontend/src/components/FeedCard.module.css
@@ -203,9 +203,9 @@
   background: var(--bg-3); color: var(--tx-2);
 }
 .sysrow.exec  .sysIcon { background: rgba(226,107,107,0.15); color: var(--danger); }
-.sysrow.death .sysIcon { background: #2a1418; color: var(--danger); }
+.sysrow.death .sysIcon { background: var(--danger-dark); color: var(--danger); }
 .sysrow.gm    .sysIcon { background: rgba(240,199,95,0.12);  color: var(--acc); }
-.sysrow.phase .sysIcon { background: rgba(125,108,255,0.18); color: #b6abff; }
+.sysrow.phase .sysIcon { background: rgba(125,108,255,0.18); color: var(--phase-tint); }
 
 /* Relationship snapshot (suspicion / threat meters) */
 .scoreSnapshot {
@@ -282,7 +282,7 @@
   text-align: center;
   text-transform: uppercase;
 }
-.scoreItem.low .scoreFill { background: #5fbd7a; }
+.scoreItem.low .scoreFill { background: var(--alive-low); }
 .scoreItem.medium .scoreFill { background: var(--acc); }
 .scoreItem.high .scoreFill { background: var(--danger); }
 .scoreList.threat .scoreItem.low .scoreFill { background: rgba(226,107,107,0.45); }

--- a/frontend/src/components/TopBar.module.css
+++ b/frontend/src/components/TopBar.module.css
@@ -88,10 +88,10 @@
 .primary {
   background: var(--acc);
   border-color: var(--acc);
-  color: #1a1408;
+  color: var(--acc-ink);
   font-weight: 600;
 }
-.primary:hover { background: #f5d06e; border-color: #f5d06e; color: #1a1408; }
+.primary:hover { background: var(--acc-hover); border-color: var(--acc-hover); color: var(--acc-ink); }
 
 .liveDot {
   width: 7px;

--- a/frontend/src/screens/GameListScreen.module.css
+++ b/frontend/src/screens/GameListScreen.module.css
@@ -432,7 +432,7 @@
   background: var(--acc);
   border: none;
   border-radius: var(--r1);
-  color: #fff;
+  color: var(--tx-on-acc);
   font-size: 13px;
   font-family: var(--sans);
   font-weight: 600;

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -72,7 +72,7 @@
   flex: 0 0 6px;
 }
 .phaseItem.day   .dot { background: var(--acc); }
-.phaseItem.night .dot { background: #7d6cff; }
+.phaseItem.night .dot { background: var(--phase-night); }
 .phaseItem.exec  .dot { background: var(--danger); }
 .phaseItem .turn {
   font-family: var(--mono);
@@ -249,7 +249,7 @@
 
 /* phase nav inner */
 .phaseDiscuss .dot { background: var(--acc); }
-.phaseNight   .dot { background: #7d6cff; }
+.phaseNight   .dot { background: var(--phase-night); }
 .phaseExec    .dot { background: var(--danger); }
 .deathline { font-size: 10px; color: var(--danger); }
 .phaseTurn { font-family: var(--mono); font-size: 10px; color: var(--tx-2); margin-left: auto; }

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -20,6 +20,8 @@
   --tx-2: #dadde4;
   --tx-3: #c2c7d1;
   --tx-4: #aab0bd;
+  --tx-on-acc: #fff;
+  --av-fallback: #444;
 
   /* 役職カラー */
   --r-villager: #95a8bd;
@@ -31,13 +33,20 @@
 
   /* ステータス */
   --alive: #6dd592;
+  --alive-low: #5fbd7a;
   --dead: #6e7585;
   --warn: #e8a85c;
   --danger: #e26b6b;
+  --danger-dark: #2a1418;
   --info: #6ea8ff;
+  --info-rgb: 110, 168, 255;
+  --phase-tint: #b6abff;
+  --phase-night: #7d6cff;
 
   /* アクセント（山吹色） */
   --acc: #f0c75f;
+  --acc-ink: #1a1408;
+  --acc-hover: #f5d06e;
 
   /* 角丸 */
   --r-xs: 2px;


### PR DESCRIPTION
## Summary
- `tokens.css`に9トークン（`--info-rgb`, `--av-fallback`, `--danger-dark`, `--phase-tint`, `--alive-low`, `--acc-ink`, `--acc-hover`, `--tx-on-acc`, `--phase-night`）を追加し、#561で機械的に置換できなかったcolor/background系の生値9箇所をトークン参照に置換
- `radial-gradient`構文を含む2箇所（App.module.css, Avatar.module.css）は`.stylelintrc.json`の`ignoreValues`に`/^radial-gradient\(/`を追加して許容

## Implementation notes
- 調査の結果、`stylelint-declaration-strict-value`プラグインは`radial-gradient`構文の値を一律「色として無効」と判定するバグに近い仕様を持っており、内部の色をすべて`var()`化してもエラーが解消しないことが分かった（逆に`linear-gradient`の単純な2色形式は生のhex値でも誤って常に許容される）
- このため`radial-gradient`を使う2箇所はトークン化した上で、`.stylelintrc.json`の`ignoreValues.background`に`radial-gradient`構文全体を正規表現で許容するルールを追加した（ユーザー承認済み：引数は問わず`radial-gradient`全体を許容する方針）

## Test plan
- [x] `npm run lint:css` — エラー0件
- [x] grep確認 — 対象9箇所の生hex値の残存なし
- [x] Playwright目視確認（GameListScreen createBtn / SpectatorScreen night phaseドット・FeedCard death行アイコン）— 表示色の変化なし

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)
