### PR TITLE
refactor: replace set-state-in-effect resets with key remount

### DIFF
--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -350,29 +350,18 @@ function GlobalProfile({ agent, blurb }) {
   );
 }
 
-// === メイン画面 ===
-export default function AgentDetailScreen() {
-  const { sessionId, agentName } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const viewerMode = viewerModeFromSearchParams(searchParams);
-  const viewerSearch = searchForViewerMode(viewerMode);
-  const agent = agentName || 'Nox';
-  const blurb = useAgentBlurb(agent);
+// --- game-scoped mode 本体（sessionId ごとに key 再マウントし、fetch state を新規化する） ---
+function GameScopedProfile({ sessionId, agent, blurb, viewerMode, viewerSearch, toggleViewerMode }) {
   const [gameScopedState, setGameScopedState] = useState({
-    status: sessionId ? 'loading' : 'idle',
+    status: 'loading',
     entry: null,
     gameData: null,
     error: null,
   });
-  const gameScopedEvents = gameScopedState.gameData?.events;
-  const deaths = useDeaths(gameScopedEvents);
+  const deaths = useDeaths(gameScopedState.gameData?.events);
 
   useEffect(() => {
-    if (!sessionId) return undefined;
-
     let cancelled = false;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sessionId 変更時の意図的なリセット。key 再マウント化は別Issueで検討
-    setGameScopedState({ status: 'loading', entry: null, gameData: null, error: null });
 
     fetchGameBySessionId(sessionId)
       .then(entry => fetchReplayGame({ sessionId, cast: entry.cast ?? [] }).then(gameData => ({ entry, gameData })))
@@ -387,15 +376,6 @@ export default function AgentDetailScreen() {
       cancelled = true;
     };
   }, [sessionId]);
-
-  // sessionId なし → global profile mode（横断戦績・実データ）
-  if (!sessionId) {
-    return <GlobalProfile agent={agent} blurb={blurb} />;
-  }
-
-  const toggleViewerMode = () => {
-    setSearchParams(viewerMode === 'spectator' ? { view: 'public' } : {});
-  };
 
   const topCrumbs = [
     { label: 'r/agent-jinrou', to: '/' },
@@ -464,5 +444,36 @@ export default function AgentDetailScreen() {
       </TopBar>
       {body}
     </div>
+  );
+}
+
+// === メイン画面 ===
+export default function AgentDetailScreen() {
+  const { sessionId, agentName } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const viewerMode = viewerModeFromSearchParams(searchParams);
+  const viewerSearch = searchForViewerMode(viewerMode);
+  const agent = agentName || 'Nox';
+  const blurb = useAgentBlurb(agent);
+
+  // sessionId なし → global profile mode（横断戦績・実データ）
+  if (!sessionId) {
+    return <GlobalProfile agent={agent} blurb={blurb} />;
+  }
+
+  const toggleViewerMode = () => {
+    setSearchParams(viewerMode === 'spectator' ? { view: 'public' } : {});
+  };
+
+  return (
+    <GameScopedProfile
+      key={sessionId}
+      sessionId={sessionId}
+      agent={agent}
+      blurb={blurb}
+      viewerMode={viewerMode}
+      viewerSearch={viewerSearch}
+      toggleViewerMode={toggleViewerMode}
+    />
   );
 }

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -314,69 +314,33 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
   );
 }
 
