### PR TITLE
docs: split issue #424 (read-matrix -> #581) in Ideas.md

### DIFF
--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -53,7 +53,8 @@
 | yukkie/AgentVillage#315 | enhancement | 🟢 | 8 | feat: FastAPI + WebSocket backend for real-time web streaming | リアルタイムストリーミング（Milestone 2 完了後） |
 | yukkie/AgentVillage#316 | enhancement | 🟢 | 13 | feat: mobile app (React Native) | iOS/Android 対応（#315 完了後） |
 | yukkie/AgentVillage#30 | enhancement | 🟢 | 13 | State management DB migration (SQLite → PostgreSQL) | JSON → DB 移行 |
-| yukkie/AgentVillage#424 | enhancement | 🟢 | 5 | Dev tool (1/3): AST-based relationship extraction for a central data type | 中心データ型の producer/consumer/transform を Python AST で全列挙し隣接リスト出力（consumer×field read マトリクス含む）。#466 の設計比較の入力。JS 抽出は #508 に分割 |
+| yukkie/AgentVillage#424 | enhancement | 🟢 | 5 | Dev tool (1/3): AST-based relationship extraction for a central data type | 中心データ型の producer/consumer/transform を Python AST で全列挙し隣接リスト出力。`type-lineage` スキルとして実装（skills repo・テスト同梱）。#466 の設計比較の入力。read マトリクスは #581、JS 抽出は #508 に分割 |
+| yukkie/AgentVillage#581 | enhancement | 🟢 | 3 | Dev tool (1/3, split): consumer×field read matrix for a central data type | #424 から分割。#424 の隣接リストスキーマ上に reads-field エッジ属性として consumer×field read マトリクス（structured/passthrough 区別・event-specific/shared 分類）を表現。#466 設計比較の consumer-side 入力。依存: #424。SP 再見積もり対象 |
 | yukkie/AgentVillage#508 | enhancement | 🟢 | 5 | Dev tool (2/3): JS field-access extraction | JS consumer のフィールド read をヒューリスティック抽出し #424 の隣接リストに統合（source: js / confidence: heuristic）。#379 導入後は型起点へ強化。依存: #424 |
 | yukkie/AgentVillage#425 | enhancement | 🟢 | 3 | Dev tool (3/3): smell evaluation skill over the extracted relationship graph | #424 のグラフに判定基準を適用する AI 評価スキル（判定コードは書かない）。淀み度集計＋4評価軸。依存: #424。SP 再見積もり対象 |
 | yukkie/AgentVillage#543 | enhancement | 🟢 | 8 | Dev tool: machine-managed Issue dependency graph (bidirectional) | issue SKILL.md の依存配線（依存:/依存される Issue:/順序制約）を機械抽出し隣接リスト化。片方向リンク・分割時の張り替え漏れを整合性チェックで検出。#424 の隣接リスト／2層分離思想を踏襲。依存: #424 |


### PR DESCRIPTION
## Summary
- #424 を分割し、consumer×field read マトリクス（旧 AC-9）を新 Issue #581 に切り出したのに合わせて `doc/Ideas.md` を同期。
- #581 の行を追加（`type-lineage` の隣接リストスキーマ上に reads-field エッジ属性として read マトリクスを表現、#466 の consumer-side 入力、依存: #424）。
- #424 の要約を更新（`type-lineage` スキル形式・read マトリクスは #581・JS 抽出は #508 に分割）。

## Notes
- 分割に伴う依存の双方向再配線（#581↔#424、#466 に `依存: #581`、#425/#508 に #581 を関連追記）は Issue 本体で実施済み。本 PR は Ideas.md の同期のみ。
- Ideas.md 同期 PR のため `Closes` キーワードは付けない（自動クローズ防止）。