### PR TITLE
docs: add issue #572 to Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,6 +19,7 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
+| ❌ yukkie/AgentVillage#572 | tech-debt | （なし） | （なし） | Reduce font-size variants: define --fs-* tokens and replace raw values | #562 調査の §7.4.1 粒度案を基に --fs-* トークン定義・既存CSS置き換え・stylelint検出追加。半端値の吸収先・大見出し系の扱いは実機で吟味 |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | ❌ yukkie/AgentVillage#568 | tech-debt | （なし） | （なし） | Refactor sessionId-driven state reset out of useEffect (set-state-in-effect) | ESLint導入で発覚した set-state-in-effect 違反2箇所をkey再マウント等で解消する |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |


### PR DESCRIPTION
## Summary
- フォントサイズトークン化の実装 Issue #572 を `doc/Ideas.md` のリスト先頭に `❌`（tech-debt）で追記

#562 の調査（§7.4.1 粒度案）を土台に、`--fs-*` トークン定義・既存 CSS 置き換え・stylelint 検出追加を行うフォローアップ Issue。半端値の吸収先・大見出し系の扱いは実機（Playwright）で吟味する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)