### PR TITLE
Consolidate viewerMode URL handling

### DIFF
--- a/doc/FrontendDesign.md
+++ b/doc/FrontendDesign.md
@@ -459,7 +459,7 @@ AgentDetail への画面遷移リンクラッパー（#586）。`Link to={agentD
 | `style` | `object?` | `Link` に素通しする inline style。`display: contents` のため CSS 変数（例: `--r-color`）が children に継承される |
 | `children` | node | リンクの中身。Avatar 描画は所有しない（呼び出し側が bare/labeled Avatar・テキスト span を自由に入れる） |
 
-children ベースの API とした理由: 重複していたのは「`Link` + `agentDetailPath` + `className`」の三点セットであり、Avatar 描画は重複していない（テキスト span を包む箇所もある）。パスは `lib/agentLinks.js` の `agentDetailPath` を内部で使う。
+children ベースの API とした理由: 重複していたのは「`Link` + `agentDetailPath` + `className`」の三点セットであり、Avatar 描画は重複していない（テキスト span を包む箇所もある）。パスは `lib/agentDetailPath.js` の `agentDetailPath` を内部で使う。
 
 アクセシビリティ: children が bare `Avatar` のみ（可視テキストなし）の場合、リンクのアクセシブルネームは `img alt={name}` が供給する（#585 の alt 導出規則が前提）。
 
