### PR TITLE
refactor(frontend): merge Avatar icon impls and extract AgentLink (#585 + #586)

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -424,6 +424,8 @@ stateDiagram-v2
 
 `label` あり時は identity wrapper 要素（新クラス）がアイコン frame（`.av`）を内包する構造になる。`.av` のスタイルは変更しないため、`label` なしの既存呼び出しは挙動変更なし。
 
+内部構成: アイコン描画は単一の内部実装（`AvatarIcon`）に一本化されている（#585）。`alt` は公開 prop ではなく、`Avatar` が `label` の有無から導出して内部的に渡す（`label` あり → `alt=""`、なし → `alt={name}`）。導出規則と食い違う消費箇所を作らないため、`alt` を個別制御する prop は設けない。
+
 データソース: `AGENT_COLORS`（`lib/agentMeta.js`・`agents.json` の `color` 由来）でエージェント名 → 個人カラー（`--av-c`）を解決。
 
 #### `AvatarButton`（named export）
@@ -437,12 +439,29 @@ stateDiagram-v2
 | `...avatarProps` | — | `Avatar` の全 props をそのまま受け付ける |
 
 hover / focus スタイルは CSS `:hover` / `:focus-visible` で付与（`variant` prop には含まない）。
-画面遷移用途では Avatar を React Router `<Link>` で直接包む方式を採用（#485）。`AvatarLink` コンポーネントの追加は不要と判断。
+画面遷移用途では Avatar を `<Link>` で包む方式を採用（#485）。当初はコンポーネント化せず各呼び出し側で `<Link>` を書いていたが、link wrapper JSX と `.agentLink` CSS のコピーが増えたため `AgentLink` に一本化した（#586）。
 
 **使い分け:**
 - icon-only（名前テキスト不要）→ bare `Avatar`（`label` なし）
 - 名前表示・display-only → `Avatar` with `label`
-- 名前表示・クリック可能 → `AvatarButton` with `label`
+- 名前表示・クリック可能（画面内アクション）→ `AvatarButton` with `label`
+- AgentDetail への画面遷移 → `AgentLink` で包む（中身は bare `Avatar` / labeled `Avatar` / テキストいずれも可）
+
+#### `AgentLink`
+
+AgentDetail への画面遷移リンクラッパー（#586）。`Link to={agentDetailPath(...)}` の組み立てと `.agentLink` CSS（reset＋`display: contents` / `:hover` opacity / `:focus-visible` outline）を単独で所有する。SpectatorScreen（CoStatusBoard・NightActionsPanel・投票グリッド）と FeedCard（SpeechCard・AgentEpisodeCard・WolfChatCard・SystemRow）の全リンク箇所がこれを使う。
+
+| prop | 型 | 説明 |
+|---|---|---|
+| `sessionId` | `string` | セッション ID（必須） |
+| `name` | `string` | 遷移先エージェント名（必須） |
+| `viewerMode` | `string` | `'spectator'｜'public'`（必須・デフォルトなし）。渡し忘れを黙って spectator に落とさず、テストで顕在化させるため |
+| `style` | `object?` | `Link` に素通しする inline style。`display: contents` のため CSS 変数（例: `--r-color`）が children に継承される |
+| `children` | node | リンクの中身。Avatar 描画は所有しない（呼び出し側が bare/labeled Avatar・テキスト span を自由に入れる） |
+
+children ベースの API とした理由: 重複していたのは「`Link` + `agentDetailPath` + `className`」の三点セットであり、Avatar 描画は重複していない（テキスト span を包む箇所もある）。パスは `lib/agentLinks.js` の `agentDetailPath` を内部で使う。
+
+アクセシビリティ: children が bare `Avatar` のみ（可視テキストなし）の場合、リンクのアクセシブルネームは `img alt={name}` が供給する（#585 の alt 導出規則が前提）。
 
 #### `RoleTag`
 
@@ -483,7 +502,7 @@ hover / focus スタイルは CSS `:hover` / `:focus-visible` で付与（`varia
 
 内部に `SpeechCard` / `WolfChatCard` / `AgentEpisodeCard` / `RelationshipUpdateRow` と付随純粋関数（`fmtTurn` / `fmtTime` / `Mentioned` / `ThoughtDetails` / `contentForViewer` / `RelationshipMeterList` / `SYSTEM_EVENT_VIEWS` / `renderConfiguredSystemEvent`）・定数（`MISSING_CONTENT` / `SPECTATOR_ONLY_EVENTS`）を同梱する。
 
-特定 screen の state（`useState`）に依存せず、`sessionId` は props で受ける（`useParams` は使わない）。AgentDetail へのリンクパスは `lib/agentLinks.js` の `agentDetailPath(sessionId, name, viewerMode)` で組み立てる（SpectatorScreen 側 RightPane とも共有する純粋関数）。
+特定 screen の state（`useState`）に依存せず、`sessionId` は props で受ける（`useParams` は使わない）。AgentDetail へのリンクは共有コンポーネント `AgentLink`（#586）で描画する（パス組み立ては `AgentLink` 内部の `lib/agentLinks.js` `agentDetailPath` に委譲）。
 
 #### `Icon`
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,8 +20,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#585 | tech-debt | 🔴 | - | Merge duplicated AvatarIcon / AvatarIconLabeled in Avatar.jsx | Avatar.jsx の2関数がほぼ完全コピー（差分は img alt のみ）。alt を prop 化して1実装に統合。SP は refinement で見積もり |
-| yukkie/AgentVillage#586 | tech-debt | 🔴 | - | Extract shared AgentLink component (JSX + copied .agentLink CSS) | `<Link><Avatar/></Link>` パターン約10箇所と .agentLink CSS の2重コピーを AgentLink コンポーネントに集約。SP は refinement で見積もり |
 | yukkie/AgentVillage#587 | tech-debt | 🔴 | - | Consolidate viewerMode handling into a shared useViewerMode hook | viewerMode の parse/serialize/toggle/切替ボタンが両 screen に重複（searchForViewerMode は lib 済みなのに再定義）。useViewerMode() に集約。SP は refinement で見積もり |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#495 | enhancement | 🟢 | 3 | design: log visibility classes and recipient-based authorization model (for LIVE / player participation) | LIVE/プレイヤー参加に向け、可視性クラス×受信者権限の配信認可モデルを先行設計（ADR）。replay は全配信の特殊ケース |
@@ -81,3 +79,4 @@ frontend 特化 self-reflection review（観点 E 中心）で検出した mediu
 - **FeedCard 3カードの骨格コピー**（🟡）: SpeechCard / AgentEpisodeCard / WolfChatCard が `article > Link+Avatar > vert > spHead` を複製 → `FeedCardShell` 抽出
 - **Set トグル state の3重複**（🟢）: toggleAgentFilter / toggleRoleFilter / GameList toggleAgent → `toggleInSet` ユーティリティか `useToggleSet()` フック
 - **fetchGameBySessionId の INDEX fetch 再実装**（🟢）: fetchGameList と同じ fetch＋エラー処理を重複、呼び出しごとに index.json 全体を再取得 → 共通 `fetchIndex()`
+- **AgentRosterRow のアクセシブルネーム重複**（🟢・#585/#586 設計時に検出）: 行リンク内で bare Avatar の `alt={name}` と可視の名前 span が同居し、スクリーンリーダーの読み上げが「Alice Alice …」と二重になる。#585 の alt 導出（可視ラベルがあれば `alt=""`）は Avatar の `label` prop 経由でしか効かないため、AgentRosterRow が alt 抑制を伝える手段（`label` 利用への構造変更 or 装飾指定 prop）が要る

--- a/frontend/src/components/AgentLink.jsx
+++ b/frontend/src/components/AgentLink.jsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+import { agentDetailPath } from '../lib/agentLinks.js';
+import styles from './AgentLink.module.css';
+
+/**
+ * AgentDetail への画面遷移リンクラッパー（#586）。
+ * `Link to={agentDetailPath(...)}` の組み立てと `.agentLink` CSS を単独で所有する。
+ * children ベース: Avatar 描画は所有しない（bare/labeled Avatar・テキスト span いずれも包める）。
+ * `viewerMode` は必須（デフォルトなし。渡し忘れを黙って spectator に落とさずテストで顕在化させる）。
+ * `style` は Link へ素通し（`display: contents` のため CSS 変数が children に継承される）。
+ */
+export default function AgentLink({ sessionId, name, viewerMode, style, children }) {
+  return (
+    <Link to={agentDetailPath(sessionId, name, viewerMode)} className={styles.agentLink} style={style}>
+      {children}
+    </Link>
+  );
+}

--- a/frontend/src/components/AgentLink.module.css
+++ b/frontend/src/components/AgentLink.module.css
@@ -1,0 +1,8 @@
+/* agent navigation link wrapper — 唯一の家（#586。旧 SpectatorScreen / FeedCard のコピーを一本化） */
+.agentLink {
+  text-decoration: none;
+  color: inherit;
+  display: contents;
+}
+.agentLink:hover { opacity: 0.75; }
+.agentLink:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; border-radius: var(--r1); }

--- a/frontend/src/components/AgentLink.test.jsx
+++ b/frontend/src/components/AgentLink.test.jsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AgentLink from './AgentLink.jsx';
+import Avatar from './Avatar.jsx';
+import styles from './AgentLink.module.css';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AgentLink', () => {
+  it('統合: AgentLink: agentDetailPath で href を組み立てる（spectator はクエリなし）', () => {
+    /*
+     * SUT: AgentLink
+     * Mock: なし（plain props を入力）
+     * Level: integration
+     * Objective: sessionId / name / viewerMode=spectator から /game/{sessionId}/agent/{name}（クエリなし）の href を組み立てることを検証する（AC-586-1）。
+     */
+    render(
+      <MemoryRouter>
+        <AgentLink sessionId="s1" name="Alice" viewerMode="spectator">Alice</AgentLink>
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link').getAttribute('href')).toBe('/game/s1/agent/Alice');
+  });
+
+  it('統合: AgentLink: viewerMode=public で ?view=public を付与する', () => {
+    /*
+     * SUT: AgentLink
+     * Mock: なし（plain props を入力）
+     * Level: integration
+     * Objective: viewerMode=public のとき href に ?view=public を付与し、viewer モードをリンク先へ引き継ぐことを検証する（AC-586-1）。
+     */
+    render(
+      <MemoryRouter>
+        <AgentLink sessionId="s1" name="Alice" viewerMode="public">Alice</AgentLink>
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link').getAttribute('href')).toBe('/game/s1/agent/Alice?view=public');
+  });
+
+  it('統合: AgentLink: children を agentLink クラスの Link 内に描画する', () => {
+    /*
+     * SUT: AgentLink
+     * Mock: なし（plain props を入力）
+     * Level: integration
+     * Objective: children が Link 要素の内側に描画され、Link に AgentLink.module.css の agentLink クラスが付くことを検証する（AC-586-1）。
+     */
+    render(
+      <MemoryRouter>
+        <AgentLink sessionId="s1" name="Alice" viewerMode="spectator">
+          <span data-testid="child">Alice</span>
+        </AgentLink>
+      </MemoryRouter>
+    );
+    const link = screen.getByRole('link');
+    expect(link.classList.contains(styles.agentLink)).toBe(true);
+    expect(link.contains(screen.getByTestId('child'))).toBe(true);
+  });
+
+  it('統合: AgentLink: style を Link に引き継ぐ', () => {
+    /*
+     * SUT: AgentLink
+     * Mock: なし（plain props を入力）
+     * Level: integration
+     * Objective: style prop（CSS 変数 --r-color 等）が Link 要素の inline style へ素通しされることを検証する（SpectatorScreen NightActions target の役職色の契約。AC-586-3 の className/style 面）。
+     */
+    render(
+      <MemoryRouter>
+        <AgentLink sessionId="s1" name="Alice" viewerMode="spectator" style={{ '--r-color': 'rgb(1, 2, 3)' }}>Alice</AgentLink>
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link').style.getPropertyValue('--r-color')).toBe('rgb(1, 2, 3)');
+  });
+
+  it('統合: AgentLink: bare Avatar 子のリンクは name をアクセシブルネームに持つ', () => {
+    /*
+     * SUT: AgentLink（+ bare Avatar）
+     * Mock: なし（plain props を入力）
+     * Level: integration
+     * Objective: 可視テキストのない bare Avatar のみを包むリンクが img alt={name} をアクセシブルネームとして持つことを検証する（#585×#586 の組み合わせ境界: SystemRow 型 icon-only リンク）。
+     */
+    const { container } = render(
+      <MemoryRouter>
+        <AgentLink sessionId="s1" name="Nox" viewerMode="spectator">
+          <Avatar name="Nox" />
+        </AgentLink>
+      </MemoryRouter>
+    );
+    // jsdom は img の load を発火しないため頭文字フォールバック "N" が残り、
+    // アクセシブルネームが "Nox N" になる。実ブラウザの画像ロード後状態に合わせて load を発火する。
+    fireEvent.load(container.querySelector('img'));
+    expect(screen.getByRole('link', { name: 'Nox' })).toBeTruthy();
+  });
+});

--- a/frontend/src/components/Avatar.jsx
+++ b/frontend/src/components/Avatar.jsx
@@ -3,7 +3,9 @@ import { ROLE_META_BY_KEY } from '../lib/roleMeta.js';
 import { AGENT_COLORS } from '../lib/agentMeta.js';
 import styles from './Avatar.module.css';
 
-function AvatarIcon({ name, role, dead, size, highlight }) {
+// 唯一のアイコン描画実装（#585 で labeled 用コピーを統合）。
+// alt は内部 API: Avatar が label の有無から導出して渡す（labeled は隣の可視ラベルが名前を担うため alt=""）。
+function AvatarIcon({ name, role, dead, size, highlight, alt }) {
   const [imgLoaded, setImgLoaded] = useState(false);
   const color = AGENT_COLORS[name] || '#888';
   const roleInfo = role && ROLE_META_BY_KEY[role];
@@ -20,36 +22,7 @@ function AvatarIcon({ name, role, dead, size, highlight }) {
       <div className={styles.grad} />
       <img
         src={`/icons/${name}.png`}
-        alt={name}
-        className={styles.img}
-        onLoad={() => setImgLoaded(true)}
-        onError={(e) => { e.currentTarget.style.display = 'none'; }}
-      />
-      {!imgLoaded && <div className={styles.mono}>{(name || '?').charAt(0)}</div>}
-      {roleInfo && <div className={styles.roleTag}>{roleInfo.ja}</div>}
-      {dead && <div className={styles.deadMark}>死亡</div>}
-    </div>
-  );
-}
-
-function AvatarIconLabeled({ name, role, dead, size, highlight }) {
-  const [imgLoaded, setImgLoaded] = useState(false);
-  const color = AGENT_COLORS[name] || '#888';
-  const roleInfo = role && ROLE_META_BY_KEY[role];
-  const sizeClass = size === 'sm' ? styles.sm : size === 'xs' ? styles.xs : '';
-
-  return (
-    <div
-      className={`${styles.av} ${sizeClass}`}
-      style={{
-        '--av-c': color,
-        boxShadow: highlight ? `0 0 0 2px ${color}` : 'none',
-      }}
-    >
-      <div className={styles.grad} />
-      <img
-        src={`/icons/${name}.png`}
-        alt=""
+        alt={alt}
         className={styles.img}
         onLoad={() => setImgLoaded(true)}
         onError={(e) => { e.currentTarget.style.display = 'none'; }}
@@ -67,7 +40,7 @@ function AvatarIconLabeled({ name, role, dead, size, highlight }) {
  */
 export default function Avatar({ name, role, dead, size = 'md', highlight, label, layout = 'vertical', variant = 'plain' }) {
   if (!label) {
-    return <AvatarIcon name={name} role={role} dead={dead} size={size} highlight={highlight} />;
+    return <AvatarIcon name={name} role={role} dead={dead} size={size} highlight={highlight} alt={name} />;
   }
 
   const layoutClass = layout === 'horizontal' ? styles.chipH : styles.chipV;
@@ -75,7 +48,7 @@ export default function Avatar({ name, role, dead, size = 'md', highlight, label
 
   return (
     <span className={`${styles.chip} ${layoutClass} ${variantClass}`} data-layout={layout} data-variant={variant}>
-      <AvatarIconLabeled name={name} role={role} dead={dead} size={size} highlight={highlight} />
+      <AvatarIcon name={name} role={role} dead={dead} size={size} highlight={highlight} alt="" />
       <span className={styles.chipLabel} data-testid="avatar-label">{label}</span>
     </span>
   );

--- a/frontend/src/components/FeedCard.jsx
+++ b/frontend/src/components/FeedCard.jsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import AgentLink from './AgentLink.jsx';
 import Avatar from './Avatar.jsx';
 import RoleTag from './RoleTag.jsx';
 import { ROLE_META_BY_KEY } from '../lib/roleMeta.js';
-import { agentDetailPath } from '../lib/agentLinks.js';
 import styles from './FeedCard.module.css';
 
 const MISSING_CONTENT = '[missing content]';
@@ -66,7 +65,6 @@ function SpeechCard({ ev, prevById, roleAssignment, sessionId, viewerMode = 'spe
   const isPublic = viewerMode === 'public';
   const coedRole = ev.claimed_role;
   const coColor = coedRole ? ROLE_META_BY_KEY[coedRole]?.color : undefined;
-  const agentTo = agentDetailPath(sessionId, ev.agent, viewerMode);
 
   return (
     <article
@@ -74,13 +72,13 @@ function SpeechCard({ ev, prevById, roleAssignment, sessionId, viewerMode = 'spe
       style={{ '--r-color': r?.color }}
       aria-label={`${ev.agent} ${fmtTurn(ev.day, ev.speech_id || 0)} ${fmtTime(ev.day, ev.speech_id || 0)}`}
     >
-      <Link to={agentTo} className={styles.agentLink}>
+      <AgentLink sessionId={sessionId} name={ev.agent} viewerMode={viewerMode}>
         <Avatar name={ev.agent} role={isPublic ? undefined : role} />
-      </Link>
+      </AgentLink>
       <div className={styles.vert} />
       <div>
         <div className={styles.spHead}>
-          <Link to={agentTo} className={styles.agentLink}><span className={styles.name}>{ev.agent}</span></Link>
+          <AgentLink sessionId={sessionId} name={ev.agent} viewerMode={viewerMode}><span className={styles.name}>{ev.agent}</span></AgentLink>
           <span className={styles.turn}>{fmtTurn(ev.day, ev.speech_id || 0)}</span>
           {!isPublic && <RoleTag role={role} />}
           {coedRole && (
@@ -109,7 +107,6 @@ function AgentEpisodeCard({ ev, roleAssignment, sessionId, viewerMode = 'spectat
   const role = roleAssignment[ev.agent];
   const r = ROLE_META_BY_KEY[role];
   const isPublic = viewerMode === 'public';
-  const agentTo = agentDetailPath(sessionId, ev.agent, viewerMode);
 
   return (
     <article
@@ -117,13 +114,13 @@ function AgentEpisodeCard({ ev, roleAssignment, sessionId, viewerMode = 'spectat
       style={{ '--r-color': r?.color }}
       aria-label={`${ev.agent} ${label}`}
     >
-      <Link to={agentTo} className={styles.agentLink}>
+      <AgentLink sessionId={sessionId} name={ev.agent} viewerMode={viewerMode}>
         <Avatar name={ev.agent} role={isPublic ? undefined : role} />
-      </Link>
+      </AgentLink>
       <div className={styles.vert} />
       <div>
         <div className={styles.spHead}>
-          <Link to={agentTo} className={styles.agentLink}><span className={styles.name}>{ev.agent}</span></Link>
+          <AgentLink sessionId={sessionId} name={ev.agent} viewerMode={viewerMode}><span className={styles.name}>{ev.agent}</span></AgentLink>
           <span className={styles.turn}>{label}</span>
           {!isPublic && <RoleTag role={role} />}
         </div>
@@ -313,16 +310,16 @@ export function SystemRow({ kind, icon, label, children, strategy, reasoning, ts
       <div className={styles.sysContent}>
         <div className={styles.sysMain}>
           {leftName && (
-            <Link to={agentDetailPath(sessionId, leftName, viewerMode)} className={styles.agentLink}>
+            <AgentLink sessionId={sessionId} name={leftName} viewerMode={viewerMode}>
               <Avatar name={leftName} role={roleAssignment[leftName]} size="xs" />
-            </Link>
+            </AgentLink>
           )}
           <div className={styles.sysText}>{children}</div>
           {ts && <div className={styles.sysTs}>{ts}</div>}
           {rightName && (
-            <Link to={agentDetailPath(sessionId, rightName, viewerMode)} className={styles.agentLink}>
+            <AgentLink sessionId={sessionId} name={rightName} viewerMode={viewerMode}>
               <Avatar name={rightName} role={roleAssignment[rightName]} size="xs" />
-            </Link>
+            </AgentLink>
           )}
         </div>
         {strategy && viewerMode === 'spectator' && (
@@ -336,16 +333,15 @@ export function SystemRow({ kind, icon, label, children, strategy, reasoning, ts
 
 // --- 人狼会話カード ---
 function WolfChatCard({ ev, sessionId, viewerMode = 'spectator', bulkThoughtsOpen = false }) {
-  const agentTo = agentDetailPath(sessionId, ev.agent, viewerMode);
   return (
     <article className={`${styles.speech} ${styles.wolfChat}`} aria-label={`${ev.agent} wolf chat`}>
-      <Link to={agentTo} className={styles.agentLink}>
+      <AgentLink sessionId={sessionId} name={ev.agent} viewerMode={viewerMode}>
         <Avatar name={ev.agent} />
-      </Link>
+      </AgentLink>
       <div className={styles.vert} />
       <div>
         <div className={styles.spHead}>
-          <Link to={agentTo} className={styles.agentLink}><span className={styles.name}>{ev.agent}</span></Link>
+          <AgentLink sessionId={sessionId} name={ev.agent} viewerMode={viewerMode}><span className={styles.name}>{ev.agent}</span></AgentLink>
         </div>
         <div className={styles.spBody}>{ev.content}</div>
         <ThoughtDetails key={String(bulkThoughtsOpen)} reasoning={ev.reasoning} viewerMode={viewerMode} bulkOpen={bulkThoughtsOpen} />

--- a/frontend/src/components/FeedCard.module.css
+++ b/frontend/src/components/FeedCard.module.css
@@ -307,12 +307,3 @@
 .gameOverWolf    { color: var(--r-werewolf); }
 .gameOverVillage { color: var(--r-villager); }
 .gameOverUnknown { color: var(--tx); }
-
-/* agent navigation link wrapper (shared reset; copy of SpectatorScreen .agentLink) */
-.agentLink {
-  text-decoration: none;
-  color: inherit;
-  display: contents;
-}
-.agentLink:hover { opacity: 0.75; }
-.agentLink:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; border-radius: var(--r1); }

--- a/frontend/src/screens/AgentDetailScreen.module.css
+++ b/frontend/src/screens/AgentDetailScreen.module.css
@@ -63,12 +63,6 @@
 .pickOn { background: var(--bg-2); border-left-color: var(--acc); }
 .pickDead { opacity: 0.55; }
 
-.pickLink {
-  display: contents;
-  color: inherit;
-  text-decoration: none;
-}
-
 .who {
   display: flex;
   flex-direction: column;

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import AgentLink from '../components/AgentLink.jsx';
 import Avatar, { AvatarButton } from '../components/Avatar.jsx';
 import AgentRosterRow from '../components/AgentRosterRow.jsx';
 import { FeedItem, SystemRow } from '../components/FeedCard.jsx';
@@ -187,9 +188,9 @@ function CoStatusBoard({ coStatus, sessionId, viewerMode }) {
                 {coAgents.length ? coAgents.map((name, i) => (
                   <span key={name} className={styles.coAgent}>
                     {i > 0 && ', '}
-                    <Link to={agentDetailPath(sessionId, name, viewerMode)} className={styles.agentLink}>
+                    <AgentLink sessionId={sessionId} name={name} viewerMode={viewerMode}>
                       <Avatar name={name} size="xs" label={name} layout="horizontal" />
-                    </Link>
+                    </AgentLink>
                   </span>
                 )) : '未CO'}
               </span>
@@ -207,13 +208,13 @@ function NightActionsPanel({ nightActions, roleAssignment, sessionId, viewerMode
         <li key={i} className={`${styles.action} ${styles[a.event_type] || ''}`}>
           <div className={styles.actionIco}>{NIGHT_ACTION_ICON[a.event_type] || '・'}</div>
           <div className={styles.what}>
-            <Link to={agentDetailPath(sessionId, a.agent, viewerMode)} className={styles.agentLink}>
+            <AgentLink sessionId={sessionId} name={a.agent} viewerMode={viewerMode}>
               <Avatar name={a.agent} size="xs" label={a.agent} layout="horizontal" />
-            </Link>
+            </AgentLink>
             {a.target && (
-              <> → <Link to={agentDetailPath(sessionId, a.target, viewerMode)} className={styles.agentLink} style={{ '--r-color': ROLE_META_BY_KEY[roleAssignment[a.target]]?.color }}>
+              <> → <AgentLink sessionId={sessionId} name={a.target} viewerMode={viewerMode} style={{ '--r-color': ROLE_META_BY_KEY[roleAssignment[a.target]]?.color }}>
                 <Avatar name={a.target} size="xs" label={a.target} layout="horizontal" />
-              </Link></>
+              </AgentLink></>
             )}
             <span style={{ color: 'var(--tx-4)', marginLeft: 6 }}>{NIGHT_ACTION_LABEL[a.event_type]}</span>
           </div>
@@ -259,13 +260,13 @@ export function RightPane({ agents, roleAssignment, coStatus = {}, daySummary = 
             <div className={styles.voteGrid}>
               {execResult.voteTable.map((v, i) => (
                 <div className={styles.voteCell} key={i}>
-                  <Link to={agentDetailPath(sessionId, v.from, viewerMode)} className={styles.agentLink}>
+                  <AgentLink sessionId={sessionId} name={v.from} viewerMode={viewerMode}>
                     <Avatar name={v.from} size="xs" label={v.from} layout="horizontal" />
-                  </Link>
+                  </AgentLink>
                   <span className={styles.voteArrow}>▶</span>
-                  <Link to={agentDetailPath(sessionId, v.to, viewerMode)} className={styles.agentLink}>
+                  <AgentLink sessionId={sessionId} name={v.to} viewerMode={viewerMode}>
                     <Avatar name={v.to} size="xs" label={v.to} layout="horizontal" variant={v.to === execResult.target ? 'danger' : 'plain'} />
-                  </Link>
+                  </AgentLink>
                 </div>
               ))}
             </div>

--- a/frontend/src/screens/SpectatorScreen.module.css
+++ b/frontend/src/screens/SpectatorScreen.module.css
@@ -272,12 +272,3 @@
 
 /* game_over result row in left pane */
 .phaseGameOver { color: var(--tx-2); }
-
-/* agent navigation link wrapper (shared with FeedCard; kept here for RightPane) */
-.agentLink {
-  text-decoration: none;
-  color: inherit;
-  display: contents;
-}
-.agentLink:hover { opacity: 0.75; }
-.agentLink:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; border-radius: var(--r1); }


### PR DESCRIPTION
Closes #585, closes #586

## Summary

#585 と #586 の統合リファクタリング（idd-team フロー: 設計・実装をサブエージェント分業、設計正本は #586 のコメント）。両 Issue は「アクセシブルネームの契約」（可視ラベルがあるとき img alt は空）を共有するため、1 PR で境界を一度に設計した。

- **#585**: `AvatarIconLabeled` を削除し `AvatarIcon` に一本化。alt は `Avatar` が `label ? '' : name` で導出（新規 prop なし・公開 props 不変・呼び出し側変更ゼロ）
- **#586**: `components/AgentLink.jsx`（+ 専用 CSS module）を新設し、`Link + agentDetailPath + .agentLink` の三点セットを単独所有。children ベース、`viewerMode` 必須、`style` 素通し（`--r-color` 継承用）
- 全13箇所移行（SpectatorScreen ×5 / FeedCard ×8）、コピー `.agentLink` CSS 2ブロック削除、`.pickLink` dead CSS ついで削除（承認済み確定事項）
- doc/FrontendDesign.md に AgentLink と alt 導出規則を記載

正味 **−35 行**（実装分）。

## AC 対応

| AC | 担保 |
|---|---|
| 585-1 アイコン実装が1つだけ | `grep AvatarIconLabeled` 0件 |
| 585-2 bare `alt={name}` / labeled `alt=""` 維持 | 既存 alt 番兵テスト2本が**無変更 GREEN** |
| 585-3 Avatar 既存テスト無変更パス | Avatar.test.jsx 変更なし |
| 586-1 AgentLink が JSX + CSS を所有 | AgentLink.test.jsx contract 5本（アサートレベル RED→GREEN） |
| 586-2 全13箇所移行・CSS 削除 | 既存 href 契約テスト群が**無変更 GREEN**、`.agentLink` は新 module のみ |
| 586-3 hover / focus-visible 不変 | Playwright 目視: hover opacity 0.75 / focus ring / L214 役職色 / `?view=public` 42リンク |
| lint / test | vitest 340 passed / lint / `ruff check .` / pytest 402 passed |

## Out of scope（記録済み）

- `agentDetailPath` の `encodeURIComponent` 非対称 → #587 の AC に追記済み（URL contract 一元化と同時修正）
- AgentRosterRow のアクセシブルネーム重複（"Alice Alice"）→ Ideas.md バンドルに記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)