### PR TITLE
docs: add AgentDetail wolf_chat bug to Ideas.md tracker

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -19,6 +19,7 @@
 
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
+| ❌ yukkie/AgentVillage#578 | bug | 🔴 | - | AgentDetail day timeline is missing wolf_chat (night conversation) events | AgentDetailScreen の中央タイムラインに wolf_chat が含まれておらず夜の会話が表示されない（#533 の要件漏れ） |
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#495 | enhancement | 🟢 | 3 | design: log visibility classes and recipient-based authorization model (for LIVE / player participation) | LIVE/プレイヤー参加に向け、可視性クラス×受信者権限の配信認可モデルを先行設計（ADR）。replay は全配信の特殊ケース |


### PR DESCRIPTION
## Summary
- Ideas.md の Milestone 3 テーブル先頭に、新規起票した AgentDetail wolf_chat 表示バグを追記