@@ -502,7 +502,7 @@ children ベースの API とした理由: 重複していたのは「`Link` + `
 
 内部に `SpeechCard` / `WolfChatCard` / `AgentEpisodeCard` / `RelationshipUpdateRow` と付随純粋関数（`fmtTurn` / `fmtTime` / `Mentioned` / `ThoughtDetails` / `contentForViewer` / `RelationshipMeterList` / `SYSTEM_EVENT_VIEWS` / `renderConfiguredSystemEvent`）・定数（`MISSING_CONTENT` / `SPECTATOR_ONLY_EVENTS`）を同梱する。
 
-特定 screen の state（`useState`）に依存せず、`sessionId` は props で受ける（`useParams` は使わない）。AgentDetail へのリンクは共有コンポーネント `AgentLink`（#586）で描画する（パス組み立ては `AgentLink` 内部の `lib/agentLinks.js` `agentDetailPath` に委譲）。
+特定 screen の state（`useState`）に依存せず、`sessionId` は props で受ける（`useParams` は使わない）。AgentDetail へのリンクは共有コンポーネント `AgentLink`（#586）で描画する（パス組み立ては `AgentLink` 内部の `lib/agentDetailPath.js` `agentDetailPath` に委譲）。
 
 #### `Icon`
 
@@ -577,6 +577,9 @@ Semantic HTML: `SpeechCard` / `WolfChatCard` は独立した発言カードと�
 ヘッダーの「観戦者モード / 参加者視点」トグルで `viewerMode: 'spectator' | 'public'` を切り替える。
 `viewerMode` は URL query を正本とし、`?view=public` のとき `public`、未指定または不正値では
 `spectator` として扱う（#493）。`spectator` は既存 URL 互換を保つため query なしを canonical とする。
+URL contract（parse / serialize / toggle）の実装正本は `frontend/src/lib/useViewerMode.js` とする。
+AgentDetail への path assembly は `frontend/src/lib/agentDetailPath.js` の `agentDetailPath` が所有し、
+agent 名は同関数内で `encodeURIComponent` する。
 SpectatorScreen から AgentDetailScreen への遷移、および AgentDetailScreen から SpectatorScreen へ戻る
 パンくずでは `?view=public` を引き継ぐ。
 

--- a/doc/Ideas.md
+++ b/doc/Ideas.md
@@ -20,7 +20,6 @@
 | # | 種別 | 優先度 | SP | タイトル | 内容 |
 |---|---|---|---|---|---|
 | yukkie/AgentVillage#312 | enhancement | 🔴 | 3 | feat(frontend): GameData registry — track data gaps continuously | doc/GameData.md でデータギャップを継続管理（Milestone 横串モニター） |
-| yukkie/AgentVillage#587 | tech-debt | 🔴 | - | Consolidate viewerMode handling into a shared useViewerMode hook | viewerMode の parse/serialize/toggle/切替ボタンが両 screen に重複（searchForViewerMode は lib 済みなのに再定義）。useViewerMode() に集約。SP は refinement で見積もり |
 | yukkie/AgentVillage#466 | tech-debt | 🟡 | 5 | Refactor LogEvent payload design | #451 設計中に派生。LogEvent の event-specific payload を直下 optional field / extra_data / discriminated union のどれで整理するか比較検討する |
 | yukkie/AgentVillage#495 | enhancement | 🟢 | 3 | design: log visibility classes and recipient-based authorization model (for LIVE / player participation) | LIVE/プレイヤー参加に向け、可視性クラス×受信者権限の配信認可モデルを先行設計（ADR）。replay は全配信の特殊ケース |
 | yukkie/AgentVillage#319 | enhancement | 🟢 | 3 | feat(frontend): LIVE spectator (real-time view of in-progress game) | state/ を tail して進行中ゲームを表示（将来フェーズ） |

--- a/frontend/src/components/AgentLink.jsx
+++ b/frontend/src/components/AgentLink.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { agentDetailPath } from '../lib/agentLinks.js';
+import { agentDetailPath } from '../lib/agentDetailPath.js';
 import styles from './AgentLink.module.css';
 
 /**

--- a/frontend/src/components/AgentLink.test.jsx
+++ b/frontend/src/components/AgentLink.test.jsx
@@ -40,6 +40,21 @@ describe('AgentLink', () => {
     expect(screen.getByRole('link').getAttribute('href')).toBe('/game/s1/agent/Alice?view=public');
   });
 
+  it('統合: AgentLink: agent name with spaces is percent-encoded', () => {
+    /*
+     * SUT: AgentLink
+     * Mock: なし（plain props を入力）
+     * Level: contract
+     * Objective: agentDetailPath が agent 名を encodeURIComponent し、空白を含む名前でも壊れない URL を組み立てることを検証する（#587）。
+     */
+    render(
+      <MemoryRouter>
+        <AgentLink sessionId="s1" name="Ada Lovelace" viewerMode="public">Ada Lovelace</AgentLink>
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link').getAttribute('href')).toBe('/game/s1/agent/Ada%20Lovelace?view=public');
+  });
+
   it('統合: AgentLink: children を agentLink クラスの Link 内に描画する', () => {
     /*
      * SUT: AgentLink

--- a/frontend/src/lib/agentDetailPath.js
+++ b/frontend/src/lib/agentDetailPath.js
@@ -1,10 +1,7 @@
 // AgentDetail へのリンクパスを組み立てる純粋関数。
 // FeedCard（中央フィード）と SpectatorScreen 右ペインの両方で共有する（screen 非依存）。
-
-export function searchForViewerMode(viewerMode) {
-  return viewerMode === 'public' ? '?view=public' : '';
-}
+import { searchForViewerMode } from './useViewerMode.js';
 
 export function agentDetailPath(sessionId, agentName, viewerMode) {
-  return `/game/${sessionId}/agent/${agentName}${searchForViewerMode(viewerMode)}`;
+  return `/game/${sessionId}/agent/${encodeURIComponent(agentName)}${searchForViewerMode(viewerMode)}`;
 }

--- a/frontend/src/lib/useViewerMode.js
+++ b/frontend/src/lib/useViewerMode.js
@@ -1,0 +1,28 @@
+import { useSearchParams } from 'react-router-dom';
+
+export function viewerModeFromSearchParams(searchParams) {
+  return searchParams.get('view') === 'public' ? 'public' : 'spectator';
+}
+
+export function searchForViewerMode(viewerMode) {
+  return viewerMode === 'public' ? '?view=public' : '';
+}
+
+export function viewerModeToggleLabel(viewerMode) {
+  return viewerMode === 'spectator' ? '🔍 観戦者モード' : '👤 参加者視点';
+}
+
+export function useViewerMode() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const viewerMode = viewerModeFromSearchParams(searchParams);
+
+  const toggleViewerMode = () => {
+    setSearchParams(viewerMode === 'spectator' ? { view: 'public' } : {});
+  };
+
+  return {
+    viewerMode,
+    viewerSearch: searchForViewerMode(viewerMode),
+    toggleViewerMode,
+  };
+}

--- a/frontend/src/lib/useViewerMode.test.jsx
+++ b/frontend/src/lib/useViewerMode.test.jsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import {
+  searchForViewerMode,
+  useViewerMode,
+  viewerModeFromSearchParams,
+  viewerModeToggleLabel,
+} from './useViewerMode.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function ViewerModeProbe() {
+  const { viewerMode, viewerSearch, toggleViewerMode } = useViewerMode();
+  const location = useLocation();
+
+  return (
+    <>
+      <output aria-label="viewer-mode">{viewerMode}</output>
+      <output aria-label="viewer-search">{viewerSearch}</output>
+      <output aria-label="current-location">{location.pathname}{location.search}</output>
+      <button type="button" onClick={toggleViewerMode}>toggle</button>
+    </>
+  );
+}
+
+function renderProbe(initialEntry = '/game/s1') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/game/:sessionId" element={<ViewerModeProbe />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('useViewerMode URL contract', () => {
+  it('pure: viewerModeFromSearchParams: view=public のみ public にする', () => {
+    /*
+     * SUT: viewerModeFromSearchParams
+     * Mock: なし（URLSearchParams を直接入力）
+     * Level: unit
+     * Objective: ?view=public のみ public viewerMode として解釈し、それ以外は spectator にフォールバックすることを検証する。
+     */
+    expect(viewerModeFromSearchParams(new URLSearchParams('view=public'))).toBe('public');
+    expect(viewerModeFromSearchParams(new URLSearchParams('view=spectator'))).toBe('spectator');
+    expect(viewerModeFromSearchParams(new URLSearchParams('view=unknown'))).toBe('spectator');
+    expect(viewerModeFromSearchParams(new URLSearchParams(''))).toBe('spectator');
+  });
+
+  it('pure: searchForViewerMode: public のみ ?view=public を返す', () => {
+    /*
+     * SUT: searchForViewerMode
+     * Mock: なし
+     * Level: unit
+     * Objective: viewerMode を URL query へ serialize するとき public のみ ?view=public を返すことを検証する。
+     */
+    expect(searchForViewerMode('public')).toBe('?view=public');
+    expect(searchForViewerMode('spectator')).toBe('');
+    expect(searchForViewerMode('unknown')).toBe('');
+  });
+
+  it('pure: viewerModeToggleLabel: 現在 mode に対応する表示ラベルを返す', () => {
+    /*
+     * SUT: viewerModeToggleLabel
+     * Mock: なし
+     * Level: unit
+     * Objective: mode-toggle button label を1箇所の関数で定義することを検証する。
+     */
+    expect(viewerModeToggleLabel('spectator')).toBe('🔍 観戦者モード');
+    expect(viewerModeToggleLabel('public')).toBe('👤 参加者視点');
+  });
+
+  it('統合: useViewerMode: toggleViewerMode が URL query を付与/削除する', async () => {
+    /*
+     * SUT: useViewerMode
+     * Mock: なし（MemoryRouter）
+     * Level: integration
+     * Objective: shared hook が URL query を正本として viewerMode/viewerSearch/toggle を一貫して扱うことを検証する。
+     */
+    const user = userEvent.setup();
+    renderProbe('/game/s1');
+
+    expect(screen.getByLabelText('viewer-mode').textContent).toBe('spectator');
+    expect(screen.getByLabelText('viewer-search').textContent).toBe('');
+    expect(screen.getByLabelText('current-location').textContent).toBe('/game/s1');
+
+    await user.click(screen.getByRole('button', { name: 'toggle' }));
+    expect(screen.getByLabelText('viewer-mode').textContent).toBe('public');
+    expect(screen.getByLabelText('viewer-search').textContent).toBe('?view=public');
+    expect(screen.getByLabelText('current-location').textContent).toBe('/game/s1?view=public');
+
+    await user.click(screen.getByRole('button', { name: 'toggle' }));
+    expect(screen.getByLabelText('viewer-mode').textContent).toBe('spectator');
+    expect(screen.getByLabelText('viewer-search').textContent).toBe('');
+    expect(screen.getByLabelText('current-location').textContent).toBe('/game/s1');
+  });
+});

--- a/frontend/src/screens/AgentDetailScreen.jsx
+++ b/frontend/src/screens/AgentDetailScreen.jsx
@@ -1,15 +1,17 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import Avatar from '../components/Avatar.jsx';
 import AgentRosterRow from '../components/AgentRosterRow.jsx';
 import { FeedItem } from '../components/FeedCard.jsx';
 import TopBar, { TopBarBtn } from '../components/TopBar.jsx';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLE_META_BY_KEY } from '../lib/roleMeta.js';
+import { agentDetailPath } from '../lib/agentDetailPath.js';
 import { fetchGameStats, parseGameStats, parseAllAgentNames, fetchGameBySessionId, fetchAgentConfig, parseBlurb } from '../lib/archiveLoader.js';
 import { fetchReplayGame } from '../lib/replayLoader.js';
 import { buildAgentDetailRoster, buildSuspicionMatrix, countAgentSpeeches } from '../lib/parseGameData.js';
 import { useDeaths } from '../lib/useDeaths.js';
+import { useViewerMode, viewerModeToggleLabel } from '../lib/useViewerMode.js';
 import styles from './AgentDetailScreen.module.css';
 
 // blurb（frontend/public/config/agents.json 由来の1行プロフィール・#519）が無い／fetch 失敗時のフォールバック表示。
@@ -31,19 +33,10 @@ function useAgentBlurb(agent) {
   return parseBlurb(config, agent) ?? BLURB_FALLBACK;
 }
 
-function viewerModeFromSearchParams(searchParams) {
-  return searchParams.get('view') === 'public' ? 'public' : 'spectator';
-}
-
-function searchForViewerMode(viewerMode) {
-  return viewerMode === 'public' ? '?view=public' : '';
-}
-
 // --- 左ペイン ---
 function LeftPane({ current, sessionId, viewerMode = 'spectator', roster = [] }) {
   const alive = roster.filter(agent => agent.isAlive);
   const dead = roster.filter(agent => !agent.isAlive);
-  const viewerSearch = searchForViewerMode(viewerMode);
 
   return (
     <>
@@ -58,7 +51,7 @@ function LeftPane({ current, sessionId, viewerMode = 'spectator', roster = [] })
               key={row.name}
               name={row.name}
               role={row.role}
-              to={`/game/${sessionId}/agent/${encodeURIComponent(row.name)}${viewerSearch}`}
+              to={agentDetailPath(sessionId, row.name, viewerMode)}
               showRole={viewerMode === 'spectator'}
               dead={!row.isAlive}
               selected={current === row.name}
@@ -451,7 +444,7 @@ function GameScopedProfile({ sessionId, agent, blurb, viewerMode, viewerSearch, 
     <div className={styles.frame}>
       <TopBar crumbs={topCrumbs}>
         <TopBarBtn onClick={toggleViewerMode}>
-          {viewerMode === 'spectator' ? '🔍 観戦者モード' : '👤 参加者視点'}
+          {viewerModeToggleLabel(viewerMode)}
         </TopBarBtn>
       </TopBar>
       {body}
@@ -462,9 +455,7 @@ function GameScopedProfile({ sessionId, agent, blurb, viewerMode, viewerSearch, 
 // === メイン画面 ===
 export default function AgentDetailScreen() {
   const { sessionId, agentName } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const viewerMode = viewerModeFromSearchParams(searchParams);
-  const viewerSearch = searchForViewerMode(viewerMode);
+  const { viewerMode, viewerSearch, toggleViewerMode } = useViewerMode();
   const agent = agentName || 'Nox';
   const blurb = useAgentBlurb(agent);
 
@@ -472,10 +463,6 @@ export default function AgentDetailScreen() {
   if (!sessionId) {
     return <GlobalProfile agent={agent} blurb={blurb} />;
   }
-
-  const toggleViewerMode = () => {
-    setSearchParams(viewerMode === 'spectator' ? { view: 'public' } : {});
-  };
 
   return (
     <GameScopedProfile

--- a/frontend/src/screens/AgentDetailScreen.test.jsx
+++ b/frontend/src/screens/AgentDetailScreen.test.jsx
@@ -83,7 +83,7 @@ const GAME_SCOPED_INDEX = {
   session_id: 'session-real-001',
   title: '桜霞村',
   days: 2,
-  cast: ['Nox', 'Mira', 'Kai'],
+  cast: ['Nox', 'Mira', 'Kai', 'Ada Lovelace'],
 };
 
 const GAME_SCOPED_JSONL = [
@@ -113,6 +113,11 @@ const GAME_SCOPED_AGENTS = {
     profile: { name: 'Kai', model: 'm', persona: {} },
     state: { is_alive: false, beliefs: {}, claimed_role: null },
     role: 'Werewolf',
+  },
+  'Ada Lovelace': {
+    profile: { name: 'Ada Lovelace', model: 'm', persona: {} },
+    state: { is_alive: true, beliefs: {}, claimed_role: null },
+    role: 'Villager',
   },
 };
 
@@ -188,6 +193,7 @@ describe('AgentDetailScreen game-scoped breadcrumbs', () => {
     renderGameScoped({ sessionId: 'test-session-001', agentName: 'Nox', search: '?view=public' });
 
     expect((await screen.findByRole('link', { name: /Mira/ })).getAttribute('href')).toBe('/game/test-session-001/agent/Mira?view=public');
+    expect((await screen.findByRole('link', { name: /Ada Lovelace/ })).getAttribute('href')).toBe('/game/test-session-001/agent/Ada%20Lovelace?view=public');
   });
 });
 

--- a/frontend/src/screens/SpectatorScreen.jsx
+++ b/frontend/src/screens/SpectatorScreen.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import AgentLink from '../components/AgentLink.jsx';
 import Avatar, { AvatarButton } from '../components/Avatar.jsx';
 import AgentRosterRow from '../components/AgentRosterRow.jsx';
@@ -8,17 +8,14 @@ import TopBar, { TopBarBtn } from '../components/TopBar.jsx';
 import topBarStyles from '../components/TopBar.module.css';
 import ThreePaneLayout from '../components/ThreePaneLayout.jsx';
 import { ROLE_META_BY_KEY, ROLE_KEYS, listRoles } from '../lib/roleMeta.js';
-import { agentDetailPath } from '../lib/agentLinks.js';
+import { agentDetailPath } from '../lib/agentDetailPath.js';
 import { fetchReplayAgents, fetchReplayLog } from '../lib/replayLoader.js';
 import { fetchGameBySessionId } from '../lib/archiveLoader.js';
 import { parseGameData, aggregateCoStatus } from '../lib/parseGameData.js';
 import { useDeaths } from '../lib/useDeaths.js';
 import { filterByAgents, filterByRoles, filterFeedEvents } from '../lib/feedFilter.js';
+import { useViewerMode, viewerModeToggleLabel } from '../lib/useViewerMode.js';
 import styles from './SpectatorScreen.module.css';
-
-function viewerModeFromSearchParams(searchParams) {
-  return searchParams.get('view') === 'public' ? 'public' : 'spectator';
-}
 
 // === 左ペイン ===
 export function LeftPane({
@@ -414,7 +411,7 @@ function SpectatorReplayData({
         <TopBarBtn><span className={topBarStyles.liveDot} /> REPLAY</TopBarBtn>
         <TopBarBtn>同時観戦 142</TopBarBtn>
         <TopBarBtn onClick={toggleViewerMode}>
-          {viewerMode === 'spectator' ? '🔍 観戦者モード' : '👤 参加者視点'}
+          {viewerModeToggleLabel(viewerMode)}
         </TopBarBtn>
         <TopBarBtn>⤓ 全ログDL</TopBarBtn>
         <TopBarBtn primary>★ 応援</TopBarBtn>
@@ -467,17 +464,12 @@ function SpectatorReplayData({
 export default function SpectatorScreen() {
   const { sessionId } = useParams();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const { viewerMode, toggleViewerMode } = useViewerMode();
   const [activeDay, setActiveDay] = useState(2);
   const [activePhase, setActivePhase] = useState('discuss');
   const [selectedAgents, setSelectedAgents] = useState(() => new Set());
   const [selectedRoles, setSelectedRoles] = useState(() => new Set());
   const [thoughtsOpen, setThoughtsOpen] = useState(false);
-  const viewerMode = viewerModeFromSearchParams(searchParams);
-
-  const toggleViewerMode = () => {
-    setSearchParams(viewerMode === 'spectator' ? { view: 'public' } : {});
-  };
 
   const toggleAgentFilter = (agentName) => {
     setSelectedAgents(current => {


### PR DESCRIPTION
## Summary
- Add `useViewerMode()` as the shared source of truth for viewerMode parse / serialize / toggle behavior.
- Rename `agentLinks.js` to `agentDetailPath.js` and centralize encoded AgentDetail path assembly there.
- Migrate SpectatorScreen and AgentDetailScreen off local viewerMode helpers, and document the URL contract owner.

## Implementation notes
- `agentDetailPath()` now applies `encodeURIComponent(agentName)`, so game-scoped links handle names such as `Ada Lovelace`.
- Mode-toggle labels are defined in `viewerModeToggleLabel()` instead of duplicated in screens.
- `doc/Ideas.md` was updated to remove completed issue #587.

## Test plan
- [x] RED targeted contract tests confirmed assertion failures before implementation
- [x] `npm.cmd test`
- [x] `npm.cmd run test:coverage`
- [x] `npm.cmd run lint`
- [x] `npm.cmd run lint:css`
- [x] Playwright browser check on `/game/20260611_195733?view=public`

Closes #587

🤖 Generated with [OpenAI Codex](https://openai.com/codex)