-// === メイン観戦画面 ===
-export default function SpectatorScreen() {
-  const { sessionId } = useParams();
-  const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [activeDay, setActiveDay] = useState(2);
-  const [activePhase, setActivePhase] = useState('discuss');
+// --- リプレイ fetch state（sessionId ごとに key 再マウントし、fetch state を新規化する） ---
+function SpectatorReplayData({
+  sessionId,
+  viewerMode,
+  navigate,
+  toggleViewerMode,
+  activeDay,
+  setActiveDay,
+  activePhase,
+  setActivePhase,
+  selectedAgents,
+  toggleAgentFilter,
+  selectedRoles,
+  toggleRoleFilter,
+  thoughtsOpen,
+  toggleThoughtsOpen,
+}) {
   const [replayEvents, setReplayEvents] = useState(null);
   const [replayAgents, setReplayAgents] = useState({});
   const [replayDaySummary, setReplayDaySummary] = useState({});
   const [gameOverDay, setGameOverDay] = useState(null);
-  const [loadingEvents, setLoadingEvents] = useState(Boolean(sessionId));
-  const [loadingAgents, setLoadingAgents] = useState(Boolean(sessionId));
+  const [loadingEvents, setLoadingEvents] = useState(true);
+  const [loadingAgents, setLoadingAgents] = useState(true);
   const [loadError, setLoadError] = useState(null);
-  const [selectedAgents, setSelectedAgents] = useState(() => new Set());
-  const [selectedRoles, setSelectedRoles] = useState(() => new Set());
-  const [thoughtsOpen, setThoughtsOpen] = useState(false);
-  const viewerMode = viewerModeFromSearchParams(searchParams);
-
-  const toggleViewerMode = () => {
-    setSearchParams(viewerMode === 'spectator' ? { view: 'public' } : {});
-  };
-
-  const toggleAgentFilter = (agentName) => {
-    setSelectedAgents(current => {
-      const next = new Set(current);
-      if (next.has(agentName)) {
-        next.delete(agentName);
-      } else {
-        next.add(agentName);
-      }
-      return next;
-    });
-  };
-
-  const toggleRoleFilter = (roleKey) => {
-    setSelectedRoles(current => {
-      const next = new Set(current);
-      if (next.has(roleKey)) {
-        next.delete(roleKey);
-      } else {
-        next.add(roleKey);
-      }
-      return next;
-    });
-  };
-
-  const toggleThoughtsOpen = () => {
-    setThoughtsOpen(current => !current);
-  };
 
   useEffect(() => {
-    if (!sessionId) return undefined;
-
     let cancelled = false;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sessionId 変更時の意図的なリセット。key 再マウント化は別Issueで検討
-    setReplayEvents(null);
-    setReplayAgents({});
-    setReplayDaySummary({});
-    setGameOverDay(null);
-    setLoadingEvents(true);
-    setLoadingAgents(true);
-    setLoadError(null);
 
     fetchGameBySessionId(sessionId)
       .then(entry => fetchReplayAgents({ sessionId, cast: entry.cast ?? [] }))
@@ -412,7 +376,7 @@ export default function SpectatorScreen() {
     return () => {
       cancelled = true;
     };
-  }, [sessionId]);
+  }, [sessionId, setActiveDay, setActivePhase]);
 
   const events = useMemo(() => replayEvents ?? [], [replayEvents]);
   const replayDeaths = useDeaths(replayEvents);
@@ -495,5 +459,70 @@ export default function SpectatorScreen() {
         </div>
       </ThreePaneLayout>
     </div>
+  );
+}
+
+// === メイン観戦画面 ===
+export default function SpectatorScreen() {
+  const { sessionId } = useParams();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [activeDay, setActiveDay] = useState(2);
+  const [activePhase, setActivePhase] = useState('discuss');
+  const [selectedAgents, setSelectedAgents] = useState(() => new Set());
+  const [selectedRoles, setSelectedRoles] = useState(() => new Set());
+  const [thoughtsOpen, setThoughtsOpen] = useState(false);
+  const viewerMode = viewerModeFromSearchParams(searchParams);
+
+  const toggleViewerMode = () => {
+    setSearchParams(viewerMode === 'spectator' ? { view: 'public' } : {});
+  };
+
+  const toggleAgentFilter = (agentName) => {
+    setSelectedAgents(current => {
+      const next = new Set(current);
+      if (next.has(agentName)) {
+        next.delete(agentName);
+      } else {
+        next.add(agentName);
+      }
+      return next;
+    });
+  };
+
+  const toggleRoleFilter = (roleKey) => {
+    setSelectedRoles(current => {
+      const next = new Set(current);
+      if (next.has(roleKey)) {
+        next.delete(roleKey);
+      } else {
+        next.add(roleKey);
+      }
+      return next;
+    });
+  };
+
+  const toggleThoughtsOpen = () => {
+    setThoughtsOpen(current => !current);
+  };
+
+  return (
+    <SpectatorReplayData
+      key={sessionId}
+      sessionId={sessionId}
+      viewerMode={viewerMode}
+      navigate={navigate}
+      toggleViewerMode={toggleViewerMode}
+      activeDay={activeDay}
+      setActiveDay={setActiveDay}
+      activePhase={activePhase}
+      setActivePhase={setActivePhase}
+      selectedAgents={selectedAgents}
+      toggleAgentFilter={toggleAgentFilter}
+      selectedRoles={selectedRoles}
+      toggleRoleFilter={toggleRoleFilter}
+      thoughtsOpen={thoughtsOpen}
+      toggleThoughtsOpen={toggleThoughtsOpen}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- `AgentDetailScreen.jsx` / `SpectatorScreen.jsx` の `sessionId` 変更時の state リセットを `useEffect` 本体内の直接 `setState` から `key={sessionId}` 再マウント方式に書き直した
- fetch 関連 state のみを内側コンポーネント（`GameScopedProfile` / `SpectatorReplayData`）へ切り出し、`key` 再マウントで初期化する。フィルタ・UI 状態（`activeDay` 等）は既存どおりリセットせず親に残し、挙動を変えていない
- 両ファイルの `react-hooks/set-state-in-effect` disable コメントを除去

## Implementation notes
- 切り出した内側コンポーネントは既存パターン（`GlobalProfile`）に揃えて命名
- ドキュメント更新なし（FrontendDesign.md にこの実装詳細の設計記述はもとからない）

## Test plan
- [x] `npm run lint` パス
- [x] `npx vitest run`（フルスイート329件）パス
- [x] Playwright で sessionId 切替時の古いデータリークなしを目視確認（AgentDetailScreen / SpectatorScreen 双方でSPA内クリック遷移を検証）

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)